### PR TITLE
fix(nav-logo): prevent infinite recursion when loading rijkswapen

### DIFF
--- a/.github/workflows/accessibility.yml
+++ b/.github/workflows/accessibility.yml
@@ -30,6 +30,9 @@ jobs:
       - name: Run ESLint (including lit-a11y rules)
         run: npm run lint
 
+      - name: Build tokens
+        run: npm run build:tokens
+
       - name: Start Storybook in background
         run: npm run storybook -- --ci &
 

--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -32,6 +32,9 @@ jobs:
       - name: Install Playwright browsers
         run: npx playwright@1.47.2 install chromium
 
+      - name: Build tokens
+        run: npm run build:tokens
+
       - name: Build Storybook
         run: npm run build-storybook
 
@@ -70,6 +73,9 @@ jobs:
 
       - name: Install Playwright browsers
         run: npx playwright@1.47.2 install chromium
+
+      - name: Build tokens
+        run: npm run build:tokens
 
       - name: Build Storybook
         run: npm run build-storybook

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@regelrecht/design-system",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@regelrecht/design-system",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "license": "EUPL-1.2",
       "dependencies": {
         "@rijkshuisstijl-community/font": "^1.1.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@minbzk/storybook",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Design System voor RegelRecht - Nederlandse Overheid",
   "type": "module",
   "main": "dist/components/rr-components.js",

--- a/src/components/base/base-component.js
+++ b/src/components/base/base-component.js
@@ -145,7 +145,7 @@ async function loadTokensCSS() {
         return tokensCSSContent;
       }
     }
-  } catch (e) {
+  } catch {
     // Silent fail - tokens should be loaded via CSS import in production
   }
 

--- a/src/components/top-navigation-bar/rr-nav-logo.js
+++ b/src/components/top-navigation-bar/rr-nav-logo.js
@@ -42,19 +42,25 @@ export class RRNavLogo extends RRBaseComponent {
 
   constructor() {
     super();
+    this._logoLoaded = false;
   }
 
-  connectedCallback() {
-    super.connectedCallback();
-    this._loadRijkswapen();
+  async connectedCallback() {
+    await super.connectedCallback();
+    // Only load once - prevents infinite loop when cache exists
+    if (!this._logoLoaded) {
+      this._logoLoaded = true;
+      await this._loadRijkswapen();
+    }
   }
 
   /**
    * Loads the official Rijkswapen SVG and caches it.
    */
   async _loadRijkswapen() {
+    // If already cached, no need to fetch or re-render
+    // (base class connectedCallback already called render())
     if (cachedRijkswapen) {
-      this.render();
       return;
     }
 
@@ -68,6 +74,7 @@ export class RRNavLogo extends RRBaseComponent {
 
       const svgText = await response.text();
       cachedRijkswapen = svgText;
+      // Re-render now that we have the SVG
       this.render();
     } catch (error) {
       console.error('Failed to load Rijkswapen:', error.message);


### PR DESCRIPTION
- Await super.connectedCallback() before loading logo
- Add _logoLoaded guard to prevent duplicate loading
- Remove redundant render() call when cache exists