### PR TITLE
feat(layout): add spacer, spacer-cell, divider and page-sticky-area-background

### DIFF
--- a/.claude/skills/component/SKILL.md
+++ b/.claude/skills/component/SKILL.md
@@ -85,6 +85,25 @@ grep -i "controls.*min-size" dist/css/tokens.css
 **Controleer ook bestaande componenten voor patronen:**
 - `src/components/toggle-button/rr-toggle-button.ts` (referentie implementatie)
 
+### Spacer Component Gebruik
+
+**Gebruik `<rr-spacer>` voor spacing in componenten waar Figma spacer elementen heeft.**
+
+Check in Figma data of er spacer frames zijn (bijv. `top-navigation-bar__section-spacer`).
+
+```html
+<!-- Vaste spacing -->
+<rr-spacer size="32"></rr-spacer>
+
+<!-- Flexibele spacing (vult beschikbare ruimte) -->
+<rr-spacer size="flexible"></rr-spacer>
+
+<!-- Container-responsive spacing -->
+<rr-spacer size="m" container="l"></rr-spacer>
+```
+
+**Beschikbare sizes:** 2, 4, 6, 8, 12, 16, 20, 24, 32, 40, 44, 48, 64, 80, 96, m, flexible
+
 ### Stap 5: Component Genereren/Updaten
 
 **Bestanden:**

--- a/.claude/skills/figma-pr/SKILL.md
+++ b/.claude/skills/figma-pr/SKILL.md
@@ -124,17 +124,24 @@ Always screenshot the `ftl-holster` element directly, NOT fullPage. This gives c
 
 **Important: Playwright MCP output directory**
 
-Screenshots are saved to `.playwright-mcp/` directory (restricted by Playwright MCP).
+Screenshots are saved to `.playwright-mcp/` directory in the folder where Claude Code was started (NOT the current working directory). When working in a worktree, screenshots will be saved to the main repository's `.playwright-mcp/` folder, not the worktree's folder.
+
+Example: If Claude Code was started in `C:\Users\timde\Documents\Code\storybook` but you're working in `.worktrees\feat-spacer-lit`, screenshots go to:
+- `C:\Users\timde\Documents\Code\storybook\.playwright-mcp\` (correct)
+- NOT `.worktrees\feat-spacer-lit\.playwright-mcp\`
 
 ### Step 4: Upload Screenshots to 0x0.st
 
-Upload each screenshot to 0x0.st (no authentication required):
+Upload each screenshot to 0x0.st (no authentication required).
+
+**Important:** Screenshots are in the `.playwright-mcp/` folder where Claude Code was started, NOT the current worktree. When working in a worktree, look in the main repo folder.
 
 ```bash
 # Upload and capture the returned URL
 # IMPORTANT: On Windows, use ABSOLUTE paths - relative paths cause exit code 26
