### PR TITLE
fix(tokens): consistent numeric fontWeight conversion

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -175,6 +175,13 @@ Gebruik BEM (Block Element Modifier) voor alle class namen in HTML/CSS:
 - Geen nesting van blocks binnen element namen (niet: `block__element__subelement`)
 - Modifiers zijn altijd aanvullend, nooit vervanging van base class
 
+## Fallback Consistency Rule
+
+Bij wijzigingen aan design tokens:
+- Update altijd de corresponderende fallback waarden in component styles
+- Fallbacks moeten overeenkomen met de token waarden
+- Zoek naar `var(--token-name, fallback)` patronen in `src/components/`
+
 ## Rules
 
 1. Extend `RRBaseComponent`

--- a/src/components/button/rr-button.js
+++ b/src/components/button/rr-button.js
@@ -161,7 +161,7 @@ export class RRButton extends RRBaseComponent {
         justify-content: center;
 
         /* Typography */
-        font-weight: var(--semantics-buttons-font-weight, 600);
+        font-weight: var(--semantics-buttons-font-weight, 550);
         text-decoration: none;
 
         /* Animation */
@@ -182,7 +182,7 @@ export class RRButton extends RRBaseComponent {
         min-height: var(--semantics-controls-xs-min-size, 24px);
         /* Figma: padding 4px 6px (top/bottom 4, left/right 6) */
         padding: var(--primitives-space-4, 4px) var(--primitives-space-6, 6px);
-        font: var(--components-button-xs-font, 600 14px/1.125 system-ui);
+        font: var(--components-button-xs-font, 550 14px/1.125 system-ui);
         border-radius: var(--semantics-controls-xs-corner-radius, 4px);
         gap: var(--primitives-space-2, 2px);
       }
@@ -192,7 +192,7 @@ export class RRButton extends RRBaseComponent {
         min-height: var(--semantics-controls-s-min-size, 32px);
         /* Figma: padding 6px 8px (top/bottom 6, left/right 8) */
         padding: var(--primitives-space-6, 6px) var(--primitives-space-8, 8px);
-        font: var(--components-button-s-font, 600 16px/1.125 system-ui);
+        font: var(--components-button-s-font, 550 16px/1.125 system-ui);
         border-radius: var(--semantics-controls-s-corner-radius, 6px);
         gap: var(--primitives-space-2, 2px);
       }
@@ -202,7 +202,7 @@ export class RRButton extends RRBaseComponent {
       :host(:not([size])) .button {
         min-height: var(--semantics-controls-m-min-size, 44px);
         padding: var(--primitives-space-12, 12px);
-        font: var(--components-button-m-font, 600 18px/1.125 system-ui);
+        font: var(--components-button-m-font, 550 18px/1.125 system-ui);
         border-radius: var(--semantics-controls-m-corner-radius, 7px);
         gap: var(--primitives-space-4, 4px);
       }

--- a/src/components/checkbox/rr-checkbox.stories.js
+++ b/src/components/checkbox/rr-checkbox.stories.js
@@ -245,7 +245,7 @@ export const InteractiveExample = () => {
   return html`
     <div style="display: flex; flex-direction: column; gap: 1.5rem;">
       <h3
-        style="margin: 0; font-family: RijksSansVF, system-ui; font-size: 20px; font-weight: 600;"
+        style="margin: 0; font-family: RijksSansVF, system-ui; font-size: 20px; font-weight: 550;"
       >
         Selecteer uw voorkeuren
       </h3>

--- a/src/components/icon-button/rr-icon-button.js
+++ b/src/components/icon-button/rr-icon-button.js
@@ -129,7 +129,7 @@ export class RRIconButton extends RRBaseComponent {
         justify-content: center;
 
         /* Typography */
-        font: var(--components-icon-button-font, 600 14px/1.125 RijksSansVF, system-ui);
+        font: var(--components-icon-button-font, 550 14px/1.125 RijksSansVF, system-ui);
 
         /* Animation */
         transition: background-color 0.15s ease, color 0.15s ease, border-color 0.15s ease, transform 0.1s ease;

--- a/src/components/menu-bar/rr-menu-bar.js
+++ b/src/components/menu-bar/rr-menu-bar.js
@@ -434,16 +434,16 @@ export class RRMenuBar extends RRBaseComponent {
 
       /* Title size variants */
       :host([size="s"]) .title {
-        font: var(--components-menu-bar-title-item-s-font, 600 18px/1.125 RijksSansVF, system-ui);
+        font: var(--components-menu-bar-title-item-s-font, 550 18px/1.125 RijksSansVF, system-ui);
       }
 
       :host([size="m"]) .title,
       :host(:not([size])) .title {
-        font: var(--components-menu-bar-title-item-m-font, 600 20px/1.125 RijksSansVF, system-ui);
+        font: var(--components-menu-bar-title-item-m-font, 550 20px/1.125 RijksSansVF, system-ui);
       }
 
       :host([size="l"]) .title {
-        font: var(--components-menu-bar-title-item-l-font, 600 23px/1.125 RijksSansVF, system-ui);
+        font: var(--components-menu-bar-title-item-l-font, 550 23px/1.125 RijksSansVF, system-ui);
       }
 
       .menu {
@@ -476,7 +476,7 @@ export class RRMenuBar extends RRBaseComponent {
         background: none;
         border: none;
         color: var(--components-menu-bar-menu-item-color, #154273);
-        font: var(--components-menu-bar-menu-item-font, 600 18px/1.125 RijksSansVF, system-ui);
+        font: var(--components-menu-bar-menu-item-font, 550 18px/1.125 RijksSansVF, system-ui);
         cursor: pointer;
         white-space: nowrap;
       }
@@ -527,7 +527,7 @@ export class RRMenuBar extends RRBaseComponent {
         background: none;
         border: none;
         color: var(--components-menu-bar-menu-item-color, #154273);
-        font: var(--components-menu-bar-menu-item-font, 600 18px/1.125 RijksSansVF, system-ui);
+        font: var(--components-menu-bar-menu-item-font, 550 18px/1.125 RijksSansVF, system-ui);
         text-align: left;
         cursor: pointer;
         white-space: nowrap;

--- a/src/components/menu-bar/rr-menu-item.js
+++ b/src/components/menu-bar/rr-menu-item.js
@@ -141,7 +141,7 @@ export class RRMenuItem extends RRBaseComponent {
         cursor: pointer;
 
         /* Typography */
-        font: var(--components-menu-bar-menu-item-font, 600 18px/1.125 RijksSansVF, system-ui);
+        font: var(--components-menu-bar-menu-item-font, 550 18px/1.125 RijksSansVF, system-ui);
         color: var(--rr-menu-item-color, var(--components-menu-bar-menu-item-color, #154273));
         text-align: left;
 

--- a/src/components/radio/rr-radio.stories.js
+++ b/src/components/radio/rr-radio.stories.js
@@ -158,7 +158,7 @@ export const RadioGroup = () => html`
   <div role="radiogroup" aria-labelledby="group-label-1" style="padding: 0; margin: 0;">
     <div
       id="group-label-1"
-      style="font-family: var(--rr-font-family-sans, 'RijksoverheidSans', system-ui); font-size: 18px; font-weight: 600; margin-bottom: 16px;"
+      style="font-family: var(--rr-font-family-sans, 'RijksoverheidSans', system-ui); font-size: 18px; font-weight: 550; margin-bottom: 16px;"
     >
       Kies een optie
     </div>
@@ -353,7 +353,7 @@ export const MultipleGroups = () => html`
   <div style="display: flex; gap: 3rem;">
     <fieldset style="border: none; padding: 0; margin: 0;">
       <legend
-        style="font-family: var(--rr-font-family-sans, 'RijksoverheidSans', system-ui); font-size: 16px; font-weight: 600; margin-bottom: 12px;"
+        style="font-family: var(--rr-font-family-sans, 'RijksoverheidSans', system-ui); font-size: 16px; font-weight: 550; margin-bottom: 12px;"
       >
         Groep 1: Voorkeur
       </legend>
@@ -379,7 +379,7 @@ export const MultipleGroups = () => html`
 
     <fieldset style="border: none; padding: 0; margin: 0;">
       <legend
-        style="font-family: var(--rr-font-family-sans, 'RijksoverheidSans', system-ui); font-size: 16px; font-weight: 600; margin-bottom: 12px;"
+        style="font-family: var(--rr-font-family-sans, 'RijksoverheidSans', system-ui); font-size: 16px; font-weight: 550; margin-bottom: 12px;"
       >
         Groep 2: Prioriteit
       </legend>
@@ -435,14 +435,14 @@ export const FormIntegration = () => {
     <form @submit=${handleSubmit} style="max-width: 400px;">
       <fieldset style="border: 1px solid #e2e8f0; border-radius: 8px; padding: 20px; margin: 0;">
         <legend
-          style="font-family: var(--rr-font-family-sans, 'RijksoverheidSans', system-ui); font-size: 18px; font-weight: 600; padding: 0 8px;"
+          style="font-family: var(--rr-font-family-sans, 'RijksoverheidSans', system-ui); font-size: 18px; font-weight: 550; padding: 0 8px;"
         >
           Vragenlijst
         </legend>
 
         <div style="margin-bottom: 20px;">
           <div
-            style="font-family: var(--rr-font-family-sans, 'RijksoverheidSans', system-ui); font-size: 16px; font-weight: 600; margin-bottom: 12px;"
+            style="font-family: var(--rr-font-family-sans, 'RijksoverheidSans', system-ui); font-size: 16px; font-weight: 550; margin-bottom: 12px;"
           >
             1. Hoe tevreden bent u?
           </div>
@@ -493,7 +493,7 @@ export const FormIntegration = () => {
 
         <div style="margin-bottom: 20px;">
           <div
-            style="font-family: var(--rr-font-family-sans, 'RijksoverheidSans', system-ui); font-size: 16px; font-weight: 600; margin-bottom: 12px;"
+            style="font-family: var(--rr-font-family-sans, 'RijksoverheidSans', system-ui); font-size: 16px; font-weight: 550; margin-bottom: 12px;"
           >
             2. Zou u dit aanbevelen?
           </div>
@@ -530,7 +530,7 @@ export const FormIntegration = () => {
           style="
           font-family: var(--rr-font-family-sans, 'RijksoverheidSans', system-ui);
           font-size: 16px;
-          font-weight: 600;
+          font-weight: 550;
           padding: 10px 20px;
           background: #154273;
           color: white;

--- a/src/components/toggle-button/rr-toggle-button.ts
+++ b/src/components/toggle-button/rr-toggle-button.ts
@@ -71,7 +71,7 @@ export class RRToggleButton extends LitElement {
     :host([size="xs"]) .button {
       min-height: var(--semantics-controls-xs-min-size, 24px);
       padding: var(--primitives-space-4, 4px) var(--primitives-space-12, 12px);
-      font: var(--components-button-xs-font, 600 14px/1.125 system-ui);
+      font: var(--components-button-xs-font, 550 14px/1.125 system-ui);
       border-radius: var(--semantics-controls-xs-corner-radius, 3px);
       gap: var(--primitives-space-2, 2px);
     }
@@ -80,7 +80,7 @@ export class RRToggleButton extends LitElement {
     :host([size="s"]) .button {
       min-height: var(--semantics-controls-s-min-size, 32px);
       padding: var(--primitives-space-6, 6px);
-      font: var(--components-button-s-font, 600 16px/1.125 system-ui);
+      font: var(--components-button-s-font, 550 16px/1.125 system-ui);
       border-radius: var(--semantics-controls-s-corner-radius, 5px);
       gap: var(--primitives-space-2, 2px);
     }
@@ -90,7 +90,7 @@ export class RRToggleButton extends LitElement {
     :host(:not([size])) .button {
       min-height: var(--semantics-controls-m-min-size, 44px);
       padding: var(--primitives-space-8, 8px) var(--primitives-space-10, 10px);
-      font: var(--components-button-m-font, 600 18px/1.125 system-ui);
+      font: var(--components-button-m-font, 550 18px/1.125 system-ui);
       border-radius: var(--semantics-controls-m-corner-radius, 7px);
       gap: var(--primitives-space-4, 4px);
     }

--- a/src/components/toggle-button/rr-toggle-button.vanilla.js
+++ b/src/components/toggle-button/rr-toggle-button.vanilla.js
@@ -138,7 +138,7 @@ export class RRToggleButton extends RRBaseComponent {
         justify-content: center;
 
         /* Typography */
-        font-weight: var(--semantics-buttons-font-weight, 600);
+        font-weight: var(--semantics-buttons-font-weight, 550);
         text-decoration: none;
 
         /* Animation */
@@ -157,7 +157,7 @@ export class RRToggleButton extends RRBaseComponent {
       :host([size="xs"]) .button {
         min-height: var(--semantics-controls-xs-min-size, 24px);
         padding: var(--primitives-space-4, 4px) var(--primitives-space-12, 12px);
-        font: var(--components-button-xs-font, 600 14px/1.125 system-ui);
+        font: var(--components-button-xs-font, 550 14px/1.125 system-ui);
         border-radius: var(--semantics-controls-xs-corner-radius, 3px);
         gap: var(--primitives-space-2, 2px);
       }
@@ -166,7 +166,7 @@ export class RRToggleButton extends RRBaseComponent {
       :host([size="s"]) .button {
         min-height: var(--semantics-controls-s-min-size, 32px);
         padding: var(--primitives-space-8, 8px) var(--primitives-space-6, 6px);
-        font: var(--components-button-s-font, 600 16px/1.125 system-ui);
+        font: var(--components-button-s-font, 550 16px/1.125 system-ui);
         border-radius: var(--semantics-controls-s-corner-radius, 5px);
         gap: var(--primitives-space-2, 2px);
       }
@@ -176,7 +176,7 @@ export class RRToggleButton extends RRBaseComponent {
       :host(:not([size])) .button {
         min-height: var(--semantics-controls-m-min-size, 44px);
         padding: var(--primitives-space-8, 8px) var(--primitives-space-10, 10px);
-        font: var(--components-button-m-font, 600 18px/1.125 system-ui);
+        font: var(--components-button-m-font, 550 18px/1.125 system-ui);
         border-radius: var(--semantics-controls-m-corner-radius, 7px);
         gap: var(--primitives-space-4, 4px);
       }

--- a/src/components/top-navigation-bar/rr-back-button.js
+++ b/src/components/top-navigation-bar/rr-back-button.js
@@ -115,7 +115,7 @@ export class RRBackButton extends RRBaseComponent {
         background: none;
         border: none;
         color: var(--primitives-color-accent-100, #154273);
-        font: var(--components-menu-bar-menu-item-font, 600 18px/1.125 RijksSansVF, system-ui);
+        font: var(--components-menu-bar-menu-item-font, 550 18px/1.125 RijksSansVF, system-ui);
         text-decoration: none;
         cursor: pointer;
         border-radius: var(--semantics-controls-m-corner-radius, 7px);

--- a/src/components/top-navigation-bar/rr-nav-logo.js
+++ b/src/components/top-navigation-bar/rr-nav-logo.js
@@ -190,17 +190,17 @@ export class RRNavLogo extends RRBaseComponent {
       }
 
       .title {
-        font: var(--components-menu-bar-title-item-m-font, 600 20px/1.125 RijksSansVF, system-ui);
+        font: var(--components-menu-bar-title-item-m-font, 550 20px/1.125 RijksSansVF, system-ui);
         color: var(--primitives-color-neutral-900, #0f172a);
         margin: 0;
       }
 
       :host([container="s"]) .title {
-        font: var(--components-menu-bar-title-item-s-font, 600 18px/1.125 RijksSansVF, system-ui);
+        font: var(--components-menu-bar-title-item-s-font, 550 18px/1.125 RijksSansVF, system-ui);
       }
 
       :host([container="l"]) .title {
-        font: var(--components-menu-bar-title-item-l-font, 600 23px/1.125 RijksSansVF, system-ui);
+        font: var(--components-menu-bar-title-item-l-font, 550 23px/1.125 RijksSansVF, system-ui);
       }
 
       .subtitle {

--- a/src/components/top-navigation-bar/rr-top-navigation-bar.js
+++ b/src/components/top-navigation-bar/rr-top-navigation-bar.js
@@ -231,7 +231,7 @@ export class RRTopNavigationBar extends RRBaseComponent {
         background-color: var(--primitives-color-accent-100, #154273);
         color: #ffffff;
         padding: var(--primitives-space-8, 8px) var(--primitives-space-16, 16px);
-        font: var(--components-menu-bar-menu-item-font, 600 18px/1.125 RijksSansVF, system-ui);
+        font: var(--components-menu-bar-menu-item-font, 550 18px/1.125 RijksSansVF, system-ui);
         text-decoration: none;
         border-radius: var(--semantics-controls-m-corner-radius, 7px);
       }
@@ -332,18 +332,18 @@ export class RRTopNavigationBar extends RRBaseComponent {
 
       /* Navigation title */
       .nav-title {
-        font: var(--components-menu-bar-title-item-m-font, 600 20px/1.125 RijksSansVF, system-ui);
+        font: var(--components-menu-bar-title-item-m-font, 550 20px/1.125 RijksSansVF, system-ui);
         color: var(--primitives-color-neutral-900, #0f172a);
         margin-right: var(--primitives-space-16, 16px);
         white-space: nowrap;
       }
 
       :host([container="s"]) .nav-title {
-        font: var(--components-menu-bar-title-item-s-font, 600 18px/1.125 RijksSansVF, system-ui);
+        font: var(--components-menu-bar-title-item-s-font, 550 18px/1.125 RijksSansVF, system-ui);
       }
 
       :host([container="l"]) .nav-title {
-        font: var(--components-menu-bar-title-item-l-font, 600 23px/1.125 RijksSansVF, system-ui);
+        font: var(--components-menu-bar-title-item-l-font, 550 23px/1.125 RijksSansVF, system-ui);
       }
 
       /* Menu bar integration - remove its own border as nav-bar provides structure */

--- a/src/components/top-navigation-bar/rr-utility-menu-bar.js
+++ b/src/components/top-navigation-bar/rr-utility-menu-bar.js
@@ -217,7 +217,7 @@ export class RRUtilityMenuBar extends RRBaseComponent {
         background: none;
         border: none;
         color: var(--primitives-color-accent-100, #154273);
-        font: var(--components-menu-bar-menu-item-font, 600 18px/1.125 RijksSansVF, system-ui);
+        font: var(--components-menu-bar-menu-item-font, 550 18px/1.125 RijksSansVF, system-ui);
         cursor: pointer;
         border-radius: var(--semantics-controls-m-corner-radius, 7px);
         transition: background-color 0.15s ease;

--- a/src/parser/figma-variables-parser.js
+++ b/src/parser/figma-variables-parser.js
@@ -3,6 +3,8 @@
  * Transforms to Style Dictionary DTCG format
  */
 
+import { FONT_WEIGHT_MAP } from './font-weights.js';
+
 export const figmaVariablesParser = {
   name: 'figma-variables',
   pattern: /\.json$/,
@@ -139,20 +141,27 @@ function transformTypography(value) {
 
 /**
  * Map Figma font weight names to CSS values
+ * Handles both string values (from Figma text styles) and numeric values
+ * Throws on invalid input to fail fast during build
  */
 function mapFontWeight(weight) {
-  const weightMap = {
-    Thin: '100',
-    ExtraLight: '200',
-    Light: '300',
-    Regular: '400',
-    Medium: '500',
-    SemiBold: '600',
-    Bold: '700',
-    ExtraBold: '800',
-    Black: '900',
-  };
-  return weightMap[weight] || weight;
+  if (weight === undefined || weight === null) {
+    throw new Error('fontWeight is required in typography token but was undefined');
+  }
+
+  if (typeof weight === 'string') {
+    const mapped = FONT_WEIGHT_MAP[weight];
+    if (mapped === undefined) {
+      throw new Error(`Unknown fontWeight value: "${weight}"`);
+    }
+    return mapped;
+  }
+
+  if (typeof weight === 'number') {
+    return weight;
+  }
+
+  throw new Error(`Invalid fontWeight type: ${typeof weight}`);
 }
 
 /**

--- a/src/parser/font-weights.js
+++ b/src/parser/font-weights.js
@@ -1,0 +1,19 @@
+/**
+ * Font weight mapping for RijksSans variable font
+ *
+ * RijksSans (RijksoverheidSans) uses 550 for semi-bold instead of the
+ * typical 600. This is documented in the font's design specifications.
+ *
+ * @see https://www.rijkshuisstijl.nl/publiek/modules/product/DigitalStyleGuide/default/index.aspx?ItemId=2466
+ */
+export const FONT_WEIGHT_MAP = {
+  Thin: 100,
+  ExtraLight: 200,
+  Light: 300,
+  Regular: 400,
+  Medium: 500,
+  SemiBold: 550, // RijksSans uses 550, not 600
+  Bold: 700,
+  ExtraBold: 800,
+  Black: 900,
+};

--- a/style-dictionary.config.js
+++ b/style-dictionary.config.js
@@ -1,5 +1,6 @@
 import StyleDictionary from 'style-dictionary';
 import { figmaVariablesParser } from './src/parser/figma-variables-parser.js';
+import { FONT_WEIGHT_MAP } from './src/parser/font-weights.js';
 
 // Register custom parser for Figma variables2json format
 StyleDictionary.registerParser(figmaVariablesParser);
@@ -25,6 +26,23 @@ StyleDictionary.registerTransform({
   },
   transform: (token) => {
     // Keep opacity, line-height etc as plain numbers
+    return token.$value;
+  },
+});
+
+// Custom transform for fontWeight tokens - convert string names to numeric values
+StyleDictionary.registerTransform({
+  name: 'fontWeight/number',
+  type: 'value',
+  filter: (token) => token.$type === 'fontWeight',
+  transform: (token) => {
+    if (typeof token.$value === 'string') {
+      const mapped = FONT_WEIGHT_MAP[token.$value];
+      if (mapped === undefined) {
+        throw new Error(`Unknown fontWeight value: "${token.$value}" in token ${token.name}`);
+      }
+      return mapped;
+    }
     return token.$value;
   },
 });
@@ -74,7 +92,7 @@ const config = {
   platforms: {
     // All tokens combined
     css: {
-      transforms: ['name/kebab', 'size/px', 'number/value', 'typography/css', 'color/css'],
+      transforms: ['name/kebab', 'size/px', 'number/value', 'fontWeight/number', 'typography/css', 'color/css'],
       buildPath: 'dist/css/',
       files: [
         {
@@ -86,7 +104,7 @@ const config = {
 
     // Primitives only
     'css-primitives': {
-      transforms: ['name/kebab', 'size/px', 'number/value', 'typography/css', 'color/css'],
+      transforms: ['name/kebab', 'size/px', 'number/value', 'fontWeight/number', 'typography/css', 'color/css'],
       buildPath: 'dist/css/',
       files: [
         {
@@ -99,7 +117,7 @@ const config = {
 
     // Semantics only
     'css-semantics': {
-      transforms: ['name/kebab', 'size/px', 'number/value', 'typography/css', 'color/css'],
+      transforms: ['name/kebab', 'size/px', 'number/value', 'fontWeight/number', 'typography/css', 'color/css'],
       buildPath: 'dist/css/',
       files: [
         {
@@ -112,7 +130,7 @@ const config = {
 
     // Component tokens only
     'css-components': {
-      transforms: ['name/kebab', 'size/px', 'number/value', 'typography/css', 'color/css'],
+      transforms: ['name/kebab', 'size/px', 'number/value', 'fontWeight/number', 'typography/css', 'color/css'],
       buildPath: 'dist/css/',
       files: [
         {
@@ -125,7 +143,7 @@ const config = {
 
     // JSON output for debugging/reference
     json: {
-      transforms: ['name/kebab', 'size/px', 'number/value'],
+      transforms: ['name/kebab', 'size/px', 'number/value', 'fontWeight/number'],
       buildPath: 'dist/',
       files: [
         {


### PR DESCRIPTION
## Summary

- Update `mapFontWeight()` to convert Figma string values ("SemiBold", "Regular") to numeric CSS values
- Add `fontWeight/number` transform to Style Dictionary for primitive tokens
- Change SemiBold mapping from 600 to 550 (RijksSans specification)
- Update all component CSS fallbacks from 600 to 550
- Centralize `FONT_WEIGHT_MAP` in shared `src/parser/font-weights.js`
- Add fail-fast error handling for unknown font weight values
- Add fallback consistency rule to CLAUDE.md

## Affected components

- rr-button, rr-icon-button, rr-toggle-button
- rr-menu-bar, rr-menu-item
- rr-top-navigation-bar, rr-back-button, rr-nav-logo, rr-utility-menu-bar

## FigmaComparison Screenshots

| Component | Side-by-Side | Overlay |
|-----------|--------------|---------|
| Button | ![button-side-by-side](https://0x0.st/PPHX.png) | ![button-overlay](https://0x0.st/PPoF.png) |
| Toggle Button | ![toggle-button-side-by-side](https://0x0.st/PPHc.png) | ![toggle-button-overlay](https://0x0.st/PPHb.png) |
| Icon Button | ![icon-button-side-by-side](https://0x0.st/PPHA.png) | ![icon-button-overlay](https://0x0.st/PPHT.png) |
| Menu Bar | ![menu-bar-side-by-side](https://0x0.st/PPHa.png) | ![menu-bar-overlay](https://0x0.st/PPHm.png) |
| Checkbox | ![checkbox-side-by-side](https://0x0.st/PPHM.png) | ![checkbox-overlay](https://0x0.st/PPHB.png) |
| Radio | ![radio-side-by-side](https://0x0.st/PPHS.png) | ![radio-overlay](https://0x0.st/PPHu.png) |
| Top Navigation Bar | ![top-nav-side-by-side](https://0x0.st/PPH1.png) | ![top-nav-overlay](https://0x0.st/PPHQ.png) |

## Test plan

- [ ] Run `npm run build:tokens` - verify numeric output in `dist/css/tokens.css`
- [ ] Check `--primitives-font-weight-body-semi-bold: 550` (not "SemiBold")
- [ ] Check `--components-button-m-font: 550 18px/...` (not 600)
- [ ] Run Storybook and verify button font rendering