### PR TITLE
ci: add version bump check for component changes

### DIFF
--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -1,0 +1,58 @@
+name: Version Bump Check
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'src/components/**/*.js'
+      - 'src/components/**/*.ts'
+      - 'tokens/**'
+
+jobs:
+  check-version:
+    name: Check Version Bump
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout PR branch
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Get version from PR branch
+        id: pr_version
+        run: |
+          PR_VERSION=$(node -p "require('./package.json').version")
+          echo "version=$PR_VERSION" >> $GITHUB_OUTPUT
+
+      - name: Get version from base branch
+        id: base_version
+        run: |
+          git fetch origin ${{ github.base_ref }}
+          BASE_VERSION=$(git show origin/${{ github.base_ref }}:package.json | node -p "JSON.parse(require('fs').readFileSync('/dev/stdin', 'utf8')).version")
+          echo "version=$BASE_VERSION" >> $GITHUB_OUTPUT
+
+      - name: Compare versions
+        run: |
+          PR_VERSION="${{ steps.pr_version.outputs.version }}"
+          BASE_VERSION="${{ steps.base_version.outputs.version }}"
+
+          echo "Base version: $BASE_VERSION"
+          echo "PR version: $PR_VERSION"
+
+          if [ "$PR_VERSION" = "$BASE_VERSION" ]; then
+            echo ""
+            echo "❌ ERROR: Component files were modified but package.json version was not updated."
+            echo ""
+            echo "This PR modifies files in src/components/ or tokens/."
+            echo "Please bump the version in package.json using semantic versioning:"
+            echo "  - PATCH (x.x.X): Bug fixes, minor tweaks"
+            echo "  - MINOR (x.X.x): New features, new components"
+            echo "  - MAJOR (X.x.x): Breaking changes"
+            echo ""
+            echo "Current version: $BASE_VERSION"
+            exit 1
+          else
+            echo "✅ Version bumped from $BASE_VERSION to $PR_VERSION"
+          fi


### PR DESCRIPTION
## Summary
- Adds GitHub Actions workflow that runs on PRs to main
- Checks if component files (`src/components/`) or tokens are modified
- Fails if `package.json` version is not bumped

## Test plan
- [ ] Create a PR that modifies a component without bumping version → should fail
- [ ] Create a PR that modifies a component with version bump → should pass