-SIDE_BY_SIDE_URL=$(curl -s -F "file=@/full/path/to/.playwright-mcp/{name}-side-by-side.png" https://0x0.st)
-OVERLAY_URL=$(curl -s -F "file=@/full/path/to/.playwright-mcp/{name}-overlay.png" https://0x0.st)
+# Use the MAIN REPO path, not the worktree path!
+SIDE_BY_SIDE_URL=$(curl -s -F "file=@C:/Users/.../storybook/.playwright-mcp/{name}-side-by-side.png" https://0x0.st)
+OVERLAY_URL=$(curl -s -F "file=@C:/Users/.../storybook/.playwright-mcp/{name}-overlay.png" https://0x0.st)
 ```
 
 **Windows path note:** Always use absolute paths for curl file uploads on Windows. Relative paths like `@.playwright-mcp/file.png` fail with exit code 26. Use full paths like `@C:/Users/.../project/.playwright-mcp/file.png`.
@@ -207,6 +214,7 @@ gh pr create --title "feat: {summary of changes}" --body "{PR body}"
 | Component has no FigmaComparison | Use fallback: screenshot Default story (see below) |
 | Keyboard shortcuts not working | Click buttons directly via snapshot refs |
 | curl exit code 26 (Windows) | Use absolute file paths instead of relative paths |
+| Screenshots not in worktree | Check main repo's `.playwright-mcp/` folder - Playwright saves to where Claude started |
 | 0x0.st upload fails | Retry or use alternative host |
 
 ### Worktree .env Issue

--- a/.claude/skills/figma-pr/SKILL.md
+++ b/.claude/skills/figma-pr/SKILL.md
@@ -100,10 +100,10 @@ Where `{name}` is the kebab-case component name:
 9. Wait briefly: `mcp__playwright__browser_wait_for` with time: 1
 10. **Set overlay opacity to 50%** for half-half comparison:
     - Take a new snapshot to find the opacity slider ref
-    - The slider is a `<input type="range">` element in the ftl-holster controls
-    - Use `mcp__playwright__browser_evaluate` to set slider value to 50:
+    - The slider is a `<input type="range">` element with range 0.0-1.0
+    - Use `mcp__playwright__browser_evaluate` to set slider value to 0.5 (NOT 50!):
       ```javascript
-      function: "(slider) => { slider.value = 50; slider.dispatchEvent(new Event('input', { bubbles: true })); }",
+      function: "(slider) => { slider.value = 0.5; slider.dispatchEvent(new Event('input', { bubbles: true })); }",
       ref: "{slider-ref}",
       element: "Opacity slider"
       ```

--- a/.claude/skills/figma-pr/SKILL.md
+++ b/.claude/skills/figma-pr/SKILL.md
@@ -132,9 +132,12 @@ Upload each screenshot to 0x0.st (no authentication required):
 
 ```bash
 # Upload and capture the returned URL
-SIDE_BY_SIDE_URL=$(curl -s -F "file=@.playwright-mcp/{name}-side-by-side.png" https://0x0.st)
-OVERLAY_URL=$(curl -s -F "file=@.playwright-mcp/{name}-overlay.png" https://0x0.st)
+# IMPORTANT: On Windows, use ABSOLUTE paths - relative paths cause exit code 26
+SIDE_BY_SIDE_URL=$(curl -s -F "file=@/full/path/to/.playwright-mcp/{name}-side-by-side.png" https://0x0.st)
+OVERLAY_URL=$(curl -s -F "file=@/full/path/to/.playwright-mcp/{name}-overlay.png" https://0x0.st)
 ```
+
+**Windows path note:** Always use absolute paths for curl file uploads on Windows. Relative paths like `@.playwright-mcp/file.png` fail with exit code 26. Use full paths like `@C:/Users/.../project/.playwright-mcp/file.png`.
 
 Store the URLs for each component to use in the PR body.
 
@@ -203,6 +206,7 @@ gh pr create --title "feat: {summary of changes}" --body "{PR body}"
 | gh CLI not authenticated | Run `gh auth login` |
 | Component has no FigmaComparison | Use fallback: screenshot Default story (see below) |
 | Keyboard shortcuts not working | Click buttons directly via snapshot refs |
+| curl exit code 26 (Windows) | Use absolute file paths instead of relative paths |
 | 0x0.st upload fails | Retry or use alternative host |
 
 ### Worktree .env Issue

--- a/.claude/skills/pixel-perfect/SKILL.md
+++ b/.claude/skills/pixel-perfect/SKILL.md
@@ -279,6 +279,14 @@ Perform both **automated comparisons** and **visual checks**:
 - Find correct token in `dist/css/tokens.css`
 - Adjust component or story
 
+**Token deviation (IMPORTANT):**
+If a deviation is caused by an **incorrect token value** (token doesn't match Figma):
+- Do **NOT** override the token with a hardcoded value
+- Do **NOT** modify the token file directly (it's generated from Figma)
+- Instead: **Report in the PR** that the token needs to be updated in Figma
+- The component should use the token as-is, even if it doesn't match visually yet
+- Format: "TODO: Figma token `{token-name}` should be `{correct-value}` (currently `{wrong-value}`)"
+
 ### 4.10 Modify files
 
 **Adjust story (layout/variants):**

--- a/.claude/skills/pixel-perfect/SKILL.md
+++ b/.claude/skills/pixel-perfect/SKILL.md
@@ -194,12 +194,12 @@ mcp__playwright__browser_click(
 **IMPORTANT:** Overlay screenshots must ALWAYS be taken at 50% opacity for a half-half comparison.
 
 1. Take a new snapshot to find the opacity slider ref
-2. The slider is an `<input type="range">` element in the ftl-holster controls
-3. Set the slider to 50%:
+2. The slider is an `<input type="range">` element with range 0.0-1.0
+3. Set the slider to 50% (value 0.5, NOT 50!):
 
 ```
 mcp__playwright__browser_evaluate(
-  function: "(slider) => { slider.value = 50; slider.dispatchEvent(new Event('input', { bubbles: true })); }",
+  function: "(slider) => { slider.value = 0.5; slider.dispatchEvent(new Event('input', { bubbles: true })); }",
   ref: "{slider-ref}",
   element: "Opacity slider"
 )

--- a/.claude/skills/pixel-perfect/known-issues.md
+++ b/.claude/skills/pixel-perfect/known-issues.md
@@ -203,7 +203,109 @@ line-height: 1; /* Reset, dan fine-tune */
 
 ---
 
+## Issue: Figma spacer pattern vs CSS padding
+
+**Symptoom:** Elementen in nav-bar zijn horizontaal verschoven t.o.v. Figma (bijv. 8px te ver naar rechts)
+**Root cause:** Figma gebruikt vaak interne spacer elementen (bijv. 32px brede spacers) naast container padding, terwijl CSS alleen padding gebruikt
+**Diagnostiek:**
+```javascript
+// Check Figma structuur voor spacer children:
+// Container: padding=8px + spacer child width=32px = 40px totale offset
+// CSS: padding=48px (direct op container)
+// Verschil: 48px - 40px = 8px offset
+```
+**Fix:**
+```css
+/* Compenseer met negatieve margin op specifieke elementen */
+.nav-right {
+  margin-right: -8px; /* 48px padding - 40px Figma offset */
+}
+
+/* NIET: verander globale padding, dit breekt andere elementen */
+```
+**Preventie:** Analyseer Figma's interne structuur inclusief spacer elementen voordat je padding aanpast. Gebruik negatieve margins voor compensatie in plaats van globale padding wijzigingen.
+
+---
+
+## Issue: Title margin vs padding voor spacing
+
+**Symptoom:** Titel tekst is verkeerd uitgelijnd t.o.v. aangrenzende elementen
+**Root cause:** CSS margin-right op titel creëert extra ruimte bovenop de padding van het aangrenzende element, terwijl Figma's title-item interne padding gebruikt
+**Diagnostiek:**
+```javascript
+// Figma title-item heeft padding: 0px 8px (interne spacing)
+// CSS met margin-right: 16px creëert 16px + adjacent padding
+// Dit resulteert in te veel ruimte
+```
+**Fix:**
+```css
+/* FOUT - margin stapelt op adjacent element's padding */
+.nav-title {
+  margin-right: 16px;
+}
+
+/* GOED - padding matcht Figma's interne structuur */
+.nav-title {
+  padding-right: 8px; /* Matcht Figma title-item padding */
+}
+```
+**Preventie:** Check of Figma padding of margin gebruikt voor spacing. Gebruik padding voor interne spacing binnen een element.
+
+---
+
+## Issue: Meerdere alignment changes tegelijk
+
+**Symptoom:** Na meerdere CSS wijzigingen is de layout erger dan voorheen
+**Root cause:** Alignment issues hebben vaak onderlinge afhankelijkheden; meerdere fixes tegelijk maakt het moeilijk te zien welke werkt
+**Diagnostiek:**
+```
+# Voorbeeld van verkeerde aanpak:
+1. Wijzig nav-bar padding 48px → 40px
+2. Wijzig title margin 16px → 8px
+3. Screenshot → layout is erger dan voorheen
+# Welke wijziging is fout? Onduidelijk!
+```
+**Fix:**
+```
+# Correcte aanpak: incrementeel testen
+1. Wijzig ALLEEN titel spacing
+2. Screenshot + vergelijk → beter of slechter?
+3. Als beter: houd wijziging, ga naar volgende
+4. Als slechter: revert, probeer alternatief
+5. Herhaal voor elk element apart
+```
+**Preventie:** Test alignment wijzigingen ALTIJD één voor één. Neem een screenshot na elke individuele wijziging om het effect te isoleren.
+
+---
+
 # Common Fixes (Quick Reference)
+
+## Spacing met spacer component
+
+Gebruik `<rr-spacer>` voor spacing waar Figma spacer elementen gebruikt:
+
+```html
+<!-- Vaste spacing (NxN vierkant) -->
+<rr-spacer size="32"></rr-spacer>
+
+<!-- Flexibele spacing (vult beschikbare ruimte) -->
+<rr-spacer size="flexible"></rr-spacer>
+
+<!-- Container-responsive spacing -->
+<rr-spacer size="m" container="l"></rr-spacer>
+
+<!-- Alleen horizontaal of verticaal -->
+<rr-spacer size="16" direction="horizontal"></rr-spacer>
+<rr-spacer size="16" direction="vertical"></rr-spacer>
+```
+
+**Beschikbare sizes:** 2, 4, 6, 8, 12, 16, 20, 24, 32, 40, 44, 48, 64, 80, 96, m, flexible
+
+**Container-responsive 'm' size:**
+- container="s" → 16x16px
+- container="m" of "l" → 24x24px
+
+---
 
 ## Padding klopt niet
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,12 @@ padding: 8px 8px 6px 8px;  /* NOT symmetric! */
 
 **Disabled Opacity:** Always use `calc(var(--primitives-opacity-disabled, 38) / 100)` - the token is a percentage.
 
+**Asymmetric Figma Layouts:** Figma uses padding + spacer elements that can create asymmetric distances (e.g., 48px left vs 40px right). Check both sides separately and use margin compensation if needed.
+
+**Always Check Figma Gap:** Don't assume flex containers have gaps. Figma's layout panel shows gap explicitly - if not shown, gap is 0.
+
+**Subpixel Font Drift:** Expect ~0.4px cumulative drift per text element due to font rendering differences. This is inherent and not fixable.
+
 ## Token Hierarchy
 
 ```
@@ -92,6 +98,7 @@ export const FigmaComparison = () => html`
 | Toggle Button | 309:3542 | Implemented |
 | Icon Button | 240:1391 | Implemented |
 | Menu Bar / Top Nav | 48:2135 | Implemented |
+| Spacer | 48:2234 | Implemented |
 
 See `docs/component-map.json` for full details.
 

--- a/docs/component-map.json
+++ b/docs/component-map.json
@@ -644,6 +644,25 @@
       "lastUpdated": "2026-01-28"
     },
     {
+      "name": "Spacer Cell",
+      "figma": {
+        "nodeId": "236-41413",
+        "nodeName": "spacer-cell",
+        "url": "https://www.figma.com/design/5DyHMXUNVxbgH7ZjhQxPZe/RR-Components?node-id=236-41413"
+      },
+      "properties": {
+        "size": ["2", "4", "6", "8", "10", "12", "16", "20", "24", "28", "32", "40", "44", "48", "56", "64", "80", "96", "m", "flexible"],
+        "container": ["s", "m", "l", "all"]
+      },
+      "implementation": {
+        "tagName": "rr-spacer-cell",
+        "file": "src/components/spacer-cell/rr-spacer-cell.ts",
+        "className": "RRSpacerCell"
+      },
+      "status": "implemented",
+      "lastUpdated": "2026-01-28"
+    },
+    {
       "name": "Text Field",
       "figma": {
         "nodeId": "192-37504",

--- a/docs/component-map.json
+++ b/docs/component-map.json
@@ -464,6 +464,62 @@
       ],
       "status": "implemented",
       "lastUpdated": "2025-12-22"
+    },
+    {
+      "name": "Spacer",
+      "figma": {
+        "nodeId": "48:2234",
+        "nodeName": "spacer",
+        "pageName": "Bars",
+        "url": "https://www.figma.com/design/5DyHMXUNVxbgH7ZjhQxPZe/RR-Components?node-id=48-2234",
+        "note": "Utility spacer component for layout spacing"
+      },
+      "properties": {
+        "size": ["2", "4", "6", "8", "10", "12", "16", "20", "24", "28", "32", "40", "44", "48", "56", "64", "80", "96", "m", "flexible"],
+        "container": ["s", "m", "l", "all"],
+        "direction": ["horizontal", "vertical", "both"]
+      },
+      "implementation": {
+        "tagName": "rr-spacer",
+        "file": "src/components/spacer/rr-spacer.ts",
+        "className": "RRSpacer"
+      },
+      "tokens": {
+        "primitives": [
+          "primitives-space-2",
+          "primitives-space-4",
+          "primitives-space-6",
+          "primitives-space-8",
+          "primitives-space-10",
+          "primitives-space-12",
+          "primitives-space-16",
+          "primitives-space-20",
+          "primitives-space-24",
+          "primitives-space-28",
+          "primitives-space-32",
+          "primitives-space-40",
+          "primitives-space-44",
+          "primitives-space-48",
+          "primitives-space-56",
+          "primitives-space-64",
+          "primitives-space-80",
+          "primitives-space-96"
+        ]
+      },
+      "variants": [
+        {
+          "name": "size",
+          "values": ["2", "4", "6", "8", "10", "12", "16", "20", "24", "28", "32", "40", "44", "48", "56", "64", "80", "96", "m", "flexible"],
+          "default": "8"
+        },
+        {
+          "name": "container",
+          "values": ["s", "m", "l", "all"],
+          "default": "all"
+        }
+      ],
+      "status": "implemented",
+      "lastUpdated": "2026-01-27"
     }
   ]
 }

--- a/docs/component-map.json
+++ b/docs/component-map.json
@@ -466,60 +466,483 @@
       "lastUpdated": "2025-12-22"
     },
     {
+      "name": "Action Sheet",
+      "figma": {
+        "nodeId": "94-24956",
+        "nodeName": "action-sheet",
+        "url": "https://www.figma.com/design/5DyHMXUNVxbgH7ZjhQxPZe/RR-Components?node-id=94-24956"
+      },
+      "status": "priority",
+      "neededFor": ["machine-action-sheet"]
+    },
+    {
+      "name": "Action Sheet: Header",
+      "figma": {
+        "nodeId": "108-25982",
+        "nodeName": "action-sheet__header",
+        "url": "https://www.figma.com/design/5DyHMXUNVxbgH7ZjhQxPZe/RR-Components?node-id=108-25982"
+      },
+      "status": "priority",
+      "neededFor": ["machine-action-sheet"]
+    },
+    {
+      "name": "Bottom Action Bar",
+      "figma": {
+        "nodeId": "134-28016",
+        "nodeName": "bottom-action-bar",
+        "url": "https://www.figma.com/design/5DyHMXUNVxbgH7ZjhQxPZe/RR-Components?node-id=134-28016"
+      },
+      "status": "priority",
+      "neededFor": ["machine-action-sheet"]
+    },
+    {
+      "name": "Button Cell",
+      "figma": {
+        "nodeId": "236-41331",
+        "nodeName": "button-cell",
+        "url": "https://www.figma.com/design/5DyHMXUNVxbgH7ZjhQxPZe/RR-Components?node-id=236-41331"
+      },
+      "status": "priority",
+      "neededFor": ["machine-action-sheet"]
+    },
+    {
+      "name": "Custom Cell",
+      "figma": {
+        "nodeId": "1151-6202",
+        "nodeName": "custom-cell",
+        "url": "https://www.figma.com/design/5DyHMXUNVxbgH7ZjhQxPZe/RR-Components?node-id=1151-6202"
+      },
+      "status": "priority",
+      "neededFor": ["machine-action-sheet"]
+    },
+    {
+      "name": "Divider",
+      "figma": {
+        "nodeId": "39-927",
+        "nodeName": "split-vew__divider",
+        "url": "https://www.figma.com/design/5DyHMXUNVxbgH7ZjhQxPZe/RR-Components?node-id=39-927",
+        "note": "Component naam in Figma heeft typo (vew ipv view)"
+      },
+      "properties": {
+        "orientation": ["horizontal", "vertical"]
+      },
+      "implementation": {
+        "tagName": "rr-divider",
+        "file": "src/components/divider/rr-divider.ts",
+        "className": "RRDivider"
+      },
+      "status": "implemented",
+      "lastUpdated": "2026-01-28"
+    },
+    {
+      "name": "Drop Down Field",
+      "figma": {
+        "nodeId": "358-717",
+        "nodeName": "drop-down-field",
+        "url": "https://www.figma.com/design/5DyHMXUNVxbgH7ZjhQxPZe/RR-Components?node-id=358-717"
+      },
+      "status": "priority",
+      "neededFor": ["machine-action-sheet"]
+    },
+    {
+      "name": "Drop Down Field Cell",
+      "figma": {
+        "nodeId": "1014-3843",
+        "nodeName": "drop-down-field-cell",
+        "url": "https://www.figma.com/design/5DyHMXUNVxbgH7ZjhQxPZe/RR-Components?node-id=1014-3843"
+      },
+      "status": "priority",
+      "neededFor": ["machine-action-sheet"]
+    },
+    {
+      "name": "Heading Group",
+      "figma": {
+        "nodeId": "996-3541",
+        "nodeName": "heading-group",
+        "url": "https://www.figma.com/design/5DyHMXUNVxbgH7ZjhQxPZe/RR-Components?node-id=996-3541"
+      },
+      "status": "priority",
+      "neededFor": ["machine-action-sheet"]
+    },
+    {
+      "name": "Label Cell",
+      "figma": {
+        "nodeId": "1033-4433",
+        "nodeName": "label-cell",
+        "url": "https://www.figma.com/design/5DyHMXUNVxbgH7ZjhQxPZe/RR-Components?node-id=1033-4433"
+      },
+      "status": "priority",
+      "neededFor": ["machine-action-sheet"]
+    },
+    {
+      "name": "List",
+      "figma": {
+        "nodeId": "1044-2275",
+        "nodeName": "list",
+        "url": "https://www.figma.com/design/5DyHMXUNVxbgH7ZjhQxPZe/RR-Components?node-id=1044-2275"
+      },
+      "status": "priority",
+      "neededFor": ["machine-action-sheet"]
+    },
+    {
+      "name": "List: Item",
+      "figma": {
+        "nodeId": "957-2279",
+        "nodeName": "list__item",
+        "url": "https://www.figma.com/design/5DyHMXUNVxbgH7ZjhQxPZe/RR-Components?node-id=957-2279"
+      },
+      "status": "priority",
+      "neededFor": ["machine-action-sheet"]
+    },
+    {
+      "name": "Page: Sticky Area Background",
+      "figma": {
+        "nodeId": "1171-6495",
+        "nodeName": "page__sticky-area-background",
+        "url": "https://www.figma.com/design/5DyHMXUNVxbgH7ZjhQxPZe/RR-Components?node-id=1171-6495"
+      },
+      "properties": {
+        "position": ["top", "bottom"],
+        "tinted": "boolean"
+      },
+      "implementation": {
+        "tagName": "rr-page-sticky-area-background",
+        "file": "src/components/page-sticky-area-background/rr-page-sticky-area-background.ts",
+        "className": "RRPageStickyAreaBackground"
+      },
+      "status": "implemented",
+      "lastUpdated": "2026-01-28"
+    },
+    {
+      "name": "Sheet",
+      "figma": {
+        "nodeId": "108-25937",
+        "nodeName": "sheet",
+        "url": "https://www.figma.com/design/5DyHMXUNVxbgH7ZjhQxPZe/RR-Components?node-id=108-25937"
+      },
+      "status": "priority",
+      "neededFor": ["machine-action-sheet"]
+    },
+    {
       "name": "Spacer",
       "figma": {
-        "nodeId": "48:2234",
+        "nodeId": "48-2234",
         "nodeName": "spacer",
-        "pageName": "Bars",
-        "url": "https://www.figma.com/design/5DyHMXUNVxbgH7ZjhQxPZe/RR-Components?node-id=48-2234",
-        "note": "Utility spacer component for layout spacing"
+        "url": "https://www.figma.com/design/5DyHMXUNVxbgH7ZjhQxPZe/RR-Components?node-id=48-2234"
       },
       "properties": {
         "size": ["2", "4", "6", "8", "10", "12", "16", "20", "24", "28", "32", "40", "44", "48", "56", "64", "80", "96", "m", "flexible"],
-        "container": ["s", "m", "l", "all"],
-        "direction": ["horizontal", "vertical", "both"]
+        "direction": ["horizontal", "vertical", "both"],
+        "container": ["s", "m", "l", "all"]
       },
       "implementation": {
         "tagName": "rr-spacer",
         "file": "src/components/spacer/rr-spacer.ts",
         "className": "RRSpacer"
       },
-      "tokens": {
-        "primitives": [
-          "primitives-space-2",
-          "primitives-space-4",
-          "primitives-space-6",
-          "primitives-space-8",
-          "primitives-space-10",
-          "primitives-space-12",
-          "primitives-space-16",
-          "primitives-space-20",
-          "primitives-space-24",
-          "primitives-space-28",
-          "primitives-space-32",
-          "primitives-space-40",
-          "primitives-space-44",
-          "primitives-space-48",
-          "primitives-space-56",
-          "primitives-space-64",
-          "primitives-space-80",
-          "primitives-space-96"
-        ]
-      },
-      "variants": [
-        {
-          "name": "size",
-          "values": ["2", "4", "6", "8", "10", "12", "16", "20", "24", "28", "32", "40", "44", "48", "56", "64", "80", "96", "m", "flexible"],
-          "default": "8"
-        },
-        {
-          "name": "container",
-          "values": ["s", "m", "l", "all"],
-          "default": "all"
-        }
-      ],
       "status": "implemented",
-      "lastUpdated": "2026-01-27"
+      "lastUpdated": "2026-01-28"
+    },
+    {
+      "name": "Text Field",
+      "figma": {
+        "nodeId": "192-37504",
+        "nodeName": "text-field",
+        "url": "https://www.figma.com/design/5DyHMXUNVxbgH7ZjhQxPZe/RR-Components?node-id=192-37504"
+      },
+      "status": "priority",
+      "neededFor": ["machine-action-sheet"]
+    },
+    {
+      "name": "Text Field Cell",
+      "figma": {
+        "nodeId": "1019-3941",
+        "nodeName": "text-field-cell",
+        "url": "https://www.figma.com/design/5DyHMXUNVxbgH7ZjhQxPZe/RR-Components?node-id=1019-3941"
+      },
+      "status": "priority",
+      "neededFor": ["machine-action-sheet"]
+    },
+    {
+      "name": "Title Cell",
+      "figma": {
+        "nodeId": "236-41079",
+        "nodeName": "title-cell",
+        "url": "https://www.figma.com/design/5DyHMXUNVxbgH7ZjhQxPZe/RR-Components?node-id=236-41079"
+      },
+      "status": "priority",
+      "neededFor": ["machine-action-sheet"]
+    },
+    {
+      "name": "Top Title Bar",
+      "figma": {
+        "nodeId": "1048-2288",
+        "nodeName": "top-title-bar",
+        "url": "https://www.figma.com/design/5DyHMXUNVxbgH7ZjhQxPZe/RR-Components?node-id=1048-2288"
+      },
+      "status": "priority",
+      "neededFor": ["machine-action-sheet"]
+    },
+    {
+      "name": "Accessory Cell",
+      "figma": {
+        "nodeId": "1040-4478",
+        "nodeName": "accessory-cell",
+        "url": "https://www.figma.com/design/5DyHMXUNVxbgH7ZjhQxPZe/RR-Components?node-id=1040-4478"
+      },
+      "status": "not-implemented"
+    },
+    {
+      "name": "Background",
+      "figma": {
+        "nodeId": "997-3542",
+        "nodeName": "background",
+        "url": "https://www.figma.com/design/5DyHMXUNVxbgH7ZjhQxPZe/RR-Components?node-id=997-3542"
+      },
+      "status": "not-implemented"
+    },
+    {
+      "name": "Checkbox (standalone)",
+      "figma": {
+        "nodeId": "204-38347",
+        "nodeName": "checkbox",
+        "url": "https://www.figma.com/design/5DyHMXUNVxbgH7ZjhQxPZe/RR-Components?node-id=204-38347"
+      },
+      "status": "not-implemented"
+    },
+    {
+      "name": "Checkbox Field",
+      "figma": {
+        "nodeId": "241-2345",
+        "nodeName": "checkbox-field",
+        "url": "https://www.figma.com/design/5DyHMXUNVxbgH7ZjhQxPZe/RR-Components?node-id=241-2345"
+      },
+      "status": "not-implemented"
+    },
+    {
+      "name": "Combo Box Field",
+      "figma": {
+        "nodeId": "362-2435",
+        "nodeName": "combo-box-field",
+        "url": "https://www.figma.com/design/5DyHMXUNVxbgH7ZjhQxPZe/RR-Components?node-id=362-2435"
+      },
+      "status": "not-implemented"
+    },
+    {
+      "name": "Description Cell",
+      "figma": {
+        "nodeId": "236-41321",
+        "nodeName": "description-cell",
+        "url": "https://www.figma.com/design/5DyHMXUNVxbgH7ZjhQxPZe/RR-Components?node-id=236-41321"
+      },
+      "status": "not-implemented"
+    },
+    {
+      "name": "Document Tab Bar: Item",
+      "figma": {
+        "nodeId": "38-784",
+        "nodeName": "document-tab-bar__item",
+        "url": "https://www.figma.com/design/5DyHMXUNVxbgH7ZjhQxPZe/RR-Components?node-id=38-784"
+      },
+      "status": "not-implemented"
+    },
+    {
+      "name": "Form Field",
+      "figma": {
+        "nodeId": "376-2395",
+        "nodeName": "form-field",
+        "url": "https://www.figma.com/design/5DyHMXUNVxbgH7ZjhQxPZe/RR-Components?node-id=376-2395"
+      },
+      "status": "not-implemented"
+    },
+    {
+      "name": "Icon Button (standalone)",
+      "figma": {
+        "nodeId": "31-75",
+        "nodeName": "icon-button",
+        "url": "https://www.figma.com/design/5DyHMXUNVxbgH7ZjhQxPZe/RR-Components?node-id=31-75"
+      },
+      "status": "not-implemented"
+    },
+    {
+      "name": "Icon Cell",
+      "figma": {
+        "nodeId": "236-41365",
+        "nodeName": "icon-cell",
+        "url": "https://www.figma.com/design/5DyHMXUNVxbgH7ZjhQxPZe/RR-Components?node-id=236-41365"
+      },
+      "status": "not-implemented"
+    },
+    {
+      "name": "Input Field Button",
+      "figma": {
+        "nodeId": "272-353",
+        "nodeName": "input-field-button",
+        "url": "https://www.figma.com/design/5DyHMXUNVxbgH7ZjhQxPZe/RR-Components?node-id=272-353"
+      },
+      "status": "not-implemented"
+    },
+    {
+      "name": "Menu Bar: Menu Item",
+      "figma": {
+        "nodeId": "87-6523",
+        "nodeName": "menu-bar__menu-item",
+        "url": "https://www.figma.com/design/5DyHMXUNVxbgH7ZjhQxPZe/RR-Components?node-id=87-6523"
+      },
+      "status": "not-implemented"
+    },
+    {
+      "name": "Menu Item",
+      "figma": {
+        "nodeId": "331-1456",
+        "nodeName": "menu-item",
+        "url": "https://www.figma.com/design/5DyHMXUNVxbgH7ZjhQxPZe/RR-Components?node-id=331-1456"
+      },
+      "status": "not-implemented"
+    },
+    {
+      "name": "Number Field",
+      "figma": {
+        "nodeId": "266-344",
+        "nodeName": "number-field",
+        "url": "https://www.figma.com/design/5DyHMXUNVxbgH7ZjhQxPZe/RR-Components?node-id=266-344"
+      },
+      "status": "not-implemented"
+    },
+    {
+      "name": "Radio Button (standalone)",
+      "figma": {
+        "nodeId": "219-38433",
+        "nodeName": "radio-button",
+        "url": "https://www.figma.com/design/5DyHMXUNVxbgH7ZjhQxPZe/RR-Components?node-id=219-38433"
+      },
+      "status": "not-implemented"
+    },
+    {
+      "name": "Radio Button Field",
+      "figma": {
+        "nodeId": "241-2382",
+        "nodeName": "radio-button-field",
+        "url": "https://www.figma.com/design/5DyHMXUNVxbgH7ZjhQxPZe/RR-Components?node-id=241-2382"
+      },
+      "status": "not-implemented"
+    },
+    {
+      "name": "Rich Text: Heading",
+      "figma": {
+        "nodeId": "980-145",
+        "nodeName": "rich-text__heading",
+        "url": "https://www.figma.com/design/5DyHMXUNVxbgH7ZjhQxPZe/RR-Components?node-id=980-145"
+      },
+      "status": "not-implemented"
+    },
+    {
+      "name": "Search Field",
+      "figma": {
+        "nodeId": "243-3235",
+        "nodeName": "search-field",
+        "url": "https://www.figma.com/design/5DyHMXUNVxbgH7ZjhQxPZe/RR-Components?node-id=243-3235"
+      },
+      "status": "not-implemented"
+    },
+    {
+      "name": "Segmented Control",
+      "figma": {
+        "nodeId": "336-2899",
+        "nodeName": "segmented-control",
+        "url": "https://www.figma.com/design/5DyHMXUNVxbgH7ZjhQxPZe/RR-Components?node-id=336-2899"
+      },
+      "status": "not-implemented"
+    },
+    {
+      "name": "Segmented Control: Item",
+      "figma": {
+        "nodeId": "262-3512",
+        "nodeName": "segmented-control__item",
+        "url": "https://www.figma.com/design/5DyHMXUNVxbgH7ZjhQxPZe/RR-Components?node-id=262-3512"
+      },
+      "status": "not-implemented"
+    },
+    {
+      "name": "Split View: Divider",
+      "figma": {
+        "nodeId": "39-927",
+        "nodeName": "split-view__divider",
+        "url": "https://www.figma.com/design/5DyHMXUNVxbgH7ZjhQxPZe/RR-Components?node-id=39-927"
+      },
+      "status": "not-implemented"
+    },
+    {
+      "name": "Stepper",
+      "figma": {
+        "nodeId": "236-39011",
+        "nodeName": "stepper",
+        "url": "https://www.figma.com/design/5DyHMXUNVxbgH7ZjhQxPZe/RR-Components?node-id=236-39011"
+      },
+      "status": "not-implemented"
+    },
+    {
+      "name": "Stepper Cell",
+      "figma": {
+        "nodeId": "236-41344",
+        "nodeName": "stepper-cell",
+        "url": "https://www.figma.com/design/5DyHMXUNVxbgH7ZjhQxPZe/RR-Components?node-id=236-41344"
+      },
+      "status": "not-implemented"
+    },
+    {
+      "name": "Switch (standalone)",
+      "figma": {
+        "nodeId": "232-38506",
+        "nodeName": "switch",
+        "url": "https://www.figma.com/design/5DyHMXUNVxbgH7ZjhQxPZe/RR-Components?node-id=232-38506"
+      },
+      "status": "not-implemented"
+    },
+    {
+      "name": "Switch Field",
+      "figma": {
+        "nodeId": "348-2635",
+        "nodeName": "switch-field",
+        "url": "https://www.figma.com/design/5DyHMXUNVxbgH7ZjhQxPZe/RR-Components?node-id=348-2635"
+      },
+      "status": "not-implemented"
+    },
+    {
+      "name": "Tab Bar: Item",
+      "figma": {
+        "nodeId": "987-1355",
+        "nodeName": "tab-bar__item",
+        "url": "https://www.figma.com/design/5DyHMXUNVxbgH7ZjhQxPZe/RR-Components?node-id=987-1355"
+      },
+      "status": "not-implemented"
+    },
+    {
+      "name": "Text Cell",
+      "figma": {
+        "nodeId": "236-41152",
+        "nodeName": "text-cell",
+        "url": "https://www.figma.com/design/5DyHMXUNVxbgH7ZjhQxPZe/RR-Components?node-id=236-41152"
+      },
+      "status": "not-implemented"
+    },
+    {
+      "name": "Token",
+      "figma": {
+        "nodeId": "354-3680",
+        "nodeName": "token",
+        "url": "https://www.figma.com/design/5DyHMXUNVxbgH7ZjhQxPZe/RR-Components?node-id=354-3680"
+      },
+      "status": "not-implemented"
+    },
+    {
+      "name": "Top Navigation Bar: Logo",
+      "figma": {
+        "nodeId": "22-28",
+        "nodeName": "top-navigation-bar__logo",
+        "url": "https://www.figma.com/design/5DyHMXUNVxbgH7ZjhQxPZe/RR-Components?node-id=22-28"
+      },
+      "status": "not-implemented"
     }
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@minbzk/storybook",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@minbzk/storybook",
-      "version": "0.1.11",
+      "version": "0.1.12",
       "license": "EUPL-1.2",
       "dependencies": {
         "@rijkshuisstijl-community/font": "^1.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@minbzk/storybook",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "description": "Design System voor RegelRecht - Nederlandse Overheid",
   "type": "module",
   "main": "dist/components/rr-components.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@minbzk/storybook",
-  "version": "0.1.12",
+  "version": "0.1.11",
   "description": "Design System voor RegelRecht - Nederlandse Overheid",
   "type": "module",
   "main": "dist/components/rr-components.js",

--- a/src/components/divider/rr-divider.stories.js
+++ b/src/components/divider/rr-divider.stories.js
@@ -1,0 +1,117 @@
+import { html } from 'lit';
+import './rr-divider.js';
+
+export default {
+  title: 'Components/Divider',
+  component: 'rr-divider',
+  tags: ['autodocs'],
+  parameters: {
+    design: {
+      type: 'figma',
+      url: 'https://www.figma.com/design/5DyHMXUNVxbgH7ZjhQxPZe/RR-Components?node-id=39-927',
+    },
+  },
+  argTypes: {
+    orientation: {
+      control: 'select',
+      options: ['horizontal', 'vertical'],
+      description: 'Divider orientation',
+    },
+  },
+};
+
+export const Default = {
+  args: {
+    orientation: 'horizontal',
+  },
+  render: (args) => html`
+    <div style="width: 200px;">
+      <rr-divider orientation=${args.orientation}></rr-divider>
+    </div>
+  `,
+};
+
+export const Horizontal = {
+  render: () => html`
+    <div style="width: 300px;">
+      <p style="margin: 0 0 16px 0;">Content above</p>
+      <rr-divider orientation="horizontal"></rr-divider>
+      <p style="margin: 16px 0 0 0;">Content below</p>
+    </div>
+  `,
+};
+
+export const Vertical = {
+  render: () => html`
+    <div style="display: flex; align-items: center; height: 100px;">
+      <span>Left</span>
+      <rr-divider
+        orientation="vertical"
+        style="height: 50px; margin: 0 16px;"
+      ></rr-divider>
+      <span>Right</span>
+    </div>
+  `,
+};
+
+export const AllOrientations = {
+  render: () => html`
+    <div style="display: flex; flex-direction: column; gap: 32px;">
+      <div>
+        <h4 style="margin: 0 0 8px 0;">Horizontal</h4>
+        <div style="width: 200px;">
+          <rr-divider orientation="horizontal"></rr-divider>
+        </div>
+      </div>
+      <div>
+        <h4 style="margin: 0 0 8px 0;">Vertical</h4>
+        <div style="display: flex; align-items: center; height: 60px;">
+          <span>A</span>
+          <rr-divider
+            orientation="vertical"
+            style="height: 40px; margin: 0 12px;"
+          ></rr-divider>
+          <span>B</span>
+        </div>
+      </div>
+    </div>
+  `,
+};
+
+// Figma Comparison
+const FIGMA_TOKEN = import.meta.env.STORYBOOK_FIGMA_TOKEN || '';
+const FIGMA_FILE_ID = '5DyHMXUNVxbgH7ZjhQxPZe';
+
+export const FigmaComparison = () => html`
+  <ftl-belt access-token="${FIGMA_TOKEN}" file-id="${FIGMA_FILE_ID}">
+    <div style="display: flex; flex-direction: column; gap: 1rem;">
+      <p style="font-size: 0.875rem; color: #64748b; margin: 0;">
+        Our dividers (Code) vs Figma design. Use Toggle/Overlay/Side-by-Side to
+        compare.
+      </p>
+      <ftl-holster node="39:927" style="display: inline-block;">
+        <!--
+          Figma split-vew__divider (39:927) component set:
+          - Layout: column, gap: 16px, padding: 16px
+          - Dimensions: 120x120px fixed
+          - Vertical variant: fills parent height (70px after gap)
+          - Horizontal variant: fills parent width (88px)
+        -->
+        <div
+          style="width: 120px; height: 120px; padding: 16px; box-sizing: border-box; display: flex; flex-direction: column; gap: 16px;"
+        >
+          <!-- Vertical divider: fills height of its row -->
+          <rr-divider orientation="vertical" style="height: 70px;"></rr-divider>
+          <!-- Horizontal divider: fills width -->
+          <rr-divider orientation="horizontal" style="width: 88px;"></rr-divider>
+        </div>
+      </ftl-holster>
+      <p style="font-size: 0.75rem; color: #64748b; margin-top: 0.5rem;">
+        Keyboard: T (toggle) | O (overlay) | S (side-by-side)
+      </p>
+    </div>
+  </ftl-belt>
+`;
+FigmaComparison.storyName = '🎨 Figma Comparison';
+FigmaComparison.tags = ['!autodocs', 'figma'];
+FigmaComparison.parameters = { controls: { disable: true } };

--- a/src/components/divider/rr-divider.ts
+++ b/src/components/divider/rr-divider.ts
@@ -29,15 +29,16 @@ export class RRDivider extends LitElement {
     }
 
     /* Horizontal orientation (default) */
+    /* Note: Figma shows 1px thickness, token incorrectly says 2px */
     :host([orientation='horizontal']) .divider,
     :host(:not([orientation])) .divider {
       width: 100%;
-      height: var(--semantics-divider-thickness, 2px);
+      height: 1px;
     }
 
     /* Vertical orientation */
     :host([orientation='vertical']) .divider {
-      width: var(--semantics-divider-thickness, 2px);
+      width: 1px;
       height: 100%;
     }
 

--- a/src/components/divider/rr-divider.ts
+++ b/src/components/divider/rr-divider.ts
@@ -29,16 +29,15 @@ export class RRDivider extends LitElement {
     }
 
     /* Horizontal orientation (default) */
-    /* Note: Figma shows 1px thickness, token incorrectly says 2px */
     :host([orientation='horizontal']) .divider,
     :host(:not([orientation])) .divider {
       width: 100%;
-      height: 1px;
+      height: var(--semantics-divider-thickness, 2px);
     }
 
     /* Vertical orientation */
     :host([orientation='vertical']) .divider {
-      width: 1px;
+      width: var(--semantics-divider-thickness, 2px);
       height: 100%;
     }
 

--- a/src/components/divider/rr-divider.ts
+++ b/src/components/divider/rr-divider.ts
@@ -1,0 +1,75 @@
+/**
+ * RegelRecht Divider Component (Lit + TypeScript)
+ *
+ * A visual separator for content sections.
+ *
+ * @element rr-divider
+ * @attr {string} orientation - Divider orientation: 'horizontal' | 'vertical'
+ */
+
+import { LitElement, html, css } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+
+type Orientation = 'horizontal' | 'vertical';
+
+@customElement('rr-divider')
+export class RRDivider extends LitElement {
+  static override styles = css`
+    :host {
+      display: block;
+      flex-shrink: 0;
+    }
+
+    :host([hidden]) {
+      display: none;
+    }
+
+    .divider {
+      background-color: var(--semantics-divider-color, #d8dee7);
+    }
+
+    /* Horizontal orientation (default) */
+    :host([orientation='horizontal']) .divider,
+    :host(:not([orientation])) .divider {
+      width: 100%;
+      height: var(--semantics-divider-thickness, 2px);
+    }
+
+    /* Vertical orientation */
+    :host([orientation='vertical']) .divider {
+      width: var(--semantics-divider-thickness, 2px);
+      height: 100%;
+    }
+
+    :host([orientation='vertical']) {
+      display: inline-block;
+      height: 100%;
+    }
+
+    /* Accessibility: High Contrast Mode */
+    @media (forced-colors: active) {
+      .divider {
+        background-color: CanvasText;
+      }
+    }
+  `;
+
+  @property({ type: String, reflect: true })
+  orientation: Orientation = 'horizontal';
+
+  override render() {
+    return html`
+      <div
+        class="divider"
+        role="separator"
+        aria-orientation=${this.orientation}
+      ></div>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'rr-divider': RRDivider;
+  }
+}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -26,6 +26,7 @@ export { RRUtilityMenuBar } from './top-navigation-bar/rr-utility-menu-bar.ts';
 
 // Layout utility components
 export { RRSpacer } from './spacer/rr-spacer.ts';
+export { RRSpacerCell } from './spacer-cell/rr-spacer-cell.ts';
 export { RRDivider } from './divider/rr-divider.ts';
 export { RRPageStickyAreaBackground } from './page-sticky-area-background/rr-page-sticky-area-background.ts';
 

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -24,6 +24,11 @@ export { RRMenuBar } from './menu-bar/rr-menu-bar.ts';
 export { RRMenuItem } from './menu-bar/rr-menu-item.ts';
 export { RRUtilityMenuBar } from './top-navigation-bar/rr-utility-menu-bar.ts';
 
+// Layout utility components
+export { RRSpacer } from './spacer/rr-spacer.ts';
+export { RRDivider } from './divider/rr-divider.ts';
+export { RRPageStickyAreaBackground } from './page-sticky-area-background/rr-page-sticky-area-background.ts';
+
 // Vanilla JS components
 export { RRBox } from './box/rr-box.js';
 export { RRTopNavigationBar } from './top-navigation-bar/rr-top-navigation-bar.ts';

--- a/src/components/page-sticky-area-background/rr-page-sticky-area-background.stories.js
+++ b/src/components/page-sticky-area-background/rr-page-sticky-area-background.stories.js
@@ -1,0 +1,216 @@
+import { html } from 'lit';
+import './rr-page-sticky-area-background.js';
+
+export default {
+  title: 'Components/Page Sticky Area Background',
+  component: 'rr-page-sticky-area-background',
+  tags: ['autodocs'],
+  parameters: {
+    design: {
+      type: 'figma',
+      url: 'https://www.figma.com/design/5DyHMXUNVxbgH7ZjhQxPZe/RR-Components?node-id=1171-6495',
+    },
+  },
+  argTypes: {
+    position: {
+      control: 'select',
+      options: ['top', 'bottom'],
+      description: 'Position of the sticky area',
+    },
+    tinted: {
+      control: 'boolean',
+      description: 'Use tinted (gray) background',
+    },
+  },
+};
+
+export const Default = {
+  args: {
+    position: 'top',
+    tinted: false,
+  },
+  render: (args) => html`
+    <div
+      style="width: 300px; height: 200px; background: linear-gradient(135deg, #ff6b6b, #4ecdc4); position: relative;"
+    >
+      <rr-page-sticky-area-background
+        position=${args.position}
+        ?tinted=${args.tinted}
+        style="position: absolute; ${args.position}: 0; left: 0; right: 0;"
+      ></rr-page-sticky-area-background>
+    </div>
+  `,
+};
+
+export const TopWhite = {
+  render: () => html`
+    <div
+      style="width: 300px; height: 200px; background: linear-gradient(135deg, #667eea, #764ba2); position: relative;"
+    >
+      <rr-page-sticky-area-background
+        position="top"
+        style="position: absolute; top: 0; left: 0; right: 0;"
+      ></rr-page-sticky-area-background>
+      <p
+        style="position: absolute; top: 20px; left: 20px; margin: 0; color: white; z-index: 1;"
+      >
+        Sticky Header Area
+      </p>
+    </div>
+  `,
+};
+
+export const BottomWhite = {
+  render: () => html`
+    <div
+      style="width: 300px; height: 200px; background: linear-gradient(135deg, #667eea, #764ba2); position: relative;"
+    >
+      <rr-page-sticky-area-background
+        position="bottom"
+        style="position: absolute; bottom: 0; left: 0; right: 0;"
+      ></rr-page-sticky-area-background>
+      <p
+        style="position: absolute; bottom: 20px; left: 20px; margin: 0; color: white; z-index: 1;"
+      >
+        Sticky Footer Area
+      </p>
+    </div>
+  `,
+};
+
+export const TopTinted = {
+  render: () => html`
+    <div
+      style="width: 300px; height: 200px; background: linear-gradient(135deg, #f093fb, #f5576c); position: relative;"
+    >
+      <rr-page-sticky-area-background
+        position="top"
+        tinted
+        style="position: absolute; top: 0; left: 0; right: 0;"
+      ></rr-page-sticky-area-background>
+    </div>
+  `,
+};
+
+export const BottomTinted = {
+  render: () => html`
+    <div
+      style="width: 300px; height: 200px; background: linear-gradient(135deg, #f093fb, #f5576c); position: relative;"
+    >
+      <rr-page-sticky-area-background
+        position="bottom"
+        tinted
+        style="position: absolute; bottom: 0; left: 0; right: 0;"
+      ></rr-page-sticky-area-background>
+    </div>
+  `,
+};
+
+export const AllVariants = {
+  render: () => html`
+    <div style="display: grid; grid-template-columns: repeat(2, 1fr); gap: 24px;">
+      <div>
+        <h4 style="margin: 0 0 8px 0;">Top - White</h4>
+        <div
+          style="width: 200px; height: 120px; background: linear-gradient(135deg, #667eea, #764ba2); position: relative;"
+        >
+          <rr-page-sticky-area-background
+            position="top"
+            style="position: absolute; top: 0; left: 0; right: 0;"
+          ></rr-page-sticky-area-background>
+        </div>
+      </div>
+      <div>
+        <h4 style="margin: 0 0 8px 0;">Top - Tinted</h4>
+        <div
+          style="width: 200px; height: 120px; background: linear-gradient(135deg, #667eea, #764ba2); position: relative;"
+        >
+          <rr-page-sticky-area-background
+            position="top"
+            tinted
+            style="position: absolute; top: 0; left: 0; right: 0;"
+          ></rr-page-sticky-area-background>
+        </div>
+      </div>
+      <div>
+        <h4 style="margin: 0 0 8px 0;">Bottom - White</h4>
+        <div
+          style="width: 200px; height: 120px; background: linear-gradient(135deg, #667eea, #764ba2); position: relative;"
+        >
+          <rr-page-sticky-area-background
+            position="bottom"
+            style="position: absolute; bottom: 0; left: 0; right: 0;"
+          ></rr-page-sticky-area-background>
+        </div>
+      </div>
+      <div>
+        <h4 style="margin: 0 0 8px 0;">Bottom - Tinted</h4>
+        <div
+          style="width: 200px; height: 120px; background: linear-gradient(135deg, #667eea, #764ba2); position: relative;"
+        >
+          <rr-page-sticky-area-background
+            position="bottom"
+            tinted
+            style="position: absolute; bottom: 0; left: 0; right: 0;"
+          ></rr-page-sticky-area-background>
+        </div>
+      </div>
+    </div>
+  `,
+};
+
+// Figma Comparison
+const FIGMA_TOKEN = import.meta.env.STORYBOOK_FIGMA_TOKEN || '';
+const FIGMA_FILE_ID = '5DyHMXUNVxbgH7ZjhQxPZe';
+
+export const FigmaComparison = () => html`
+  <ftl-belt access-token="${FIGMA_TOKEN}" file-id="${FIGMA_FILE_ID}">
+    <div style="display: flex; flex-direction: column; gap: 1rem;">
+      <p style="font-size: 0.875rem; color: #64748b; margin: 0;">
+        Our page sticky area backgrounds (Code) vs Figma design. Use
+        Toggle/Overlay/Side-by-Side to compare.
+      </p>
+      <ftl-holster node="1171:6495" style="display: inline-block;">
+        <!--
+          Figma page__sticky-area-background (1171:6495) component set:
+          - Layout: column, gap: 32px, padding: 16px
+          - Variants: position (top/bottom) x tinted (true/false)
+          - Each variant: 80px height, 414px content width
+          - Total: 446px wide (414 + 32 padding)
+        -->
+        <div
+          style="width: 446px; padding: 16px; box-sizing: border-box; display: flex; flex-direction: column; gap: 32px;"
+        >
+          <!-- Top, not tinted -->
+          <rr-page-sticky-area-background
+            position="top"
+            style="width: 414px;"
+          ></rr-page-sticky-area-background>
+          <!-- Top, tinted -->
+          <rr-page-sticky-area-background
+            position="top"
+            tinted
+            style="width: 414px;"
+          ></rr-page-sticky-area-background>
+          <!-- Bottom, not tinted -->
+          <rr-page-sticky-area-background
+            position="bottom"
+            style="width: 414px;"
+          ></rr-page-sticky-area-background>
+          <!-- Bottom, tinted -->
+          <rr-page-sticky-area-background
+            position="bottom"
+            tinted
+            style="width: 414px;"
+          ></rr-page-sticky-area-background>
+        </div>
+      </ftl-holster>
+      <p style="font-size: 0.75rem; color: #64748b; margin-top: 0.5rem;">
+        Keyboard: T (toggle) | O (overlay) | S (side-by-side)
+      </p>
+    </div>
+  </ftl-belt>
+`;
+FigmaComparison.storyName = '🎨 Figma Comparison';
+FigmaComparison.tags = ['!autodocs', 'figma'];
+FigmaComparison.parameters = { controls: { disable: true } };

--- a/src/components/page-sticky-area-background/rr-page-sticky-area-background.ts
+++ b/src/components/page-sticky-area-background/rr-page-sticky-area-background.ts
@@ -1,0 +1,179 @@
+/**
+ * RegelRecht Page Sticky Area Background Component (Lit + TypeScript)
+ *
+ * A gradient background for sticky headers/footers that fades content smoothly.
+ * The gradient extends beyond the component boundary to create a smooth fade effect.
+ *
+ * @element rr-page-sticky-area-background
+ * @attr {string} position - Position of the sticky area: 'top' | 'bottom'
+ * @attr {boolean} tinted - Whether to use tinted (gray) background instead of white
+ */
+
+import { LitElement, html, css } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+
+type Position = 'top' | 'bottom';
+
+@customElement('rr-page-sticky-area-background')
+export class RRPageStickyAreaBackground extends LitElement {
+  static override styles = css`
+    :host {
+      display: block;
+      position: relative;
+      width: 100%;
+      height: var(--components-page-sticky-area-height, 80px);
+      overflow: visible;
+    }
+
+    :host([hidden]) {
+      display: none;
+    }
+
+    .sticky-area {
+      display: flex;
+      flex-direction: column;
+      width: 100%;
+      height: 100%;
+      position: relative;
+    }
+
+    /* For top position: filled at top, spacer, then gradient extending down */
+    :host([position='top']) .sticky-area,
+    :host(:not([position])) .sticky-area {
+      flex-direction: column;
+    }
+
+    /* For bottom position: gradient extending up, spacer, then filled at bottom */
+    :host([position='bottom']) .sticky-area {
+      flex-direction: column-reverse;
+    }
+
+    .filled {
+      flex: 1;
+      min-height: 0;
+    }
+
+    .gradient-spacer {
+      height: 28px;
+      flex-shrink: 0;
+    }
+
+    .gradient {
+      position: absolute;
+      left: 0;
+      right: 0;
+      width: 100%;
+      height: 44px;
+      pointer-events: none;
+    }
+
+    /* Top position - gradient extends below component */
+    :host([position='top']) .gradient,
+    :host(:not([position])) .gradient {
+      bottom: -16px;
+    }
+
+    /* Bottom position - gradient extends above component */
+    :host([position='bottom']) .gradient {
+      top: -16px;
+    }
+
+    /* White background (default) - filled area */
+    :host(:not([tinted])) .filled,
+    :host([tinted='false']) .filled {
+      background-color: rgba(255, 255, 255, 0.9);
+    }
+
+    /* White gradient - top position (fades from solid to transparent going down) */
+    :host([position='top']:not([tinted])) .gradient,
+    :host([position='top'][tinted='false']) .gradient,
+    :host(:not([position]):not([tinted])) .gradient,
+    :host(:not([position])[tinted='false']) .gradient {
+      background: linear-gradient(
+        180deg,
+        rgba(255, 255, 255, 0.9) 0%,
+        rgba(255, 255, 255, 0.5) 70%,
+        rgba(255, 255, 255, 0) 100%
+      );
+    }
+
+    /* White gradient - bottom position (fades from transparent to solid going down) */
+    :host([position='bottom']:not([tinted])) .gradient,
+    :host([position='bottom'][tinted='false']) .gradient {
+      background: linear-gradient(
+        180deg,
+        rgba(255, 255, 255, 0) 0%,
+        rgba(255, 255, 255, 0.5) 30%,
+        rgba(255, 255, 255, 0.9) 100%
+      );
+    }
+
+    /* Tinted background (gray) - filled area */
+    :host([tinted]) .filled,
+    :host([tinted='true']) .filled {
+      background-color: rgba(245, 246, 249, 0.9);
+    }
+
+    /* Tinted gradient - top position */
+    :host([position='top'][tinted]) .gradient,
+    :host([position='top'][tinted='true']) .gradient,
+    :host(:not([position])[tinted]) .gradient,
+    :host(:not([position])[tinted='true']) .gradient {
+      background: linear-gradient(
+        180deg,
+        rgba(245, 246, 249, 0.9) 0%,
+        rgba(245, 246, 249, 0.5) 70%,
+        rgba(245, 246, 249, 0) 100%
+      );
+    }
+
+    /* Tinted gradient - bottom position */
+    :host([position='bottom'][tinted]) .gradient,
+    :host([position='bottom'][tinted='true']) .gradient {
+      background: linear-gradient(
+        180deg,
+        rgba(245, 246, 249, 0) 0%,
+        rgba(245, 246, 249, 0.5) 30%,
+        rgba(245, 246, 249, 0.9) 100%
+      );
+    }
+
+    /* Accessibility: High Contrast Mode */
+    @media (forced-colors: active) {
+      .filled {
+        background-color: Canvas;
+      }
+
+      :host([position='top']) .gradient,
+      :host(:not([position])) .gradient {
+        background: linear-gradient(180deg, Canvas 0%, transparent 100%);
+      }
+
+      :host([position='bottom']) .gradient {
+        background: linear-gradient(180deg, transparent 0%, Canvas 100%);
+      }
+    }
+  `;
+
+  @property({ type: String, reflect: true })
+  position: Position = 'top';
+
+  @property({ type: Boolean, reflect: true })
+  tinted = false;
+
+  override render() {
+    return html`
+      <div class="sticky-area">
+        <div class="filled"></div>
+        <div class="gradient-spacer"></div>
+        <div class="gradient"></div>
+      </div>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'rr-page-sticky-area-background': RRPageStickyAreaBackground;
+  }
+}

--- a/src/components/spacer-cell/rr-spacer-cell.stories.js
+++ b/src/components/spacer-cell/rr-spacer-cell.stories.js
@@ -1,0 +1,124 @@
+import { html } from 'lit';
+import './rr-spacer-cell.ts';
+
+export default {
+  title: 'Components/Spacer Cell',
+  component: 'rr-spacer-cell',
+  tags: ['autodocs'],
+  parameters: {
+    design: {
+      type: 'figma',
+      url: 'https://www.figma.com/design/5DyHMXUNVxbgH7ZjhQxPZe/RR-Components?node-id=236-41413',
+    },
+  },
+  argTypes: {
+    size: {
+      control: 'select',
+      options: [
+        '2',
+        '4',
+        '6',
+        '8',
+        '10',
+        '12',
+        '16',
+        '20',
+        '24',
+        '28',
+        '32',
+        '40',
+        '44',
+        '48',
+        '56',
+        '64',
+        '80',
+        '96',
+        'm',
+        'flexible',
+      ],
+      description: 'Spacer size',
+    },
+    container: {
+      control: 'select',
+      options: ['s', 'm', 'l', 'all'],
+      description: 'Container size for responsive sizing',
+    },
+  },
+};
+
+export const Default = {
+  args: {
+    size: '16',
+    container: 'all',
+  },
+  render: (args) => html`
+    <div
+      style="display: flex; align-items: center; background: #f0f0f0; padding: 8px;"
+    >
+      <span>Before</span>
+      <rr-spacer-cell
+        size=${args.size}
+        container=${args.container}
+        style="background: rgba(255, 36, 189, 0.2); outline: 1px dashed #ff24bd;"
+      ></rr-spacer-cell>
+      <span>After</span>
+    </div>
+  `,
+};
+
+export const AllSizes = {
+  render: () => html`
+    <div
+      style="display: flex; flex-direction: column; gap: 8px; align-items: flex-start;"
+    >
+      ${['8', '12', '16', '24', '32', '48'].map(
+        (size) => html`
+          <div style="display: flex; align-items: center; gap: 8px;">
+            <span style="width: 40px; font-size: 12px;">${size}px</span>
+            <div
+              style="display: flex; align-items: center; background: #f0f0f0;"
+            >
+              <span>|</span>
+              <rr-spacer-cell
+                size=${size}
+                style="background: rgba(255, 36, 189, 0.2);"
+              ></rr-spacer-cell>
+              <span>|</span>
+            </div>
+          </div>
+        `
+      )}
+    </div>
+  `,
+};
+
+// Figma Comparison
+const FIGMA_TOKEN = import.meta.env.STORYBOOK_FIGMA_TOKEN || '';
+const FIGMA_FILE_ID = '5DyHMXUNVxbgH7ZjhQxPZe';
+
+export const FigmaComparison = () => html`
+  <ftl-belt access-token="${FIGMA_TOKEN}" file-id="${FIGMA_FILE_ID}">
+    <div style="display: flex; flex-direction: column; gap: 1rem;">
+      <p style="font-size: 0.875rem; color: #64748b; margin: 0;">
+        Spacer Cell (Code) vs Figma design. Use Toggle/Overlay/Side-by-Side to
+        compare.
+      </p>
+      <ftl-holster node="236-41413" style="display: inline-block;">
+        <!--
+          Figma spacer-cell (236:41413) component:
+          - Layout: column, justify: center, align: center
+          - Sizing: hug width, hug height
+          - Contains: spacer with size=16, container=all
+          - Dimensions: 16x16px
+        -->
+        <rr-spacer-cell size="16" container="all"></rr-spacer-cell>
+      </ftl-holster>
+      <p style="font-size: 0.75rem; color: #64748b; margin-top: 0.5rem;">
+        Keyboard: T (toggle) | O (overlay) | S (side-by-side)
+      </p>
+    </div>
+  </ftl-belt>
+`;
+FigmaComparison.storyName = 'Figma Comparison';
+FigmaComparison.tags = ['!autodocs', 'figma'];
+FigmaComparison.parameters = { controls: { disable: true } };

--- a/src/components/spacer-cell/rr-spacer-cell.ts
+++ b/src/components/spacer-cell/rr-spacer-cell.ts
@@ -1,0 +1,73 @@
+/**
+ * RegelRecht Spacer Cell Component (Lit + TypeScript)
+ *
+ * A wrapper cell component that contains a spacer, used within list items
+ * to provide consistent spacing in start/end areas.
+ *
+ * @element rr-spacer-cell
+ * @attr {string} size - Spacer size passed through to inner rr-spacer
+ * @attr {string} container - Container size passed through to inner rr-spacer
+ */
+
+import { LitElement, html, css } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+import '../spacer/rr-spacer.ts';
+
+type SpacerSize =
+  | '2'
+  | '4'
+  | '6'
+  | '8'
+  | '10'
+  | '12'
+  | '16'
+  | '20'
+  | '24'
+  | '28'
+  | '32'
+  | '40'
+  | '44'
+  | '48'
+  | '56'
+  | '64'
+  | '80'
+  | '96'
+  | 'm'
+  | 'flexible';
+type ContainerSize = 's' | 'm' | 'l' | 'all';
+
+@customElement('rr-spacer-cell')
+export class RRSpacerCell extends LitElement {
+  static override styles = css`
+    :host {
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      align-items: center;
+      box-sizing: border-box;
+    }
+
+    :host([hidden]) {
+      display: none;
+    }
+  `;
+
+  @property({ type: String, reflect: true })
+  size: SpacerSize = '16';
+
+  @property({ type: String, reflect: true })
+  container: ContainerSize = 'all';
+
+  override render() {
+    return html`<rr-spacer
+      size=${this.size}
+      container=${this.container}
+    ></rr-spacer>`;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'rr-spacer-cell': RRSpacerCell;
+  }
+}

--- a/src/components/spacer/rr-spacer.stories.js
+++ b/src/components/spacer/rr-spacer.stories.js
@@ -1,0 +1,356 @@
+import { html } from 'lit';
+import './rr-spacer.js';
+
+/**
+ * De Spacer component is een utility component voor het creëren van ruimte
+ * tussen elementen. Ondersteunt vaste sizes, flexibele ruimte, en container-responsive sizes.
+ *
+ * ## Figma Design
+ * [Open in Figma](https://www.figma.com/design/5DyHMXUNVxbgH7ZjhQxPZe/RR-Components?node-id=48-2234)
+ *
+ * ## Gebruik
+ * ```html
+ * <!-- Vaste spacing -->
+ * <rr-spacer size="32"></rr-spacer>
+ *
+ * <!-- Flexibele spacing -->
+ * <rr-spacer size="flexible"></rr-spacer>
+ *
+ * <!-- Container-responsive -->
+ * <rr-spacer size="m" container="l"></rr-spacer>
+ * ```
+ */
+export default {
+  title: 'Components/Spacer',
+  component: 'rr-spacer',
+  tags: ['autodocs'],
+  parameters: {
+    design: {
+      type: 'figma',
+      url: 'https://www.figma.com/design/5DyHMXUNVxbgH7ZjhQxPZe/RR-Components?node-id=48-2234',
+    },
+    componentSource: {
+      file: 'src/components/spacer/rr-spacer.ts',
+      repository: 'https://github.com/regelrecht/design-system',
+    },
+    status: {
+      type: 'stable',
+    },
+  },
+  argTypes: {
+    size: {
+      control: 'select',
+      options: [
+        '2',
+        '4',
+        '6',
+        '8',
+        '10',
+        '12',
+        '16',
+        '20',
+        '24',
+        '28',
+        '32',
+        '40',
+        '44',
+        '48',
+        '56',
+        '64',
+        '80',
+        '96',
+        'm',
+        'flexible',
+      ],
+      description: 'Spacer size',
+      table: {
+        defaultValue: { summary: '8' },
+      },
+    },
+    container: {
+      control: 'select',
+      options: ['s', 'm', 'l', 'all'],
+      description: 'Container size for responsive "m" size',
+      table: {
+        defaultValue: { summary: 'all' },
+      },
+    },
+    direction: {
+      control: 'select',
+      options: ['horizontal', 'vertical', 'both'],
+      description: 'Direction of spacing',
+      table: {
+        defaultValue: { summary: 'both' },
+      },
+    },
+  },
+  args: {
+    size: '8',
+    container: 'all',
+    direction: 'both',
+  },
+};
+
+// Helper to visualize spacer
+const SpacerDemo = ({ size, container, direction }) => html`
+  <div
+    style="display: flex; align-items: center; gap: 8px; padding: 16px; background: #f8fafc; border-radius: 8px;"
+  >
+    <div
+      style="padding: 8px 16px; background: #e2e8f0; border-radius: 4px; font-family: system-ui;"
+    >
+      Before
+    </div>
+    <rr-spacer
+      size=${size}
+      container=${container}
+      direction=${direction}
+      style="background: #3b82f6; opacity: 0.5;"
+    ></rr-spacer>
+    <div
+      style="padding: 8px 16px; background: #e2e8f0; border-radius: 4px; font-family: system-ui;"
+    >
+      After
+    </div>
+  </div>
+`;
+
+// Primary story
+export const Default = SpacerDemo.bind({});
+Default.args = {
+  size: '16',
+};
+
+// Fixed sizes
+export const FixedSizes = () => html`
+  <div style="display: flex; flex-direction: column; gap: 16px;">
+    <h3 style="margin: 0; font-family: system-ui;">Fixed Sizes (NxN squares)</h3>
+    <div style="display: flex; gap: 8px; align-items: flex-end; flex-wrap: wrap;">
+      ${['8', '16', '24', '32', '48', '64', '96'].map(
+        (size) => html`
+          <div style="display: flex; flex-direction: column; align-items: center; gap: 4px;">
+            <rr-spacer
+              size=${size}
+              style="background: #3b82f6; opacity: 0.7; border-radius: 2px;"
+            ></rr-spacer>
+            <span style="font-size: 12px; color: #64748b; font-family: system-ui;">${size}px</span>
+          </div>
+        `
+      )}
+    </div>
+  </div>
+`;
+FixedSizes.parameters = {
+  controls: { disable: true },
+};
+
+// Flexible size
+export const Flexible = () => html`
+  <div style="display: flex; flex-direction: column; gap: 16px;">
+    <h3 style="margin: 0; font-family: system-ui;">Flexible Spacing</h3>
+    <p style="margin: 0; font-size: 14px; color: #64748b; font-family: system-ui;">
+      The flexible spacer fills available space, useful for layouts like navigation bars.
+    </p>
+    <div
+      style="display: flex; align-items: center; padding: 16px; background: #f8fafc; border-radius: 8px; width: 100%; box-sizing: border-box;"
+    >
+      <div style="padding: 8px 16px; background: #154273; color: white; border-radius: 4px; font-family: system-ui;">
+        Logo
+      </div>
+      <rr-spacer size="flexible" style="background: #3b82f6; opacity: 0.2; min-height: 8px;"></rr-spacer>
+      <div style="padding: 8px 16px; background: #e2e8f0; border-radius: 4px; font-family: system-ui;">
+        Menu
+      </div>
+    </div>
+  </div>
+`;
+Flexible.parameters = {
+  controls: { disable: true },
+};
+
+// Container-responsive 'm' size
+export const ContainerResponsive = () => html`
+  <div style="display: flex; flex-direction: column; gap: 16px;">
+    <h3 style="margin: 0; font-family: system-ui;">Container-Responsive 'm' Size</h3>
+    <p style="margin: 0; font-size: 14px; color: #64748b; font-family: system-ui;">
+      The 'm' size changes based on the container size attribute.
+    </p>
+    <div style="display: flex; flex-direction: column; gap: 12px;">
+      <div style="display: flex; align-items: center; gap: 8px;">
+        <code style="font-family: monospace; background: #f1f5f9; padding: 2px 6px; border-radius: 4px;">container="s"</code>
+        <span style="color: #64748b; font-family: system-ui;">→ 16x16px</span>
+        <rr-spacer size="m" container="s" style="background: #3b82f6; opacity: 0.7; border-radius: 2px;"></rr-spacer>
+      </div>
+      <div style="display: flex; align-items: center; gap: 8px;">
+        <code style="font-family: monospace; background: #f1f5f9; padding: 2px 6px; border-radius: 4px;">container="m"</code>
+        <span style="color: #64748b; font-family: system-ui;">→ 24x24px</span>
+        <rr-spacer size="m" container="m" style="background: #3b82f6; opacity: 0.7; border-radius: 2px;"></rr-spacer>
+      </div>
+      <div style="display: flex; align-items: center; gap: 8px;">
+        <code style="font-family: monospace; background: #f1f5f9; padding: 2px 6px; border-radius: 4px;">container="l"</code>
+        <span style="color: #64748b; font-family: system-ui;">→ 24x24px</span>
+        <rr-spacer size="m" container="l" style="background: #3b82f6; opacity: 0.7; border-radius: 2px;"></rr-spacer>
+      </div>
+    </div>
+  </div>
+`;
+ContainerResponsive.parameters = {
+  controls: { disable: true },
+};
+
+// Direction
+export const Direction = () => html`
+  <div style="display: flex; flex-direction: column; gap: 24px;">
+    <h3 style="margin: 0; font-family: system-ui;">Direction</h3>
+
+    <div>
+      <h4 style="margin: 0 0 8px 0; font-family: system-ui; font-size: 14px;">
+        direction="both" (default) - NxN square
+      </h4>
+      <div
+        style="display: inline-flex; align-items: center; padding: 8px; background: #f8fafc; border-radius: 4px;"
+      >
+        <div style="padding: 8px; background: #e2e8f0; border-radius: 4px;">A</div>
+        <rr-spacer size="32" style="background: #3b82f6; opacity: 0.5;"></rr-spacer>
+        <div style="padding: 8px; background: #e2e8f0; border-radius: 4px;">B</div>
+      </div>
+    </div>
+
+    <div>
+      <h4 style="margin: 0 0 8px 0; font-family: system-ui; font-size: 14px;">
+        direction="horizontal" - only width
+      </h4>
+      <div
+        style="display: inline-flex; align-items: center; padding: 8px; background: #f8fafc; border-radius: 4px;"
+      >
+        <div style="padding: 8px; background: #e2e8f0; border-radius: 4px;">A</div>
+        <rr-spacer
+          size="32"
+          direction="horizontal"
+          style="background: #3b82f6; opacity: 0.5;"
+        ></rr-spacer>
+        <div style="padding: 8px; background: #e2e8f0; border-radius: 4px;">B</div>
+      </div>
+    </div>
+
+    <div>
+      <h4 style="margin: 0 0 8px 0; font-family: system-ui; font-size: 14px;">
+        direction="vertical" - only height
+      </h4>
+      <div
+        style="display: inline-flex; flex-direction: column; align-items: center; padding: 8px; background: #f8fafc; border-radius: 4px;"
+      >
+        <div style="padding: 8px; background: #e2e8f0; border-radius: 4px;">A</div>
+        <rr-spacer
+          size="32"
+          direction="vertical"
+          style="background: #3b82f6; opacity: 0.5;"
+        ></rr-spacer>
+        <div style="padding: 8px; background: #e2e8f0; border-radius: 4px;">B</div>
+      </div>
+    </div>
+  </div>
+`;
+Direction.parameters = {
+  controls: { disable: true },
+};
+
+// All fixed sizes overview
+export const AllSizes = () => html`
+  <div style="display: flex; flex-direction: column; gap: 8px;">
+    <h3 style="margin: 0; font-family: system-ui;">All Fixed Sizes</h3>
+    <div style="display: flex; gap: 4px; align-items: flex-end; flex-wrap: wrap;">
+      ${['2', '4', '6', '8', '10', '12', '16', '20', '24', '28', '32', '40', '44', '48', '56', '64', '80', '96'].map(
+        (size) => html`
+          <div style="display: flex; flex-direction: column; align-items: center; gap: 2px;">
+            <rr-spacer
+              size=${size}
+              style="background: #3b82f6; opacity: 0.7; border-radius: 2px;"
+            ></rr-spacer>
+            <span style="font-size: 10px; color: #64748b; font-family: system-ui;">${size}</span>
+          </div>
+        `
+      )}
+    </div>
+  </div>
+`;
+AllSizes.parameters = {
+  controls: { disable: true },
+};
+
+// Real-world example: Navigation bar with spacers
+export const NavigationExample = () => html`
+  <div style="display: flex; flex-direction: column; gap: 16px;">
+    <h3 style="margin: 0; font-family: system-ui;">Real-World Example: Navigation Bar</h3>
+    <div
+      style="display: flex; align-items: center; padding: 8px 16px; background: #1f252d; border-radius: 8px; color: white; font-family: system-ui;"
+    >
+      <div style="font-weight: 600;">RegelRecht</div>
+      <rr-spacer size="32"></rr-spacer>
+      <nav style="display: flex; gap: 24px;">
+        <a href="#" style="color: white; text-decoration: none;">Home</a>
+        <a href="#" style="color: white; text-decoration: none;">Products</a>
+        <a href="#" style="color: white; text-decoration: none;">About</a>
+      </nav>
+      <rr-spacer size="flexible"></rr-spacer>
+      <button
+        style="padding: 8px 16px; background: #154273; color: white; border: none; border-radius: 4px; cursor: pointer;"
+      >
+        Login
+      </button>
+    </div>
+  </div>
+`;
+NavigationExample.parameters = {
+  controls: { disable: true },
+};
+
+// Figma Comparison - visual comparison with Figma design
+const FIGMA_TOKEN = import.meta.env.STORYBOOK_FIGMA_TOKEN || '';
+const FIGMA_FILE_ID = '5DyHMXUNVxbgH7ZjhQxPZe';
+
+export const FigmaComparison = () => html`
+  <ftl-belt access-token="${FIGMA_TOKEN}" file-id="${FIGMA_FILE_ID}">
+    <div style="display: flex; flex-direction: column; gap: 1rem;">
+      <p style="font-size: 0.875rem; color: #64748b; margin: 0;">
+        Our spacers (Code) vs Figma design. Use Toggle/Overlay/Side-by-Side to compare.
+      </p>
+      <ftl-holster node="48:2234" style="display: inline-block;">
+        <!--
+          Figma spacer (48:2234) component set:
+          - Variants: flexible (fill width, 8px height), fixed sizes (NxN)
+          - Container-responsive 'm' size: s=16px, m/l=24px
+        -->
+        <div
+          style="background: #ffffff; padding: 16px; box-sizing: border-box; display: flex; flex-direction: column; gap: 16px; align-items: flex-start;"
+        >
+          <!-- Flexible spacer (width: fill, height: 8px) -->
+          <div style="width: 200px; display: flex;">
+            <rr-spacer size="flexible" style="background: #e2e8f0; min-height: 8px;"></rr-spacer>
+          </div>
+          <!-- Fixed sizes -->
+          <div style="display: flex; gap: 8px; align-items: flex-start;">
+            <rr-spacer size="8" style="background: #e2e8f0;"></rr-spacer>
+            <rr-spacer size="16" style="background: #e2e8f0;"></rr-spacer>
+            <rr-spacer size="24" style="background: #e2e8f0;"></rr-spacer>
+            <rr-spacer size="32" style="background: #e2e8f0;"></rr-spacer>
+          </div>
+          <!-- Container-responsive 'm' sizes -->
+          <div style="display: flex; gap: 8px; align-items: flex-start;">
+            <rr-spacer size="m" container="s" style="background: #e2e8f0;"></rr-spacer>
+            <rr-spacer size="m" container="m" style="background: #e2e8f0;"></rr-spacer>
+            <rr-spacer size="m" container="l" style="background: #e2e8f0;"></rr-spacer>
+          </div>
+        </div>
+      </ftl-holster>
+      <p style="font-size: 0.75rem; color: #64748b; margin-top: 0.5rem;">
+        Keyboard: T (toggle) | O (overlay) | S (side-by-side)
+      </p>
+    </div>
+  </ftl-belt>
+`;
+FigmaComparison.storyName = 'Figma Comparison';
+FigmaComparison.tags = ['!autodocs', 'figma'];
+FigmaComparison.parameters = {
+  controls: { disable: true },
+};

--- a/src/components/spacer/rr-spacer.stories.js
+++ b/src/components/spacer/rr-spacer.stories.js
@@ -318,29 +318,50 @@ export const FigmaComparison = () => html`
       <ftl-holster node="48:2234" style="display: inline-block;">
         <!--
           Figma spacer (48:2234) component set:
-          - Variants: flexible (fill width, 8px height), fixed sizes (NxN)
-          - Container-responsive 'm' size: s=16px, m/l=24px
+          - Layout: column, gap: 16px, padding: 16px
+          - 19 variants in order: m(s), m(m), m(l), flexible, 2, 4, 6, 8, 12, 16, 20, 24, 32, 40, 44, 48, 64, 80, 96
         -->
         <div
           style="background: #ffffff; padding: 16px; box-sizing: border-box; display: flex; flex-direction: column; gap: 16px; align-items: flex-start;"
         >
-          <!-- Flexible spacer (width: fill, height: 8px) -->
-          <div style="width: 200px; display: flex;">
-            <rr-spacer size="flexible" style="background: #e2e8f0; min-height: 8px;"></rr-spacer>
-          </div>
-          <!-- Fixed sizes -->
-          <div style="display: flex; gap: 8px; align-items: flex-start;">
-            <rr-spacer size="8" style="background: #e2e8f0;"></rr-spacer>
-            <rr-spacer size="16" style="background: #e2e8f0;"></rr-spacer>
-            <rr-spacer size="24" style="background: #e2e8f0;"></rr-spacer>
-            <rr-spacer size="32" style="background: #e2e8f0;"></rr-spacer>
-          </div>
-          <!-- Container-responsive 'm' sizes -->
-          <div style="display: flex; gap: 8px; align-items: flex-start;">
-            <rr-spacer size="m" container="s" style="background: #e2e8f0;"></rr-spacer>
-            <rr-spacer size="m" container="m" style="background: #e2e8f0;"></rr-spacer>
-            <rr-spacer size="m" container="l" style="background: #e2e8f0;"></rr-spacer>
-          </div>
+          <!-- container=s, size=m (16x16) -->
+          <rr-spacer size="m" container="s" style="background: #e2e8f0;"></rr-spacer>
+          <!-- container=m, size=m (24x24) -->
+          <rr-spacer size="m" container="m" style="background: #e2e8f0;"></rr-spacer>
+          <!-- container=l, size=m (24x24) -->
+          <rr-spacer size="m" container="l" style="background: #e2e8f0;"></rr-spacer>
+          <!-- container=all, size=flexible (fill x 8px) -->
+          <rr-spacer size="flexible" style="background: #e2e8f0; min-height: 8px; width: 96px;"></rr-spacer>
+          <!-- container=all, size=2 -->
+          <rr-spacer size="2" style="background: #e2e8f0;"></rr-spacer>
+          <!-- container=all, size=4 -->
+          <rr-spacer size="4" style="background: #e2e8f0;"></rr-spacer>
+          <!-- container=all, size=6 -->
+          <rr-spacer size="6" style="background: #e2e8f0;"></rr-spacer>
+          <!-- container=all, size=8 -->
+          <rr-spacer size="8" style="background: #e2e8f0;"></rr-spacer>
+          <!-- container=all, size=12 -->
+          <rr-spacer size="12" style="background: #e2e8f0;"></rr-spacer>
+          <!-- container=all, size=16 -->
+          <rr-spacer size="16" style="background: #e2e8f0;"></rr-spacer>
+          <!-- container=all, size=20 -->
+          <rr-spacer size="20" style="background: #e2e8f0;"></rr-spacer>
+          <!-- container=all, size=24 -->
+          <rr-spacer size="24" style="background: #e2e8f0;"></rr-spacer>
+          <!-- container=all, size=32 -->
+          <rr-spacer size="32" style="background: #e2e8f0;"></rr-spacer>
+          <!-- container=all, size=40 -->
+          <rr-spacer size="40" style="background: #e2e8f0;"></rr-spacer>
+          <!-- container=all, size=44 -->
+          <rr-spacer size="44" style="background: #e2e8f0;"></rr-spacer>
+          <!-- container=all, size=48 -->
+          <rr-spacer size="48" style="background: #e2e8f0;"></rr-spacer>
+          <!-- container=all, size=64 -->
+          <rr-spacer size="64" style="background: #e2e8f0;"></rr-spacer>
+          <!-- container=all, size=80 -->
+          <rr-spacer size="80" style="background: #e2e8f0;"></rr-spacer>
+          <!-- container=all, size=96 -->
+          <rr-spacer size="96" style="background: #e2e8f0;"></rr-spacer>
         </div>
       </ftl-holster>
       <p style="font-size: 0.75rem; color: #64748b; margin-top: 0.5rem;">

--- a/src/components/spacer/rr-spacer.ts
+++ b/src/components/spacer/rr-spacer.ts
@@ -1,0 +1,196 @@
+/**
+ * RegelRecht Spacer Component (Lit + TypeScript)
+ *
+ * @element rr-spacer
+ * @attr {string} size - Spacer size: fixed values (2-96), 'm' (responsive), or 'flexible'
+ * @attr {string} container - Container size for responsive 'm' size: 's' | 'm' | 'l' | 'all'
+ * @attr {string} direction - Direction: 'horizontal' | 'vertical' | 'both'
+ */
+
+import { LitElement, css } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+
+type FixedSize =
+  | '2'
+  | '4'
+  | '6'
+  | '8'
+  | '10'
+  | '12'
+  | '16'
+  | '20'
+  | '24'
+  | '28'
+  | '32'
+  | '40'
+  | '44'
+  | '48'
+  | '56'
+  | '64'
+  | '80'
+  | '96';
+type SpacerSize = FixedSize | 'm' | 'flexible';
+type ContainerSize = 's' | 'm' | 'l' | 'all';
+type Direction = 'horizontal' | 'vertical' | 'both';
+
+@customElement('rr-spacer')
+export class RRSpacer extends LitElement {
+  static override styles = css`
+    :host {
+      display: block;
+      flex-shrink: 0;
+    }
+
+    :host([hidden]) {
+      display: none;
+    }
+
+    /* Flexible size - fills available space */
+    :host([size='flexible']) {
+      flex: 1;
+      min-width: 0;
+      min-height: 0;
+    }
+
+    /* Fixed sizes using primitives tokens */
+    :host([size='2']) {
+      width: var(--primitives-space-2, 2px);
+      height: var(--primitives-space-2, 2px);
+    }
+
+    :host([size='4']) {
+      width: var(--primitives-space-4, 4px);
+      height: var(--primitives-space-4, 4px);
+    }
+
+    :host([size='6']) {
+      width: var(--primitives-space-6, 6px);
+      height: var(--primitives-space-6, 6px);
+    }
+
+    :host([size='8']),
+    :host(:not([size])) {
+      width: var(--primitives-space-8, 8px);
+      height: var(--primitives-space-8, 8px);
+    }
+
+    :host([size='10']) {
+      width: var(--primitives-space-10, 10px);
+      height: var(--primitives-space-10, 10px);
+    }
+
+    :host([size='12']) {
+      width: var(--primitives-space-12, 12px);
+      height: var(--primitives-space-12, 12px);
+    }
+
+    :host([size='16']) {
+      width: var(--primitives-space-16, 16px);
+      height: var(--primitives-space-16, 16px);
+    }
+
+    :host([size='20']) {
+      width: var(--primitives-space-20, 20px);
+      height: var(--primitives-space-20, 20px);
+    }
+
+    :host([size='24']) {
+      width: var(--primitives-space-24, 24px);
+      height: var(--primitives-space-24, 24px);
+    }
+
+    :host([size='28']) {
+      width: var(--primitives-space-28, 28px);
+      height: var(--primitives-space-28, 28px);
+    }
+
+    :host([size='32']) {
+      width: var(--primitives-space-32, 32px);
+      height: var(--primitives-space-32, 32px);
+    }
+
+    :host([size='40']) {
+      width: var(--primitives-space-40, 40px);
+      height: var(--primitives-space-40, 40px);
+    }
+
+    :host([size='44']) {
+      width: var(--primitives-space-44, 44px);
+      height: var(--primitives-space-44, 44px);
+    }
+
+    :host([size='48']) {
+      width: var(--primitives-space-48, 48px);
+      height: var(--primitives-space-48, 48px);
+    }
+
+    :host([size='56']) {
+      width: var(--primitives-space-56, 56px);
+      height: var(--primitives-space-56, 56px);
+    }
+
+    :host([size='64']) {
+      width: var(--primitives-space-64, 64px);
+      height: var(--primitives-space-64, 64px);
+    }
+
+    :host([size='80']) {
+      width: var(--primitives-space-80, 80px);
+      height: var(--primitives-space-80, 80px);
+    }
+
+    :host([size='96']) {
+      width: var(--primitives-space-96, 96px);
+      height: var(--primitives-space-96, 96px);
+    }
+
+    /* Container-responsive 'm' size */
+    :host([size='m']),
+    :host([size='m'][container='s']),
+    :host([size='m'][container='all']) {
+      width: var(--primitives-space-16, 16px);
+      height: var(--primitives-space-16, 16px);
+    }
+
+    :host([size='m'][container='m']),
+    :host([size='m'][container='l']) {
+      width: var(--primitives-space-24, 24px);
+      height: var(--primitives-space-24, 24px);
+    }
+
+    /* Direction modifiers */
+    :host([direction='horizontal']) {
+      height: auto;
+    }
+
+    :host([direction='vertical']) {
+      width: auto;
+    }
+
+    /* Flexible with direction */
+    :host([size='flexible'][direction='horizontal']) {
+      height: auto;
+      min-height: auto;
+    }
+
+    :host([size='flexible'][direction='vertical']) {
+      width: auto;
+      min-width: auto;
+    }
+  `;
+
+  @property({ type: String, reflect: true })
+  size: SpacerSize = '8';
+
+  @property({ type: String, reflect: true })
+  container: ContainerSize = 'all';
+
+  @property({ type: String, reflect: true })
+  direction: Direction = 'both';
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'rr-spacer': RRSpacer;
+  }
+}

--- a/src/components/top-navigation-bar/rr-top-navigation-bar.ts
+++ b/src/components/top-navigation-bar/rr-top-navigation-bar.ts
@@ -65,7 +65,6 @@ import '../menu-bar/rr-menu-bar.ts';
 import '../menu-bar/rr-menu-item.ts';
 import './rr-utility-menu-bar.ts';
 import './rr-back-button.ts';
-import '../spacer/rr-spacer.ts';
 
 type ContainerSize = 's' | 'm' | 'l';
 
@@ -149,48 +148,21 @@ export class RRTopNavigationBar extends LitElement {
       background-color: #ffffff;
     }
 
-    /* Responsive base padding for nav-bar - matches Figma's menu-bar padding
-       Spacers provide additional offset from edge */
+    /* Responsive padding - only for nav-bar, logo-bar centers content without padding */
     :host([container='s']) .nav-bar {
-      padding-left: var(--primitives-space-4, 4px);
-      padding-right: var(--primitives-space-4, 4px);
+      padding-left: var(--semantics-sections-s-margin-inline, 20px);
+      padding-right: var(--semantics-sections-s-margin-inline, 20px);
     }
 
     :host([container='m']) .nav-bar,
     :host(:not([container])) .nav-bar {
-      padding-left: var(--primitives-space-8, 8px);
-      padding-right: var(--primitives-space-8, 8px);
+      padding-left: var(--semantics-sections-m-margin-inline, 32px);
+      padding-right: var(--semantics-sections-m-margin-inline, 32px);
     }
 
     :host([container='l']) .nav-bar {
-      padding-left: var(--primitives-space-8, 8px);
-      padding-right: var(--primitives-space-8, 8px);
-    }
-
-    /* Section spacers - match Figma's top-navigation-bar__section-spacer */
-    .section-spacer {
-      flex-shrink: 0;
-    }
-
-    :host([container='s']) .section-spacer {
-      display: none; /* No spacer on small screens */
-    }
-
-    :host([container='m']) .section-spacer,
-    :host(:not([container])) .section-spacer {
-      width: var(--primitives-space-16, 16px);
-    }
-
-    :host([container='l']) .section-spacer {
-      width: var(--primitives-space-32, 32px);
-    }
-
-    .nav-content {
-      display: flex;
-      align-items: center;
-      justify-content: space-between;
-      flex: 1;
-      min-width: 0;
+      padding-left: var(--semantics-sections-l-margin-inline, 48px);
+      padding-right: var(--semantics-sections-l-margin-inline, 48px);
     }
 
     .nav-left {
@@ -204,6 +176,12 @@ export class RRTopNavigationBar extends LitElement {
       display: flex;
       align-items: center;
       flex-shrink: 0; /* Prevent utility bar from shrinking */
+    }
+
+    /* Figma: utility buttons are 40px from edge (8px nav + 32px spacer)
+       Code: nav-bar has 48px padding, so compensate with -8px margin */
+    :host([container='l']) .nav-right {
+      margin-right: -8px;
     }
 
     .global-menu {
@@ -364,42 +342,34 @@ export class RRTopNavigationBar extends LitElement {
 
         <!-- Navigation bar: Back | Title | Menu items | Utility buttons -->
         <nav class="nav-bar" part="nav-bar" aria-label="Hoofdnavigatie">
-          <!-- Left spacer - matches Figma top-navigation-bar__section-spacer -->
-          <rr-spacer class="section-spacer" direction="horizontal"></rr-spacer>
-
-          <div class="nav-content">
-            <!-- Left: Back button, Title, Global Menu -->
-            <div class="nav-left">
-              <rr-back-button
-                container="${this.container}"
-                href="${this.backHref}"
-                label="${this.backLabel}"
-              ></rr-back-button>
-              <span class="nav-title">${this.title}</span>
-              <div class="global-menu">
-                <rr-menu-bar size="${this.container}" has-overflow-menu overflow-label="Meer">
-                  <slot name="menu"></slot>
-                </rr-menu-bar>
-              </div>
-            </div>
-
-            <!-- Right: Utility buttons -->
-            <div class="nav-right">
-              <rr-utility-menu-bar
-                container="${this.container}"
-                ?no-language-switch="${this.utilityNoLanguageSwitch}"
-                ?no-search="${this.utilityNoSearch}"
-                ?no-account="${this.utilityNoAccount}"
-                ?has-help="${this.utilityHasHelp}"
-                ?has-settings="${this.utilityHasSettings}"
-                language="${this.utilityLanguage}"
-                account-label="${this._accountLabel}"
-              ></rr-utility-menu-bar>
+          <!-- Left: Back button, Title, Global Menu -->
+          <div class="nav-left">
+            <rr-back-button
+              container="${this.container}"
+              href="${this.backHref}"
+              label="${this.backLabel}"
+            ></rr-back-button>
+            <span class="nav-title">${this.title}</span>
+            <div class="global-menu">
+              <rr-menu-bar size="${this.container}" has-overflow-menu overflow-label="Meer">
+                <slot name="menu"></slot>
+              </rr-menu-bar>
             </div>
           </div>
 
-          <!-- Right spacer - matches Figma top-navigation-bar__section-spacer -->
-          <rr-spacer class="section-spacer" direction="horizontal"></rr-spacer>
+          <!-- Right: Utility buttons -->
+          <div class="nav-right">
+            <rr-utility-menu-bar
+              container="${this.container}"
+              ?no-language-switch="${this.utilityNoLanguageSwitch}"
+              ?no-search="${this.utilityNoSearch}"
+              ?no-account="${this.utilityNoAccount}"
+              ?has-help="${this.utilityHasHelp}"
+              ?has-settings="${this.utilityHasSettings}"
+              language="${this.utilityLanguage}"
+              account-label="${this._accountLabel}"
+            ></rr-utility-menu-bar>
+          </div>
         </nav>
       </div>
     `;

--- a/src/components/top-navigation-bar/rr-top-navigation-bar.ts
+++ b/src/components/top-navigation-bar/rr-top-navigation-bar.ts
@@ -65,6 +65,7 @@ import '../menu-bar/rr-menu-bar.ts';
 import '../menu-bar/rr-menu-item.ts';
 import './rr-utility-menu-bar.ts';
 import './rr-back-button.ts';
+import '../spacer/rr-spacer.ts';
 
 type ContainerSize = 's' | 'm' | 'l';
 
@@ -143,26 +144,34 @@ export class RRTopNavigationBar extends LitElement {
     .nav-bar {
       display: flex;
       align-items: center;
-      justify-content: space-between;
       min-height: 44px;
       background-color: #ffffff;
     }
 
-    /* Responsive padding - only for nav-bar, logo-bar centers content without padding */
+    /* Inner wrapper - contains nav-left and nav-right, handles space-between */
+    .nav-bar-inner {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      flex: 1;
+      min-width: 0;
+    }
+
+    /* Responsive padding - base padding, spacers handle the rest */
     :host([container='s']) .nav-bar {
-      padding-left: var(--semantics-sections-s-margin-inline, 20px);
-      padding-right: var(--semantics-sections-s-margin-inline, 20px);
+      padding-left: var(--primitives-space-4, 4px);
+      padding-right: var(--primitives-space-4, 4px);
     }
 
     :host([container='m']) .nav-bar,
     :host(:not([container])) .nav-bar {
-      padding-left: var(--semantics-sections-m-margin-inline, 32px);
-      padding-right: var(--semantics-sections-m-margin-inline, 32px);
+      padding-left: var(--primitives-space-8, 8px);
+      padding-right: var(--primitives-space-8, 8px);
     }
 
     :host([container='l']) .nav-bar {
-      padding-left: var(--semantics-sections-l-margin-inline, 48px);
-      padding-right: var(--semantics-sections-l-margin-inline, 48px);
+      padding-left: var(--primitives-space-8, 8px);
+      padding-right: var(--primitives-space-8, 8px);
     }
 
     .nav-left {
@@ -178,12 +187,6 @@ export class RRTopNavigationBar extends LitElement {
       flex-shrink: 0; /* Prevent utility bar from shrinking */
     }
 
-    /* Figma: utility buttons are 40px from edge (8px nav + 32px spacer)
-       Code: nav-bar has 48px padding, so compensate with -8px margin */
-    :host([container='l']) .nav-right {
-      margin-right: -8px;
-    }
-
     .global-menu {
       flex: 1;
       min-width: 0;
@@ -194,7 +197,8 @@ export class RRTopNavigationBar extends LitElement {
     .nav-title {
       font: var(--components-menu-bar-title-item-m-font, 550 20px/1.125 RijksSansVF, system-ui);
       color: var(--primitives-color-neutral-900, #0f172a);
-      /* Match Figma title-item padding: 0px 8px - title item right padding creates gap to menu */
+      /* Match Figma title-item padding: 0px 8px (8px on left AND right) */
+      padding-left: var(--primitives-space-8, 8px);
       padding-right: var(--primitives-space-8, 8px);
       white-space: nowrap;
     }
@@ -324,6 +328,13 @@ export class RRTopNavigationBar extends LitElement {
     return this.utilityAccountLabel || `Mijn ${this.title}`;
   }
 
+  /** Spacer size based on container: L=32, M=16, S=none */
+  private get _spacerSize(): '32' | '16' | null {
+    if (this.container === 'l') return '32';
+    if (this.container === 'm') return '16';
+    return null; // S container has no spacer
+  }
+
   override render() {
     return html`
       <a href="${this.skipLinkTarget}" class="skip-link">Ga naar hoofdinhoud</a>
@@ -342,34 +353,47 @@ export class RRTopNavigationBar extends LitElement {
 
         <!-- Navigation bar: Back | Title | Menu items | Utility buttons -->
         <nav class="nav-bar" part="nav-bar" aria-label="Hoofdnavigatie">
-          <!-- Left: Back button, Title, Global Menu -->
-          <div class="nav-left">
-            <rr-back-button
-              container="${this.container}"
-              href="${this.backHref}"
-              label="${this.backLabel}"
-            ></rr-back-button>
-            <span class="nav-title">${this.title}</span>
-            <div class="global-menu">
-              <rr-menu-bar size="${this.container}" has-overflow-menu overflow-label="Meer">
-                <slot name="menu"></slot>
-              </rr-menu-bar>
+          <!-- Left spacer (L=32px, M=16px, S=none) -->
+          ${this._spacerSize
+            ? html`<rr-spacer size="${this._spacerSize}" direction="horizontal"></rr-spacer>`
+            : nothing}
+
+          <!-- Inner wrapper for left/right content -->
+          <div class="nav-bar-inner">
+            <!-- Left: Back button, Title, Global Menu -->
+            <div class="nav-left">
+              <rr-back-button
+                container="${this.container}"
+                href="${this.backHref}"
+                label="${this.backLabel}"
+              ></rr-back-button>
+              <span class="nav-title">${this.title}</span>
+              <div class="global-menu">
+                <rr-menu-bar size="${this.container}" has-overflow-menu overflow-label="Meer">
+                  <slot name="menu"></slot>
+                </rr-menu-bar>
+              </div>
+            </div>
+
+            <!-- Right: Utility buttons -->
+            <div class="nav-right">
+              <rr-utility-menu-bar
+                container="${this.container}"
+                ?no-language-switch="${this.utilityNoLanguageSwitch}"
+                ?no-search="${this.utilityNoSearch}"
+                ?no-account="${this.utilityNoAccount}"
+                ?has-help="${this.utilityHasHelp}"
+                ?has-settings="${this.utilityHasSettings}"
+                language="${this.utilityLanguage}"
+                account-label="${this._accountLabel}"
+              ></rr-utility-menu-bar>
             </div>
           </div>
 
-          <!-- Right: Utility buttons -->
-          <div class="nav-right">
-            <rr-utility-menu-bar
-              container="${this.container}"
-              ?no-language-switch="${this.utilityNoLanguageSwitch}"
-              ?no-search="${this.utilityNoSearch}"
-              ?no-account="${this.utilityNoAccount}"
-              ?has-help="${this.utilityHasHelp}"
-              ?has-settings="${this.utilityHasSettings}"
-              language="${this.utilityLanguage}"
-              account-label="${this._accountLabel}"
-            ></rr-utility-menu-bar>
-          </div>
+          <!-- Right spacer (L=32px, M=16px, S=none) -->
+          ${this._spacerSize
+            ? html`<rr-spacer size="${this._spacerSize}" direction="horizontal"></rr-spacer>`
+            : nothing}
         </nav>
       </div>
     `;

--- a/src/components/top-navigation-bar/rr-top-navigation-bar.ts
+++ b/src/components/top-navigation-bar/rr-top-navigation-bar.ts
@@ -65,6 +65,7 @@ import '../menu-bar/rr-menu-bar.ts';
 import '../menu-bar/rr-menu-item.ts';
 import './rr-utility-menu-bar.ts';
 import './rr-back-button.ts';
+import '../spacer/rr-spacer.ts';
 
 type ContainerSize = 's' | 'm' | 'l';
 
@@ -148,21 +149,48 @@ export class RRTopNavigationBar extends LitElement {
       background-color: #ffffff;
     }
 
-    /* Responsive padding - only for nav-bar, logo-bar centers content without padding */
+    /* Responsive base padding for nav-bar - matches Figma's menu-bar padding
+       Spacers provide additional offset from edge */
     :host([container='s']) .nav-bar {
-      padding-left: var(--semantics-sections-s-margin-inline, 20px);
-      padding-right: var(--semantics-sections-s-margin-inline, 20px);
+      padding-left: var(--primitives-space-4, 4px);
+      padding-right: var(--primitives-space-4, 4px);
     }
 
     :host([container='m']) .nav-bar,
     :host(:not([container])) .nav-bar {
-      padding-left: var(--semantics-sections-m-margin-inline, 32px);
-      padding-right: var(--semantics-sections-m-margin-inline, 32px);
+      padding-left: var(--primitives-space-8, 8px);
+      padding-right: var(--primitives-space-8, 8px);
     }
 
     :host([container='l']) .nav-bar {
-      padding-left: var(--semantics-sections-l-margin-inline, 48px);
-      padding-right: var(--semantics-sections-l-margin-inline, 48px);
+      padding-left: var(--primitives-space-8, 8px);
+      padding-right: var(--primitives-space-8, 8px);
+    }
+
+    /* Section spacers - match Figma's top-navigation-bar__section-spacer */
+    .section-spacer {
+      flex-shrink: 0;
+    }
+
+    :host([container='s']) .section-spacer {
+      display: none; /* No spacer on small screens */
+    }
+
+    :host([container='m']) .section-spacer,
+    :host(:not([container])) .section-spacer {
+      width: var(--primitives-space-16, 16px);
+    }
+
+    :host([container='l']) .section-spacer {
+      width: var(--primitives-space-32, 32px);
+    }
+
+    .nav-content {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      flex: 1;
+      min-width: 0;
     }
 
     .nav-left {
@@ -176,12 +204,6 @@ export class RRTopNavigationBar extends LitElement {
       display: flex;
       align-items: center;
       flex-shrink: 0; /* Prevent utility bar from shrinking */
-    }
-
-    /* Figma: utility buttons are 40px from edge (8px nav + 32px spacer)
-       Code: nav-bar has 48px padding, so compensate with -8px margin */
-    :host([container='l']) .nav-right {
-      margin-right: -8px;
     }
 
     .global-menu {
@@ -342,34 +364,42 @@ export class RRTopNavigationBar extends LitElement {
 
         <!-- Navigation bar: Back | Title | Menu items | Utility buttons -->
         <nav class="nav-bar" part="nav-bar" aria-label="Hoofdnavigatie">
-          <!-- Left: Back button, Title, Global Menu -->
-          <div class="nav-left">
-            <rr-back-button
-              container="${this.container}"
-              href="${this.backHref}"
-              label="${this.backLabel}"
-            ></rr-back-button>
-            <span class="nav-title">${this.title}</span>
-            <div class="global-menu">
-              <rr-menu-bar size="${this.container}" has-overflow-menu overflow-label="Meer">
-                <slot name="menu"></slot>
-              </rr-menu-bar>
+          <!-- Left spacer - matches Figma top-navigation-bar__section-spacer -->
+          <rr-spacer class="section-spacer" direction="horizontal"></rr-spacer>
+
+          <div class="nav-content">
+            <!-- Left: Back button, Title, Global Menu -->
+            <div class="nav-left">
+              <rr-back-button
+                container="${this.container}"
+                href="${this.backHref}"
+                label="${this.backLabel}"
+              ></rr-back-button>
+              <span class="nav-title">${this.title}</span>
+              <div class="global-menu">
+                <rr-menu-bar size="${this.container}" has-overflow-menu overflow-label="Meer">
+                  <slot name="menu"></slot>
+                </rr-menu-bar>
+              </div>
+            </div>
+
+            <!-- Right: Utility buttons -->
+            <div class="nav-right">
+              <rr-utility-menu-bar
+                container="${this.container}"
+                ?no-language-switch="${this.utilityNoLanguageSwitch}"
+                ?no-search="${this.utilityNoSearch}"
+                ?no-account="${this.utilityNoAccount}"
+                ?has-help="${this.utilityHasHelp}"
+                ?has-settings="${this.utilityHasSettings}"
+                language="${this.utilityLanguage}"
+                account-label="${this._accountLabel}"
+              ></rr-utility-menu-bar>
             </div>
           </div>
 
-          <!-- Right: Utility buttons -->
-          <div class="nav-right">
-            <rr-utility-menu-bar
-              container="${this.container}"
-              ?no-language-switch="${this.utilityNoLanguageSwitch}"
-              ?no-search="${this.utilityNoSearch}"
-              ?no-account="${this.utilityNoAccount}"
-              ?has-help="${this.utilityHasHelp}"
-              ?has-settings="${this.utilityHasSettings}"
-              language="${this.utilityLanguage}"
-              account-label="${this._accountLabel}"
-            ></rr-utility-menu-bar>
-          </div>
+          <!-- Right spacer - matches Figma top-navigation-bar__section-spacer -->
+          <rr-spacer class="section-spacer" direction="horizontal"></rr-spacer>
         </nav>
       </div>
     `;


### PR DESCRIPTION
## Summary

Add layout utility components for the design system:

- **rr-spacer**: Flexible spacing component with 19 size variants
- **rr-spacer-cell**: Wrapper component for spacer, used in list items
- **rr-divider**: Visual separator with horizontal/vertical orientation
- **rr-page-sticky-area-background**: Gradient background for sticky headers/footers

## Token Issue

> ⚠️ **TODO**: Figma token `semantics/divider/thickness` should be `1` (currently `2`). The visual design in Figma shows 1px but the token exports as 2px. Please update the Figma variable and re-export tokens.

## Screenshots

### Spacer

| Side-by-Side | Overlay (50%) |
|--------------|---------------|
| ![side-by-side](https://0x0.st/PNpu.png) | ![overlay](https://0x0.st/PNpS.png) |

### Divider

| Side-by-Side | Overlay (50%) |
|--------------|---------------|
| ![side-by-side](https://0x0.st/PNwY.png) | ![overlay](https://0x0.st/PNwG.png) |

### Page Sticky Area Background

| Side-by-Side | Overlay (50%) |
|--------------|---------------|
| ![side-by-side](https://0x0.st/PNw6.png) | ![overlay](https://0x0.st/PNwD.png) |

---

## How to Verify

1. Check the Side-by-Side screenshots to see Code (bottom) vs Figma (top)
2. Check the Overlay screenshots (50% opacity) to see pixel differences
3. Minor differences in anti-aliasing are expected

🤖 Generated with [Claude Code](https://claude.ai/code)