### PR TITLE
feat(cells-list): add cell and list components

### DIFF
--- a/docs/component-map.json
+++ b/docs/component-map.json
@@ -502,8 +502,16 @@
         "nodeName": "button-cell",
         "url": "https://www.figma.com/design/5DyHMXUNVxbgH7ZjhQxPZe/RR-Components?node-id=236-41331"
       },
-      "status": "priority",
-      "neededFor": ["machine-action-sheet"]
+      "properties": {
+        "vertical-alignment": ["top", "center"]
+      },
+      "implementation": {
+        "tagName": "rr-button-cell",
+        "file": "src/components/button-cell/rr-button-cell.ts",
+        "className": "RRButtonCell"
+      },
+      "status": "implemented",
+      "lastUpdated": "2026-01-28"
     },
     {
       "name": "Custom Cell",
@@ -512,8 +520,16 @@
         "nodeName": "custom-cell",
         "url": "https://www.figma.com/design/5DyHMXUNVxbgH7ZjhQxPZe/RR-Components?node-id=1151-6202"
       },
-      "status": "priority",
-      "neededFor": ["machine-action-sheet"]
+      "properties": {
+        "vertical-alignment": ["top", "center"]
+      },
+      "implementation": {
+        "tagName": "rr-custom-cell",
+        "file": "src/components/custom-cell/rr-custom-cell.ts",
+        "className": "RRCustomCell"
+      },
+      "status": "implemented",
+      "lastUpdated": "2026-01-28"
     },
     {
       "name": "Divider",
@@ -571,8 +587,17 @@
         "nodeName": "label-cell",
         "url": "https://www.figma.com/design/5DyHMXUNVxbgH7ZjhQxPZe/RR-Components?node-id=1033-4433"
       },
-      "status": "priority",
-      "neededFor": ["machine-action-sheet"]
+      "properties": {
+        "color": ["default", "white"],
+        "horizontal-alignment": ["left", "right"]
+      },
+      "implementation": {
+        "tagName": "rr-label-cell",
+        "file": "src/components/label-cell/rr-label-cell.ts",
+        "className": "RRLabelCell"
+      },
+      "status": "implemented",
+      "lastUpdated": "2026-01-28"
     },
     {
       "name": "List",
@@ -581,18 +606,35 @@
         "nodeName": "list",
         "url": "https://www.figma.com/design/5DyHMXUNVxbgH7ZjhQxPZe/RR-Components?node-id=1044-2275"
       },
-      "status": "priority",
-      "neededFor": ["machine-action-sheet"]
+      "properties": {
+        "variant": ["simple", "box", "box-on-tint"]
+      },
+      "implementation": {
+        "tagName": "rr-list",
+        "file": "src/components/list/rr-list.ts",
+        "className": "RRList"
+      },
+      "status": "implemented",
+      "lastUpdated": "2026-01-28"
     },
     {
-      "name": "List: Item",
+      "name": "List Item",
       "figma": {
         "nodeId": "957-2279",
         "nodeName": "list__item",
         "url": "https://www.figma.com/design/5DyHMXUNVxbgH7ZjhQxPZe/RR-Components?node-id=957-2279"
       },
-      "status": "priority",
-      "neededFor": ["machine-action-sheet"]
+      "properties": {
+        "size": ["sm", "md"],
+        "is-selected": "boolean"
+      },
+      "implementation": {
+        "tagName": "rr-list-item",
+        "file": "src/components/list/rr-list-item.ts",
+        "className": "RRListItem"
+      },
+      "status": "implemented",
+      "lastUpdated": "2026-01-28"
     },
     {
       "name": "Page: Sticky Area Background",
@@ -689,8 +731,19 @@
         "nodeName": "title-cell",
         "url": "https://www.figma.com/design/5DyHMXUNVxbgH7ZjhQxPZe/RR-Components?node-id=236-41079"
       },
-      "status": "priority",
-      "neededFor": ["machine-action-sheet"]
+      "properties": {
+        "size": ["sm", "md"],
+        "color": ["default", "white"],
+        "horizontal-alignment": ["left", "right"],
+        "vertical-alignment": ["top", "center"]
+      },
+      "implementation": {
+        "tagName": "rr-title-cell",
+        "file": "src/components/title-cell/rr-title-cell.ts",
+        "className": "RRTitleCell"
+      },
+      "status": "implemented",
+      "lastUpdated": "2026-01-28"
     },
     {
       "name": "Top Title Bar",

--- a/src/components/button-cell/rr-button-cell.stories.js
+++ b/src/components/button-cell/rr-button-cell.stories.js
@@ -1,0 +1,88 @@
+import { html } from 'lit';
+import './rr-button-cell.js';
+import '../button/rr-button.js';
+
+export default {
+  title: 'Components/Button Cell',
+  component: 'rr-button-cell',
+  tags: ['autodocs'],
+  parameters: {
+    design: {
+      type: 'figma',
+      url: 'https://www.figma.com/design/5DyHMXUNVxbgH7ZjhQxPZe/RR-Components?node-id=236-41331',
+    },
+  },
+  argTypes: {
+    verticalAlignment: {
+      control: 'select',
+      options: ['top', 'center'],
+      description: 'Vertical alignment of the button',
+    },
+  },
+};
+
+export const Default = {
+  args: {
+    verticalAlignment: 'center',
+  },
+  render: (args) => html`
+    <rr-button-cell
+      vertical-alignment=${args.verticalAlignment}
+      style="height: 100px; border: 1px dashed #ccc;"
+    >
+      <rr-button variant="neutral-tinted">Button</rr-button>
+    </rr-button-cell>
+  `,
+};
+
+export const AlignmentTop = {
+  render: () => html`
+    <rr-button-cell vertical-alignment="top" style="height: 100px; border: 1px dashed #ccc;">
+      <rr-button variant="neutral-tinted">Button</rr-button>
+    </rr-button-cell>
+  `,
+};
+
+export const AlignmentCenter = {
+  render: () => html`
+    <rr-button-cell vertical-alignment="center" style="height: 100px; border: 1px dashed #ccc;">
+      <rr-button variant="neutral-tinted">Button</rr-button>
+    </rr-button-cell>
+  `,
+};
+
+// Figma Comparison
+const FIGMA_TOKEN = import.meta.env.STORYBOOK_FIGMA_TOKEN || '';
+const FIGMA_FILE_ID = '5DyHMXUNVxbgH7ZjhQxPZe';
+
+export const FigmaComparison = () => html`
+  <ftl-belt access-token="${FIGMA_TOKEN}" file-id="${FIGMA_FILE_ID}">
+    <div style="display: flex; flex-direction: column; gap: 1rem;">
+      <p style="font-size: 0.875rem; color: #64748b; margin: 0;">
+        Our button cells (Code) vs Figma design. Use Toggle/Overlay/Side-by-Side to compare.
+      </p>
+      <ftl-holster node="236:41331" style="display: inline-block;">
+        <!--
+          Figma button-cell (236:41331) component set:
+          - Layout: column, gap: 16px, padding: 16px
+          - 2 variants: vertical-alignment (center/top)
+          - Button uses neutral-tinted style, md size
+        -->
+        <div style="background: #ffffff; padding: 16px; box-sizing: border-box; display: flex; flex-direction: column; gap: 16px;">
+          <rr-button-cell vertical-alignment="center">
+            <rr-button variant="neutral-tinted" size="m">Button</rr-button>
+          </rr-button-cell>
+          <rr-button-cell vertical-alignment="top">
+            <rr-button variant="neutral-tinted" size="m">Button</rr-button>
+          </rr-button-cell>
+        </div>
+      </ftl-holster>
+      <p style="font-size: 0.75rem; color: #64748b; margin-top: 0.5rem;">
+        Keyboard: T (toggle) | O (overlay) | S (side-by-side)
+      </p>
+    </div>
+  </ftl-belt>
+`;
+FigmaComparison.storyName = '🎨 Figma Comparison';
+FigmaComparison.tags = ['!autodocs', 'figma'];
+FigmaComparison.parameters = { controls: { disable: true } };

--- a/src/components/button-cell/rr-button-cell.ts
+++ b/src/components/button-cell/rr-button-cell.ts
@@ -1,0 +1,64 @@
+/**
+ * RegelRecht Button Cell Component (Lit + TypeScript)
+ *
+ * A cell wrapper component for displaying buttons in lists with configurable vertical alignment.
+ * This component is a container that holds a button (typically rr-button) and controls its alignment.
+ *
+ * @element rr-button-cell
+ * @attr {string} vertical-alignment - Vertical alignment: 'top' | 'center' (default: 'center')
+ *
+ * @slot - Default slot for button content (typically rr-button)
+ *
+ * @csspart cell - The cell container
+ */
+
+import { LitElement, html, css } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+
+type VerticalAlignment = 'top' | 'center';
+
+@customElement('rr-button-cell')
+export class RRButtonCell extends LitElement {
+  static override styles = css`
+    :host {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+    }
+
+    :host([hidden]) {
+      display: none;
+    }
+
+    /* Vertical alignment: center (default) */
+    :host([vertical-alignment="center"]),
+    :host(:not([vertical-alignment])) {
+      justify-content: center;
+    }
+
+    /* Vertical alignment: top */
+    :host([vertical-alignment="top"]) {
+      justify-content: flex-start;
+    }
+
+    /* Ensure slotted buttons don't stretch */
+    ::slotted(*) {
+      flex-shrink: 0;
+    }
+  `;
+
+  @property({ type: String, reflect: true, attribute: 'vertical-alignment' })
+  verticalAlignment: VerticalAlignment = 'center';
+
+  override render() {
+    return html`
+      <slot></slot>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'rr-button-cell': RRButtonCell;
+  }
+}

--- a/src/components/custom-cell/rr-custom-cell.stories.js
+++ b/src/components/custom-cell/rr-custom-cell.stories.js
@@ -1,0 +1,96 @@
+import { html } from 'lit';
+import './rr-custom-cell.js';
+
+export default {
+  title: 'Components/Custom Cell',
+  component: 'rr-custom-cell',
+  tags: ['autodocs'],
+  parameters: {
+    design: {
+      type: 'figma',
+      url: 'https://www.figma.com/design/5DyHMXUNVxbgH7ZjhQxPZe/RR-Components?node-id=1151-6202',
+    },
+  },
+  argTypes: {
+    verticalAlignment: {
+      control: 'select',
+      options: ['top', 'center'],
+      description: 'Vertical alignment of the custom content',
+    },
+  },
+};
+
+export const Default = {
+  args: {
+    verticalAlignment: 'center',
+  },
+  render: (args) => html`
+    <rr-custom-cell
+      vertical-alignment=${args.verticalAlignment}
+      style="height: 80px; border: 1px dashed #ccc;"
+    >
+      <div style="background: #f0f0f0; padding: 8px;">Custom content</div>
+    </rr-custom-cell>
+  `,
+};
+
+export const AlignmentTop = {
+  render: () => html`
+    <rr-custom-cell vertical-alignment="top" style="height: 80px; border: 1px dashed #ccc;">
+      <div style="background: #e0f0ff; padding: 8px;">Top aligned content</div>
+    </rr-custom-cell>
+  `,
+};
+
+export const AlignmentCenter = {
+  render: () => html`
+    <rr-custom-cell vertical-alignment="center" style="height: 80px; border: 1px dashed #ccc;">
+      <div style="background: #e0ffe0; padding: 8px;">Center aligned content</div>
+    </rr-custom-cell>
+  `,
+};
+
+export const WithFormElements = {
+  render: () => html`
+    <rr-custom-cell style="padding: 8px; border: 1px dashed #ccc;">
+      <input type="text" placeholder="Custom input field" style="padding: 8px; border: 1px solid #ccc; border-radius: 4px;" />
+    </rr-custom-cell>
+  `,
+};
+
+// Figma Comparison
+const FIGMA_TOKEN = import.meta.env.STORYBOOK_FIGMA_TOKEN || '';
+const FIGMA_FILE_ID = '5DyHMXUNVxbgH7ZjhQxPZe';
+
+export const FigmaComparison = () => html`
+  <ftl-belt access-token="${FIGMA_TOKEN}" file-id="${FIGMA_FILE_ID}">
+    <div style="display: flex; flex-direction: column; gap: 1rem;">
+      <p style="font-size: 0.875rem; color: #64748b; margin: 0;">
+        Our custom cells (Code) vs Figma design. Use Toggle/Overlay/Side-by-Side to compare.
+      </p>
+      <ftl-holster node="1151:6202" style="display: inline-block;">
+        <!--
+          Figma custom-cell (1151:6202) component set:
+          - Layout: column, gap: 16px, padding: 16px
+          - Fixed width: 88px
+          - 2 variants: vertical-alignment (top/center)
+          - Shows a pink SLOT placeholder in Figma
+        -->
+        <div style="width: 88px; background: #ffffff; padding: 16px; box-sizing: border-box; display: flex; flex-direction: column; gap: 16px;">
+          <rr-custom-cell vertical-alignment="top">
+            <div style="background: rgba(255, 36, 189, 0.1); border: 2px solid #FF24BD; padding: 2px 8px; text-align: center; color: #FF24BD; font-weight: 700; font-size: 18px; line-height: 1.125;">SLOT</div>
+          </rr-custom-cell>
+          <rr-custom-cell vertical-alignment="center">
+            <div style="background: rgba(255, 36, 189, 0.1); border: 2px solid #FF24BD; padding: 2px 8px; text-align: center; color: #FF24BD; font-weight: 700; font-size: 18px; line-height: 1.125;">SLOT</div>
+          </rr-custom-cell>
+        </div>
+      </ftl-holster>
+      <p style="font-size: 0.75rem; color: #64748b; margin-top: 0.5rem;">
+        Keyboard: T (toggle) | O (overlay) | S (side-by-side)
+      </p>
+    </div>
+  </ftl-belt>
+`;
+FigmaComparison.storyName = '🎨 Figma Comparison';
+FigmaComparison.tags = ['!autodocs', 'figma'];
+FigmaComparison.parameters = { controls: { disable: true } };

--- a/src/components/custom-cell/rr-custom-cell.stories.js
+++ b/src/components/custom-cell/rr-custom-cell.stories.js
@@ -72,11 +72,9 @@ export const FigmaComparison = () => html`
       <!-- vertical-alignment=top -->
       <div style="display: flex; flex-direction: column; gap: 0.25rem;">
         <span style="font-size: 0.75rem; color: #64748b;">vertical-alignment: top</span>
-        <ftl-holster node="1151:6203" style="display: inline-block;">
-          <div style="display: flex; flex-direction: column; justify-content: flex-start; align-items: stretch;">
-            <div style="display: flex; flex-direction: column; justify-content: center; align-items: center; padding: 2px 8px; background: rgba(255, 36, 189, 0.1); border: 2px solid #FF24BD; box-sizing: border-box;">
-              <span style="color: #FF24BD; font-weight: 700; font-size: 18px; line-height: 1.125; text-align: center;">SLOT</span>
-            </div>
+        <ftl-holster node="1151:6203" style="display: block;">
+          <div style="display: flex; flex-direction: column; justify-content: center; align-items: center; width: 56px; height: 24px; background: rgba(255, 36, 189, 0.1); border: 2px solid #FF24BD; box-sizing: border-box;">
+            <span style="color: #FF24BD; font-weight: 700; font-size: 12px; line-height: 1; text-align: center;">SLOT</span>
           </div>
         </ftl-holster>
       </div>
@@ -84,11 +82,9 @@ export const FigmaComparison = () => html`
       <!-- vertical-alignment=center -->
       <div style="display: flex; flex-direction: column; gap: 0.25rem;">
         <span style="font-size: 0.75rem; color: #64748b;">vertical-alignment: center</span>
-        <ftl-holster node="1151:6205" style="display: inline-block;">
-          <div style="display: flex; flex-direction: column; justify-content: center; align-items: stretch;">
-            <div style="display: flex; flex-direction: column; justify-content: center; align-items: center; padding: 2px 8px; background: rgba(255, 36, 189, 0.1); border: 2px solid #FF24BD; box-sizing: border-box;">
-              <span style="color: #FF24BD; font-weight: 700; font-size: 18px; line-height: 1.125; text-align: center;">SLOT</span>
-            </div>
+        <ftl-holster node="1151:6205" style="display: block;">
+          <div style="display: flex; flex-direction: column; justify-content: center; align-items: center; width: 56px; height: 24px; background: rgba(255, 36, 189, 0.1); border: 2px solid #FF24BD; box-sizing: border-box;">
+            <span style="color: #FF24BD; font-weight: 700; font-size: 12px; line-height: 1; text-align: center;">SLOT</span>
           </div>
         </ftl-holster>
       </div>

--- a/src/components/custom-cell/rr-custom-cell.stories.js
+++ b/src/components/custom-cell/rr-custom-cell.stories.js
@@ -73,11 +73,11 @@ export const FigmaComparison = () => html`
       <div style="display: flex; flex-direction: column; gap: 0.25rem;">
         <span style="font-size: 0.75rem; color: #64748b;">vertical-alignment: top</span>
         <ftl-holster node="1151:6203" style="display: inline-block;">
-          <rr-custom-cell vertical-alignment="top">
-            <div style="display: inline-flex; flex-direction: column; justify-content: center; align-items: center; padding: 2px 8px; background: rgba(255, 36, 189, 0.1); border: 2px solid #FF24BD; box-sizing: border-box;">
+          <div style="display: flex; flex-direction: column; justify-content: flex-start; align-items: stretch;">
+            <div style="display: flex; flex-direction: column; justify-content: center; align-items: center; padding: 2px 8px; background: rgba(255, 36, 189, 0.1); border: 2px solid #FF24BD; box-sizing: border-box;">
               <span style="color: #FF24BD; font-weight: 700; font-size: 18px; line-height: 1.125; text-align: center;">SLOT</span>
             </div>
-          </rr-custom-cell>
+          </div>
         </ftl-holster>
       </div>
 
@@ -85,11 +85,11 @@ export const FigmaComparison = () => html`
       <div style="display: flex; flex-direction: column; gap: 0.25rem;">
         <span style="font-size: 0.75rem; color: #64748b;">vertical-alignment: center</span>
         <ftl-holster node="1151:6205" style="display: inline-block;">
-          <rr-custom-cell vertical-alignment="center">
-            <div style="display: inline-flex; flex-direction: column; justify-content: center; align-items: center; padding: 2px 8px; background: rgba(255, 36, 189, 0.1); border: 2px solid #FF24BD; box-sizing: border-box;">
+          <div style="display: flex; flex-direction: column; justify-content: center; align-items: stretch;">
+            <div style="display: flex; flex-direction: column; justify-content: center; align-items: center; padding: 2px 8px; background: rgba(255, 36, 189, 0.1); border: 2px solid #FF24BD; box-sizing: border-box;">
               <span style="color: #FF24BD; font-weight: 700; font-size: 18px; line-height: 1.125; text-align: center;">SLOT</span>
             </div>
-          </rr-custom-cell>
+          </div>
         </ftl-holster>
       </div>
       <p style="font-size: 0.75rem; color: #64748b; margin-top: 0.5rem;">

--- a/src/components/custom-cell/rr-custom-cell.stories.js
+++ b/src/components/custom-cell/rr-custom-cell.stories.js
@@ -66,29 +66,32 @@ export const FigmaComparison = () => html`
   <ftl-belt access-token="${FIGMA_TOKEN}" file-id="${FIGMA_FILE_ID}">
     <div style="display: flex; flex-direction: column; gap: 1rem;">
       <p style="font-size: 0.875rem; color: #64748b; margin: 0;">
-        Our custom cells (Code) vs Figma design. Use Toggle/Overlay/Side-by-Side to compare.
+        Individual variant comparisons (Code vs Figma). Use Toggle/Overlay/Side-by-Side to compare.
       </p>
-      <ftl-holster node="1151:6202" style="display: inline-block;">
-        <!--
-          Figma custom-cell (1151:6202) component set:
-          - Layout: column, gap: 16px, padding: 16px
-          - Fixed width: 88px
-          - 2 variants: vertical-alignment (top/center)
-          - Shows a pink SLOT placeholder with flexbox centering
-        -->
-        <div style="width: 88px; background: #ffffff; padding: 16px; box-sizing: border-box; display: flex; flex-direction: column; gap: 16px;">
+
+      <!-- vertical-alignment=top -->
+      <div style="display: flex; flex-direction: column; gap: 0.25rem;">
+        <span style="font-size: 0.75rem; color: #64748b;">vertical-alignment: top</span>
+        <ftl-holster node="1151:6203" style="display: inline-block;">
           <rr-custom-cell vertical-alignment="top">
             <div style="display: flex; flex-direction: column; justify-content: center; align-items: center; padding: 2px 8px; background: rgba(255, 36, 189, 0.1); border: 2px solid #FF24BD; box-sizing: border-box;">
               <span style="color: #FF24BD; font-weight: 700; font-size: 18px; line-height: 1.125; text-align: center; width: 100%;">SLOT</span>
             </div>
           </rr-custom-cell>
+        </ftl-holster>
+      </div>
+
+      <!-- vertical-alignment=center -->
+      <div style="display: flex; flex-direction: column; gap: 0.25rem;">
+        <span style="font-size: 0.75rem; color: #64748b;">vertical-alignment: center</span>
+        <ftl-holster node="1151:6205" style="display: inline-block;">
           <rr-custom-cell vertical-alignment="center">
             <div style="display: flex; flex-direction: column; justify-content: center; align-items: center; padding: 2px 8px; background: rgba(255, 36, 189, 0.1); border: 2px solid #FF24BD; box-sizing: border-box;">
               <span style="color: #FF24BD; font-weight: 700; font-size: 18px; line-height: 1.125; text-align: center; width: 100%;">SLOT</span>
             </div>
           </rr-custom-cell>
-        </div>
-      </ftl-holster>
+        </ftl-holster>
+      </div>
       <p style="font-size: 0.75rem; color: #64748b; margin-top: 0.5rem;">
         Keyboard: T (toggle) | O (overlay) | S (side-by-side)
       </p>

--- a/src/components/custom-cell/rr-custom-cell.stories.js
+++ b/src/components/custom-cell/rr-custom-cell.stories.js
@@ -74,8 +74,8 @@ export const FigmaComparison = () => html`
         <span style="font-size: 0.75rem; color: #64748b;">vertical-alignment: top</span>
         <ftl-holster node="1151:6203" style="display: inline-block;">
           <rr-custom-cell vertical-alignment="top">
-            <div style="display: flex; flex-direction: column; justify-content: center; align-items: center; padding: 2px 8px; background: rgba(255, 36, 189, 0.1); border: 2px solid #FF24BD; box-sizing: border-box;">
-              <span style="color: #FF24BD; font-weight: 700; font-size: 18px; line-height: 1.125; text-align: center; width: 100%;">SLOT</span>
+            <div style="display: inline-flex; flex-direction: column; justify-content: center; align-items: center; padding: 2px 8px; background: rgba(255, 36, 189, 0.1); border: 2px solid #FF24BD; box-sizing: border-box;">
+              <span style="color: #FF24BD; font-weight: 700; font-size: 18px; line-height: 1.125; text-align: center;">SLOT</span>
             </div>
           </rr-custom-cell>
         </ftl-holster>
@@ -86,8 +86,8 @@ export const FigmaComparison = () => html`
         <span style="font-size: 0.75rem; color: #64748b;">vertical-alignment: center</span>
         <ftl-holster node="1151:6205" style="display: inline-block;">
           <rr-custom-cell vertical-alignment="center">
-            <div style="display: flex; flex-direction: column; justify-content: center; align-items: center; padding: 2px 8px; background: rgba(255, 36, 189, 0.1); border: 2px solid #FF24BD; box-sizing: border-box;">
-              <span style="color: #FF24BD; font-weight: 700; font-size: 18px; line-height: 1.125; text-align: center; width: 100%;">SLOT</span>
+            <div style="display: inline-flex; flex-direction: column; justify-content: center; align-items: center; padding: 2px 8px; background: rgba(255, 36, 189, 0.1); border: 2px solid #FF24BD; box-sizing: border-box;">
+              <span style="color: #FF24BD; font-weight: 700; font-size: 18px; line-height: 1.125; text-align: center;">SLOT</span>
             </div>
           </rr-custom-cell>
         </ftl-holster>

--- a/src/components/custom-cell/rr-custom-cell.stories.js
+++ b/src/components/custom-cell/rr-custom-cell.stories.js
@@ -74,14 +74,18 @@ export const FigmaComparison = () => html`
           - Layout: column, gap: 16px, padding: 16px
           - Fixed width: 88px
           - 2 variants: vertical-alignment (top/center)
-          - Shows a pink SLOT placeholder in Figma
+          - Shows a pink SLOT placeholder with flexbox centering
         -->
         <div style="width: 88px; background: #ffffff; padding: 16px; box-sizing: border-box; display: flex; flex-direction: column; gap: 16px;">
           <rr-custom-cell vertical-alignment="top">
-            <div style="background: rgba(255, 36, 189, 0.1); border: 2px solid #FF24BD; padding: 2px 8px; text-align: center; color: #FF24BD; font-weight: 700; font-size: 18px; line-height: 1.125;">SLOT</div>
+            <div style="display: flex; flex-direction: column; justify-content: center; align-items: center; padding: 2px 8px; background: rgba(255, 36, 189, 0.1); border: 2px solid #FF24BD; box-sizing: border-box;">
+              <span style="color: #FF24BD; font-weight: 700; font-size: 18px; line-height: 1.125; text-align: center; width: 100%;">SLOT</span>
+            </div>
           </rr-custom-cell>
           <rr-custom-cell vertical-alignment="center">
-            <div style="background: rgba(255, 36, 189, 0.1); border: 2px solid #FF24BD; padding: 2px 8px; text-align: center; color: #FF24BD; font-weight: 700; font-size: 18px; line-height: 1.125;">SLOT</div>
+            <div style="display: flex; flex-direction: column; justify-content: center; align-items: center; padding: 2px 8px; background: rgba(255, 36, 189, 0.1); border: 2px solid #FF24BD; box-sizing: border-box;">
+              <span style="color: #FF24BD; font-weight: 700; font-size: 18px; line-height: 1.125; text-align: center; width: 100%;">SLOT</span>
+            </div>
           </rr-custom-cell>
         </div>
       </ftl-holster>

--- a/src/components/custom-cell/rr-custom-cell.ts
+++ b/src/components/custom-cell/rr-custom-cell.ts
@@ -1,0 +1,69 @@
+/**
+ * RegelRecht Custom Cell Component (Lit + TypeScript)
+ *
+ * A flexible cell component for displaying custom content in lists.
+ * Use this when you need to place arbitrary content that doesn't fit other cell types.
+ *
+ * @element rr-custom-cell
+ * @attr {string} vertical-alignment - Vertical alignment: 'top' | 'center' (default: 'center')
+ *
+ * @slot - Default slot for custom content
+ *
+ * @csspart cell - The cell container
+ */
+
+import { LitElement, html, css } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+
+type VerticalAlignment = 'top' | 'center';
+
+@customElement('rr-custom-cell')
+export class RRCustomCell extends LitElement {
+  static override styles = css`
+    :host {
+      display: flex;
+      flex-direction: row;
+      align-items: stretch;
+      justify-content: stretch;
+    }
+
+    :host([hidden]) {
+      display: none;
+    }
+
+    .custom-cell {
+      display: flex;
+      flex-direction: column;
+      flex: 1;
+      min-width: 0;
+    }
+
+    /* Vertical alignment: center (default) */
+    :host([vertical-alignment="center"]) .custom-cell,
+    :host(:not([vertical-alignment])) .custom-cell {
+      justify-content: center;
+    }
+
+    /* Vertical alignment: top */
+    :host([vertical-alignment="top"]) .custom-cell {
+      justify-content: flex-start;
+    }
+  `;
+
+  @property({ type: String, reflect: true, attribute: 'vertical-alignment' })
+  verticalAlignment: VerticalAlignment = 'center';
+
+  override render() {
+    return html`
+      <div class="custom-cell" part="cell">
+        <slot></slot>
+      </div>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'rr-custom-cell': RRCustomCell;
+  }
+}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -36,4 +36,14 @@ export { RRTopNavigationBar } from './top-navigation-bar/rr-top-navigation-bar.t
 export { RRNavLogo } from './top-navigation-bar/rr-nav-logo.ts';
 export { RRBackButton } from './top-navigation-bar/rr-back-button.ts';
 
+// Cell components
+export { RRTitleCell } from './title-cell/rr-title-cell.ts';
+export { RRLabelCell } from './label-cell/rr-label-cell.ts';
+export { RRButtonCell } from './button-cell/rr-button-cell.ts';
+export { RRCustomCell } from './custom-cell/rr-custom-cell.ts';
+
+// List components
+export { RRList } from './list/rr-list.ts';
+export { RRListItem } from './list/rr-list-item.ts';
+
 // Auto-register happens on import of individual component files

--- a/src/components/label-cell/rr-label-cell.stories.js
+++ b/src/components/label-cell/rr-label-cell.stories.js
@@ -1,0 +1,94 @@
+import { html } from 'lit';
+import './rr-label-cell.js';
+
+export default {
+  title: 'Components/Label Cell',
+  component: 'rr-label-cell',
+  tags: ['autodocs'],
+  parameters: {
+    design: {
+      type: 'figma',
+      url: 'https://www.figma.com/design/5DyHMXUNVxbgH7ZjhQxPZe/RR-Components?node-id=1033-4433',
+    },
+  },
+  argTypes: {
+    color: {
+      control: 'select',
+      options: ['default', 'white'],
+      description: 'Color variant of the label text',
+    },
+    horizontalAlignment: {
+      control: 'select',
+      options: ['left', 'right'],
+      description: 'Horizontal alignment of the label',
+    },
+  },
+};
+
+export const Default = {
+  args: {
+    color: 'default',
+    horizontalAlignment: 'left',
+  },
+  render: (args) => html`
+    <rr-label-cell
+      color=${args.color}
+      horizontal-alignment=${args.horizontalAlignment}
+    >
+      Label cell
+    </rr-label-cell>
+  `,
+};
+
+export const AlignmentRight = {
+  render: () => html`
+    <rr-label-cell horizontal-alignment="right" style="width: 200px; border: 1px dashed #ccc;">
+      Label cell
+    </rr-label-cell>
+  `,
+};
+
+export const ColorWhite = {
+  render: () => html`
+    <div style="background: #154273; padding: 16px;">
+      <rr-label-cell color="white">Label cell (White)</rr-label-cell>
+    </div>
+  `,
+};
+
+// Figma Comparison
+const FIGMA_TOKEN = import.meta.env.STORYBOOK_FIGMA_TOKEN || '';
+const FIGMA_FILE_ID = '5DyHMXUNVxbgH7ZjhQxPZe';
+
+export const FigmaComparison = () => html`
+  <ftl-belt access-token="${FIGMA_TOKEN}" file-id="${FIGMA_FILE_ID}">
+    <div style="display: flex; flex-direction: column; gap: 1rem;">
+      <p style="font-size: 0.875rem; color: #64748b; margin: 0;">
+        Our label cells (Code) vs Figma design. Use Toggle/Overlay/Side-by-Side to compare.
+      </p>
+      <ftl-holster node="1033:4433" style="display: inline-block;">
+        <!--
+          Figma label-cell (1033:4433) component set:
+          - Layout: column, gap: 16px, padding: 16px
+          - Fixed width: 308px
+          - 4 variants: 2 colors (default/white) x 2 h-align (left/right)
+        -->
+        <div style="width: 308px; background: #ffffff; padding: 16px; box-sizing: border-box; display: flex; flex-direction: column; gap: 16px;">
+          <!-- Default color variants -->
+          <rr-label-cell horizontal-alignment="left">Label cell</rr-label-cell>
+          <rr-label-cell horizontal-alignment="right">Label cell</rr-label-cell>
+
+          <!-- White color variants (no background in Figma - white text on transparent) -->
+          <rr-label-cell color="white" horizontal-alignment="left">Label cell</rr-label-cell>
+          <rr-label-cell color="white" horizontal-alignment="right">Label cell</rr-label-cell>
+        </div>
+      </ftl-holster>
+      <p style="font-size: 0.75rem; color: #64748b; margin-top: 0.5rem;">
+        Keyboard: T (toggle) | O (overlay) | S (side-by-side)
+      </p>
+    </div>
+  </ftl-belt>
+`;
+FigmaComparison.storyName = '🎨 Figma Comparison';
+FigmaComparison.tags = ['!autodocs', 'figma'];
+FigmaComparison.parameters = { controls: { disable: true } };

--- a/src/components/label-cell/rr-label-cell.stories.js
+++ b/src/components/label-cell/rr-label-cell.stories.js
@@ -71,16 +71,17 @@ export const FigmaComparison = () => html`
           Figma label-cell (1033:4433) component set:
           - Layout: column, gap: 16px, padding: 16px
           - Fixed width: 308px
+          - Background: #333A45 (dark, to show all variants)
           - 4 variants: 2 colors (default/white) x 2 h-align (left/right)
         -->
-        <div style="width: 308px; background: #ffffff; padding: 16px; box-sizing: border-box; display: flex; flex-direction: column; gap: 16px;">
-          <!-- Default color variants -->
-          <rr-label-cell horizontal-alignment="left">Label cell</rr-label-cell>
-          <rr-label-cell horizontal-alignment="right">Label cell</rr-label-cell>
-
-          <!-- White color variants (no background in Figma - white text on transparent) -->
+        <div style="width: 308px; background: #333a45; padding: 16px; box-sizing: border-box; display: flex; flex-direction: column; gap: 16px;">
+          <!-- White color variants (visible on dark background) -->
           <rr-label-cell color="white" horizontal-alignment="left">Label cell</rr-label-cell>
           <rr-label-cell color="white" horizontal-alignment="right">Label cell</rr-label-cell>
+
+          <!-- Default color variants (darker text, less visible on dark bg) -->
+          <rr-label-cell color="default" horizontal-alignment="left">Label cell</rr-label-cell>
+          <rr-label-cell color="default" horizontal-alignment="right">Label cell</rr-label-cell>
         </div>
       </ftl-holster>
       <p style="font-size: 0.75rem; color: #64748b; margin-top: 0.5rem;">

--- a/src/components/label-cell/rr-label-cell.stories.js
+++ b/src/components/label-cell/rr-label-cell.stories.js
@@ -64,24 +64,41 @@ export const FigmaComparison = () => html`
   <ftl-belt access-token="${FIGMA_TOKEN}" file-id="${FIGMA_FILE_ID}">
     <div style="display: flex; flex-direction: column; gap: 1rem;">
       <p style="font-size: 0.875rem; color: #64748b; margin: 0;">
-        Our label cells (Code) vs Figma design. Use Toggle/Overlay/Side-by-Side to compare.
+        Individual variant comparisons (Code vs Figma). Use Toggle/Overlay/Side-by-Side to compare.
       </p>
-      <ftl-holster node="1033:4433" style="display: inline-block;">
-        <!--
-          Figma label-cell (1033:4433) component set:
-          - Layout: column, gap: 16px, padding: 16px
-          - Fixed width: 308px
-          - Background: #333A45 (dark, to show all variants)
-          - 4 variants: 2 colors (default/white) x 2 h-align (left/right)
-        -->
-        <div style="width: 308px; background: #333a45; padding: 16px; box-sizing: border-box; display: flex; flex-direction: column; gap: 16px;">
-          <!-- Figma order: default/left, default/right, white/left, white/right -->
+
+      <!-- Default color, left alignment -->
+      <div style="display: flex; flex-direction: column; gap: 0.25rem;">
+        <span style="font-size: 0.75rem; color: #64748b;">default / left</span>
+        <ftl-holster node="1033:4448" style="display: inline-block;">
           <rr-label-cell color="default" horizontal-alignment="left">Label cell</rr-label-cell>
+        </ftl-holster>
+      </div>
+
+      <!-- Default color, right alignment -->
+      <div style="display: flex; flex-direction: column; gap: 0.25rem;">
+        <span style="font-size: 0.75rem; color: #64748b;">default / right</span>
+        <ftl-holster node="1033:4455" style="display: inline-block;">
           <rr-label-cell color="default" horizontal-alignment="right">Label cell</rr-label-cell>
+        </ftl-holster>
+      </div>
+
+      <!-- White color, left alignment -->
+      <div style="display: flex; flex-direction: column; gap: 0.25rem;">
+        <span style="font-size: 0.75rem; color: #64748b;">white / left</span>
+        <ftl-holster node="1033:4560" style="display: inline-block; background: #333a45;">
           <rr-label-cell color="white" horizontal-alignment="left">Label cell</rr-label-cell>
+        </ftl-holster>
+      </div>
+
+      <!-- White color, right alignment -->
+      <div style="display: flex; flex-direction: column; gap: 0.25rem;">
+        <span style="font-size: 0.75rem; color: #64748b;">white / right</span>
+        <ftl-holster node="1033:4567" style="display: inline-block; background: #333a45;">
           <rr-label-cell color="white" horizontal-alignment="right">Label cell</rr-label-cell>
-        </div>
-      </ftl-holster>
+        </ftl-holster>
+      </div>
+
       <p style="font-size: 0.75rem; color: #64748b; margin-top: 0.5rem;">
         Keyboard: T (toggle) | O (overlay) | S (side-by-side)
       </p>

--- a/src/components/label-cell/rr-label-cell.stories.js
+++ b/src/components/label-cell/rr-label-cell.stories.js
@@ -75,13 +75,11 @@ export const FigmaComparison = () => html`
           - 4 variants: 2 colors (default/white) x 2 h-align (left/right)
         -->
         <div style="width: 308px; background: #333a45; padding: 16px; box-sizing: border-box; display: flex; flex-direction: column; gap: 16px;">
-          <!-- White color variants (visible on dark background) -->
-          <rr-label-cell color="white" horizontal-alignment="left">Label cell</rr-label-cell>
-          <rr-label-cell color="white" horizontal-alignment="right">Label cell</rr-label-cell>
-
-          <!-- Default color variants (darker text, less visible on dark bg) -->
+          <!-- Figma order: default/left, default/right, white/left, white/right -->
           <rr-label-cell color="default" horizontal-alignment="left">Label cell</rr-label-cell>
           <rr-label-cell color="default" horizontal-alignment="right">Label cell</rr-label-cell>
+          <rr-label-cell color="white" horizontal-alignment="left">Label cell</rr-label-cell>
+          <rr-label-cell color="white" horizontal-alignment="right">Label cell</rr-label-cell>
         </div>
       </ftl-holster>
       <p style="font-size: 0.75rem; color: #64748b; margin-top: 0.5rem;">

--- a/src/components/label-cell/rr-label-cell.ts
+++ b/src/components/label-cell/rr-label-cell.ts
@@ -1,0 +1,105 @@
+/**
+ * RegelRecht Label Cell Component (Lit + TypeScript)
+ *
+ * A cell component for displaying labels in lists with configurable alignment and color.
+ *
+ * @element rr-label-cell
+ * @attr {string} color - Text color variant: 'default' | 'white' (default: 'default')
+ * @attr {string} horizontal-alignment - Horizontal alignment: 'left' | 'right' (default: 'left')
+ *
+ * @slot - Default slot for label text content
+ *
+ * @csspart label - The label text container
+ */
+
+import { LitElement, html, css } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+
+type Color = 'default' | 'white';
+type HorizontalAlignment = 'left' | 'right';
+
+@customElement('rr-label-cell')
+export class RRLabelCell extends LitElement {
+  static override styles = css`
+    :host {
+      display: flex;
+      flex-direction: column;
+      font-family: var(--rr-font-family-sans, 'RijksoverheidSans', system-ui, sans-serif);
+    }
+
+    :host([hidden]) {
+      display: none;
+    }
+
+    .label-cell__inner {
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+    }
+
+    .label-cell__label {
+      display: flex;
+      flex-direction: column;
+    }
+
+    .label-cell__text {
+      margin: 0;
+      font-weight: var(--primitives-font-weight-body-regular, 400);
+      font-size: var(--primitives-font-size-body-m, 18px);
+      line-height: 1.25;
+    }
+
+    /* Horizontal alignment: left (default) */
+    :host([horizontal-alignment="left"]) .label-cell__text,
+    :host(:not([horizontal-alignment])) .label-cell__text {
+      text-align: left;
+    }
+
+    /* Horizontal alignment: right */
+    :host([horizontal-alignment="right"]) .label-cell__text {
+      text-align: right;
+    }
+
+    /* Color: Default */
+    :host([color="default"]) .label-cell__text,
+    :host(:not([color])) .label-cell__text {
+      color: var(--semantics-content-color, #333a45);
+    }
+
+    /* Color: White */
+    :host([color="white"]) .label-cell__text {
+      color: var(--semantics-content-white-color, #ffffff);
+    }
+
+    /* Accessibility: High Contrast Mode */
+    @media (forced-colors: active) {
+      .label-cell__text {
+        forced-color-adjust: none;
+      }
+    }
+  `;
+
+  @property({ type: String, reflect: true })
+  color: Color = 'default';
+
+  @property({ type: String, reflect: true, attribute: 'horizontal-alignment' })
+  horizontalAlignment: HorizontalAlignment = 'left';
+
+  override render() {
+    return html`
+      <div class="label-cell__inner">
+        <div class="label-cell__label" part="label">
+          <span class="label-cell__text">
+            <slot></slot>
+          </span>
+        </div>
+      </div>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'rr-label-cell': RRLabelCell;
+  }
+}

--- a/src/components/label-cell/rr-label-cell.ts
+++ b/src/components/label-cell/rr-label-cell.ts
@@ -60,15 +60,15 @@ export class RRLabelCell extends LitElement {
       text-align: right;
     }
 
-    /* Color: Default */
+    /* Color: Default (#333A45 per Figma) */
     :host([color="default"]) .label-cell__text,
     :host(:not([color])) .label-cell__text {
-      color: var(--semantics-content-color, #333a45);
+      color: var(--components-label-cell-default-color, #333a45);
     }
 
-    /* Color: White */
+    /* Color: White (#FFFFFF per Figma) */
     :host([color="white"]) .label-cell__text {
-      color: var(--semantics-content-white-color, #ffffff);
+      color: var(--components-label-cell-white-color, #ffffff);
     }
 
     /* Accessibility: High Contrast Mode */

--- a/src/components/label-cell/rr-label-cell.ts
+++ b/src/components/label-cell/rr-label-cell.ts
@@ -43,6 +43,8 @@ export class RRLabelCell extends LitElement {
     }
 
     .label-cell__text {
+      display: block;
+      width: 100%;
       margin: 0;
       font-weight: var(--primitives-font-weight-body-regular, 400);
       font-size: var(--primitives-font-size-body-m, 18px);

--- a/src/components/label-cell/rr-label-cell.ts
+++ b/src/components/label-cell/rr-label-cell.ts
@@ -22,7 +22,10 @@ type HorizontalAlignment = 'left' | 'right';
 export class RRLabelCell extends LitElement {
   static override styles = css`
     :host {
-      display: block;
+      display: flex;
+      flex-direction: column;
+      justify-content: center; /* Match Figma's label-cell__inner justifyContent: center */
+      height: 100%; /* Fill container height so centering works */
       font-family: var(--rr-font-family-sans, 'RijksoverheidSans', system-ui, sans-serif);
     }
 

--- a/src/components/label-cell/rr-label-cell.ts
+++ b/src/components/label-cell/rr-label-cell.ts
@@ -22,8 +22,7 @@ type HorizontalAlignment = 'left' | 'right';
 export class RRLabelCell extends LitElement {
   static override styles = css`
     :host {
-      display: flex;
-      flex-direction: column;
+      display: block;
       font-family: var(--rr-font-family-sans, 'RijksoverheidSans', system-ui, sans-serif);
     }
 
@@ -31,24 +30,13 @@ export class RRLabelCell extends LitElement {
       display: none;
     }
 
-    .label-cell__inner {
-      display: flex;
-      flex-direction: column;
-      justify-content: center;
-    }
-
-    .label-cell__label {
-      display: flex;
-      flex-direction: column;
-    }
-
     .label-cell__text {
       display: block;
-      width: 100%;
       margin: 0;
+      padding: 0;
       font-weight: var(--primitives-font-weight-body-regular, 400);
       font-size: var(--primitives-font-size-body-m, 18px);
-      line-height: 1.25;
+      line-height: 22px; /* Figma: 1.25em = 22.5px, using 22px for tighter match */
     }
 
     /* Horizontal alignment: left (default) */
@@ -88,15 +76,7 @@ export class RRLabelCell extends LitElement {
   horizontalAlignment: HorizontalAlignment = 'left';
 
   override render() {
-    return html`
-      <div class="label-cell__inner">
-        <div class="label-cell__label" part="label">
-          <span class="label-cell__text">
-            <slot></slot>
-          </span>
-        </div>
-      </div>
-    `;
+    return html`<span class="label-cell__text" part="label"><slot></slot></span>`;
   }
 }
 

--- a/src/components/label-cell/rr-label-cell.ts
+++ b/src/components/label-cell/rr-label-cell.ts
@@ -36,7 +36,7 @@ export class RRLabelCell extends LitElement {
       padding: 0;
       font-weight: var(--primitives-font-weight-body-regular, 400);
       font-size: var(--primitives-font-size-body-m, 18px);
-      line-height: 22px; /* Figma: 1.25em = 22.5px, using 22px for tighter match */
+      line-height: 1.25; /* Figma: 1.25em = 22.5px */
     }
 
     /* Horizontal alignment: left (default) */

--- a/src/components/list/rr-list-item.stories.js
+++ b/src/components/list/rr-list-item.stories.js
@@ -1,0 +1,132 @@
+import { html } from 'lit';
+import './rr-list-item.js';
+import '../title-cell/rr-title-cell.js';
+import '../label-cell/rr-label-cell.js';
+
+export default {
+  title: 'Components/List Item',
+  component: 'rr-list-item',
+  tags: ['autodocs'],
+  parameters: {
+    design: {
+      type: 'figma',
+      url: 'https://www.figma.com/design/5DyHMXUNVxbgH7ZjhQxPZe/RR-Components?node-id=957-2279',
+    },
+  },
+  argTypes: {
+    size: {
+      control: 'select',
+      options: ['sm', 'md'],
+      description: 'Size of the list item',
+    },
+    selected: {
+      control: 'boolean',
+      description: 'Whether the item is selected',
+    },
+  },
+};
+
+export const Default = {
+  args: {
+    size: 'md',
+    selected: false,
+  },
+  render: (args) => html`
+    <rr-list-item
+      size=${args.size}
+      ?selected=${args.selected}
+      style="width: 300px;"
+    >
+      <rr-title-cell .color=${args.selected ? 'white' : 'default'}>List item content</rr-title-cell>
+    </rr-list-item>
+  `,
+};
+
+export const SizeMD = {
+  render: () => html`
+    <rr-list-item size="md" style="width: 300px; border: 1px dashed #ccc;">
+      <rr-title-cell>Medium size item</rr-title-cell>
+    </rr-list-item>
+  `,
+};
+
+export const SizeSM = {
+  render: () => html`
+    <rr-list-item size="sm" style="width: 300px; border: 1px dashed #ccc;">
+      <rr-title-cell size="sm">Small size item</rr-title-cell>
+    </rr-list-item>
+  `,
+};
+
+export const Selected = {
+  render: () => html`
+    <div style="display: flex; flex-direction: column; gap: 16px;">
+      <rr-list-item style="width: 300px;">
+        <rr-title-cell>Not selected</rr-title-cell>
+      </rr-list-item>
+      <rr-list-item selected style="width: 300px;">
+        <rr-title-cell color="white">Selected item</rr-title-cell>
+      </rr-list-item>
+    </div>
+  `,
+};
+
+export const WithStartAndEndSlots = {
+  render: () => html`
+    <rr-list-item style="width: 400px; border: 1px dashed #ccc;">
+      <div slot="start" style="width: 40px; height: 40px; background: #e0e0e0; border-radius: 8px;"></div>
+      <rr-title-cell>Item with start and end content</rr-title-cell>
+      <div slot="end" style="padding: 0 8px; color: #666;">→</div>
+    </rr-list-item>
+  `,
+};
+
+// Figma Comparison
+const FIGMA_TOKEN = import.meta.env.STORYBOOK_FIGMA_TOKEN || '';
+const FIGMA_FILE_ID = '5DyHMXUNVxbgH7ZjhQxPZe';
+
+export const FigmaComparison = () => html`
+  <ftl-belt access-token="${FIGMA_TOKEN}" file-id="${FIGMA_FILE_ID}">
+    <div style="display: flex; flex-direction: column; gap: 1rem;">
+      <p style="font-size: 0.875rem; color: #64748b; margin: 0;">
+        Our list items (Code) vs Figma design. Use Toggle/Overlay/Side-by-Side to compare.
+      </p>
+      <ftl-holster node="957:2279" style="display: inline-block;">
+        <!--
+          Figma list__item (957:2279) component set:
+          - Layout: column, gap: 16px, padding: 16px
+          - Fixed width: 449px
+          - 4 variants: size (md/sm) x is-selected (true/false)
+          - MD: 12px vertical padding, SM: 8px vertical padding
+        -->
+        <div style="width: 449px; background: #ffffff; padding: 16px; box-sizing: border-box; display: flex; flex-direction: column; gap: 16px;">
+          <!-- md, not selected -->
+          <rr-list-item size="md">
+            <div style="background: rgba(255, 36, 189, 0.1); border: 2px solid #FF24BD; padding: 2px 8px; text-align: center; color: #FF24BD; font-weight: 700; font-size: 18px; line-height: 1.125; width: 100%; box-sizing: border-box;">SLOT</div>
+          </rr-list-item>
+
+          <!-- md, selected -->
+          <rr-list-item size="md" selected>
+            <div style="background: rgba(255, 36, 189, 0.1); border: 2px solid #FF24BD; padding: 2px 8px; text-align: center; color: #FF24BD; font-weight: 700; font-size: 18px; line-height: 1.125; width: 100%; box-sizing: border-box;">SLOT</div>
+          </rr-list-item>
+
+          <!-- sm, not selected -->
+          <rr-list-item size="sm">
+            <div style="background: rgba(255, 36, 189, 0.1); border: 2px solid #FF24BD; padding: 2px 8px; text-align: center; color: #FF24BD; font-weight: 700; font-size: 18px; line-height: 1.125; width: 100%; box-sizing: border-box;">SLOT</div>
+          </rr-list-item>
+
+          <!-- sm, selected -->
+          <rr-list-item size="sm" selected>
+            <div style="background: rgba(255, 36, 189, 0.1); border: 2px solid #FF24BD; padding: 2px 8px; text-align: center; color: #FF24BD; font-weight: 700; font-size: 18px; line-height: 1.125; width: 100%; box-sizing: border-box;">SLOT</div>
+          </rr-list-item>
+        </div>
+      </ftl-holster>
+      <p style="font-size: 0.75rem; color: #64748b; margin-top: 0.5rem;">
+        Keyboard: T (toggle) | O (overlay) | S (side-by-side)
+      </p>
+    </div>
+  </ftl-belt>
+`;
+FigmaComparison.storyName = '🎨 Figma Comparison';
+FigmaComparison.tags = ['!autodocs', 'figma'];
+FigmaComparison.parameters = { controls: { disable: true } };

--- a/src/components/list/rr-list-item.ts
+++ b/src/components/list/rr-list-item.ts
@@ -1,0 +1,170 @@
+/**
+ * RegelRecht List Item Component (Lit + TypeScript)
+ *
+ * An item component for use within rr-list, with optional selection state.
+ *
+ * @element rr-list-item
+ * @attr {string} size - Item size: 'sm' | 'md' (default: 'md')
+ * @attr {boolean} selected - Whether the item is selected
+ *
+ * @slot - Default slot for main content (cells)
+ * @slot start - Slot for content at the start of the item
+ * @slot end - Slot for content at the end of the item
+ *
+ * @csspart item - The list item container
+ * @csspart start-area - The start slot area
+ * @csspart main-area - The main content area
+ * @csspart end-area - The end slot area
+ * @csspart indicator - The selection indicator
+ */
+
+import { LitElement, html, css } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+
+type Size = 'sm' | 'md';
+
+@customElement('rr-list-item')
+export class RRListItem extends LitElement {
+  static override styles = css`
+    :host {
+      display: flex;
+      flex-direction: row;
+      align-items: center;
+      position: relative;
+    }
+
+    :host([hidden]) {
+      display: none;
+    }
+
+    /* Selection indicator */
+    .list-item__indicator {
+      display: none;
+      position: absolute;
+      left: -10px;
+      top: 0;
+      bottom: 0;
+      right: -10px;
+      background-color: var(--semantics-buttons-accent-filled-background-color, #274e81);
+      border-radius: 8px;
+      z-index: 0;
+    }
+
+    :host([selected]) .list-item__indicator {
+      display: block;
+    }
+
+    /* Areas */
+    .list-item__start-area,
+    .list-item__end-area {
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      align-self: stretch;
+      flex-shrink: 0;
+      position: relative;
+      z-index: 1;
+    }
+
+    .list-item__main-area {
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      align-self: stretch;
+      flex: 1;
+      min-width: 0;
+      position: relative;
+      z-index: 1;
+    }
+
+    /* Size: MD (default) - 12px vertical padding */
+    :host([size="md"]) .list-item__start-area,
+    :host([size="md"]) .list-item__end-area,
+    :host(:not([size])) .list-item__start-area,
+    :host(:not([size])) .list-item__end-area {
+      padding: 12px 0;
+    }
+
+    :host([size="md"]) .list-item__main-area,
+    :host(:not([size])) .list-item__main-area {
+      padding: 12px 0;
+    }
+
+    /* Size: SM - 8px vertical padding */
+    :host([size="sm"]) .list-item__start-area,
+    :host([size="sm"]) .list-item__end-area {
+      padding: 8px 0;
+    }
+
+    :host([size="sm"]) .list-item__main-area {
+      padding: 8px 0;
+    }
+
+    /* Divider - appears at bottom of main area */
+    .list-item__divider {
+      display: var(--_list-item-divider-display, block);
+      position: absolute;
+      bottom: 0;
+      left: 0;
+      right: 0;
+      height: 1px;
+      background-color: var(--semantics-divider-color, #d9dee4);
+    }
+
+    /* Hide divider when selected */
+    :host([selected]) .list-item__divider {
+      display: none;
+    }
+
+    /* Spacer sizing - 16px default */
+    .list-item__spacer {
+      width: 16px;
+      height: 16px;
+      flex-shrink: 0;
+    }
+
+    /* Slotted content colors when selected */
+    :host([selected]) {
+      --semantics-content-color: #ffffff;
+      color: #ffffff;
+    }
+
+    /* Accessibility: focus state */
+    :host(:focus-visible) {
+      outline: var(--semantics-focus-ring-thickness, 2px) solid var(--semantics-focus-ring-color, #0f172a);
+      outline-offset: 2px;
+    }
+  `;
+
+  @property({ type: String, reflect: true })
+  size: Size = 'md';
+
+  @property({ type: Boolean, reflect: true })
+  selected = false;
+
+  override render() {
+    return html`
+      <div class="list-item__indicator" part="indicator"></div>
+      <div class="list-item__start-area" part="start-area">
+        <slot name="start">
+          <div class="list-item__spacer"></div>
+        </slot>
+      </div>
+      <div class="list-item__main-area" part="main-area">
+        <slot></slot>
+        <div class="list-item__divider"></div>
+      </div>
+      <div class="list-item__end-area" part="end-area">
+        <slot name="end">
+          <div class="list-item__spacer"></div>
+        </slot>
+      </div>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'rr-list-item': RRListItem;
+  }
+}

--- a/src/components/list/rr-list-item.ts
+++ b/src/components/list/rr-list-item.ts
@@ -42,9 +42,10 @@ export class RRListItem extends LitElement {
       display: none;
       position: absolute;
       left: -10px;
-      top: 0;
-      bottom: 0;
       right: -10px;
+      top: 50%;
+      transform: translateY(-50%);
+      height: 48px; /* MD size */
       background-color: var(--semantics-buttons-accent-filled-background-color, #274e81);
       border-radius: 8px;
       z-index: 0;
@@ -52,6 +53,11 @@ export class RRListItem extends LitElement {
 
     :host([selected]) .list-item__indicator {
       display: block;
+    }
+
+    /* SM size indicator height */
+    :host([size="sm"]) .list-item__indicator {
+      height: 40px;
     }
 
     /* Areas */

--- a/src/components/list/rr-list.stories.js
+++ b/src/components/list/rr-list.stories.js
@@ -1,0 +1,194 @@
+import { html } from 'lit';
+import './rr-list.js';
+import './rr-list-item.js';
+import '../title-cell/rr-title-cell.js';
+import '../label-cell/rr-label-cell.js';
+
+export default {
+  title: 'Components/List',
+  component: 'rr-list',
+  tags: ['autodocs'],
+  parameters: {
+    design: {
+      type: 'figma',
+      url: 'https://www.figma.com/design/5DyHMXUNVxbgH7ZjhQxPZe/RR-Components?node-id=1044-2275',
+    },
+  },
+  argTypes: {
+    variant: {
+      control: 'select',
+      options: ['simple', 'box', 'box-on-tint'],
+      description: 'Visual style of the list',
+    },
+  },
+};
+
+export const Default = {
+  args: {
+    variant: 'simple',
+  },
+  render: (args) => html`
+    <rr-list variant=${args.variant} style="width: 300px;">
+      <rr-list-item>
+        <rr-title-cell>Item 1</rr-title-cell>
+      </rr-list-item>
+      <rr-list-item>
+        <rr-title-cell>Item 2</rr-title-cell>
+      </rr-list-item>
+      <rr-list-item>
+        <rr-title-cell>Item 3</rr-title-cell>
+      </rr-list-item>
+    </rr-list>
+  `,
+};
+
+export const VariantSimple = {
+  render: () => html`
+    <rr-list variant="simple" style="width: 300px;">
+      <rr-list-item>
+        <rr-title-cell>Simple list item 1</rr-title-cell>
+      </rr-list-item>
+      <rr-list-item>
+        <rr-title-cell>Simple list item 2</rr-title-cell>
+      </rr-list-item>
+      <rr-list-item>
+        <rr-title-cell>Simple list item 3</rr-title-cell>
+      </rr-list-item>
+    </rr-list>
+  `,
+};
+
+export const VariantBox = {
+  render: () => html`
+    <rr-list variant="box" style="width: 300px;">
+      <rr-list-item>
+        <rr-title-cell>Box list item 1</rr-title-cell>
+      </rr-list-item>
+      <rr-list-item>
+        <rr-title-cell>Box list item 2</rr-title-cell>
+      </rr-list-item>
+      <rr-list-item>
+        <rr-title-cell>Box list item 3</rr-title-cell>
+      </rr-list-item>
+    </rr-list>
+  `,
+};
+
+export const VariantBoxOnTint = {
+  render: () => html`
+    <div style="background: #f1f5f9; padding: 24px;">
+      <rr-list variant="box-on-tint" style="width: 300px;">
+        <rr-list-item>
+          <rr-title-cell>Box-on-tint item 1</rr-title-cell>
+        </rr-list-item>
+        <rr-list-item>
+          <rr-title-cell>Box-on-tint item 2</rr-title-cell>
+        </rr-list-item>
+        <rr-list-item>
+          <rr-title-cell>Box-on-tint item 3</rr-title-cell>
+        </rr-list-item>
+      </rr-list>
+    </div>
+  `,
+};
+
+export const WithSelection = {
+  render: () => html`
+    <rr-list variant="simple" style="width: 300px;">
+      <rr-list-item>
+        <rr-title-cell>Not selected</rr-title-cell>
+      </rr-list-item>
+      <rr-list-item selected>
+        <rr-title-cell color="white">Selected item</rr-title-cell>
+      </rr-list-item>
+      <rr-list-item>
+        <rr-title-cell>Not selected</rr-title-cell>
+      </rr-list-item>
+    </rr-list>
+  `,
+};
+
+export const SizeSmall = {
+  render: () => html`
+    <rr-list variant="simple" style="width: 300px;">
+      <rr-list-item size="sm">
+        <rr-title-cell size="sm">Small item 1</rr-title-cell>
+      </rr-list-item>
+      <rr-list-item size="sm">
+        <rr-title-cell size="sm">Small item 2</rr-title-cell>
+      </rr-list-item>
+      <rr-list-item size="sm">
+        <rr-title-cell size="sm">Small item 3</rr-title-cell>
+      </rr-list-item>
+    </rr-list>
+  `,
+};
+
+export const WithTitleAndLabel = {
+  render: () => html`
+    <rr-list variant="box" style="width: 300px;">
+      <rr-list-item>
+        <div style="display: flex; flex-direction: column; gap: 4px; width: 100%;">
+          <rr-title-cell>Primary title</rr-title-cell>
+          <rr-label-cell>Secondary label text</rr-label-cell>
+        </div>
+      </rr-list-item>
+      <rr-list-item>
+        <div style="display: flex; flex-direction: column; gap: 4px; width: 100%;">
+          <rr-title-cell>Another title</rr-title-cell>
+          <rr-label-cell>More description here</rr-label-cell>
+        </div>
+      </rr-list-item>
+    </rr-list>
+  `,
+};
+
+// Figma Comparison
+const FIGMA_TOKEN = import.meta.env.STORYBOOK_FIGMA_TOKEN || '';
+const FIGMA_FILE_ID = '5DyHMXUNVxbgH7ZjhQxPZe';
+
+export const FigmaComparison = () => html`
+  <ftl-belt access-token="${FIGMA_TOKEN}" file-id="${FIGMA_FILE_ID}">
+    <div style="display: flex; flex-direction: column; gap: 1rem;">
+      <p style="font-size: 0.875rem; color: #64748b; margin: 0;">
+        Our lists (Code) vs Figma design. Use Toggle/Overlay/Side-by-Side to compare.
+      </p>
+      <ftl-holster node="1044:2275" style="display: inline-block;">
+        <!--
+          Figma list (1044:2275) component set:
+          - Layout: column, gap: 16px, padding: 16px
+          - Fixed width: 272px
+          - 3 variants: simple, box, box-on-tint
+        -->
+        <div style="width: 272px; background: #ffffff; padding: 16px; box-sizing: border-box; display: flex; flex-direction: column; gap: 16px;">
+          <!-- simple variant -->
+          <rr-list variant="simple">
+            <rr-list-item>
+              <div style="background: rgba(255, 36, 189, 0.1); border: 2px solid #FF24BD; padding: 2px 8px; text-align: center; color: #FF24BD; font-weight: 700; font-size: 18px; line-height: 1.125; width: 100%; box-sizing: border-box;">SLOT</div>
+            </rr-list-item>
+          </rr-list>
+
+          <!-- box variant -->
+          <rr-list variant="box">
+            <rr-list-item>
+              <div style="background: rgba(255, 36, 189, 0.1); border: 2px solid #FF24BD; padding: 2px 8px; text-align: center; color: #FF24BD; font-weight: 700; font-size: 18px; line-height: 1.125; width: 100%; box-sizing: border-box;">SLOT</div>
+            </rr-list-item>
+          </rr-list>
+
+          <!-- box-on-tint variant -->
+          <rr-list variant="box-on-tint">
+            <rr-list-item>
+              <div style="background: rgba(255, 36, 189, 0.1); border: 2px solid #FF24BD; padding: 2px 8px; text-align: center; color: #FF24BD; font-weight: 700; font-size: 18px; line-height: 1.125; width: 100%; box-sizing: border-box;">SLOT</div>
+            </rr-list-item>
+          </rr-list>
+        </div>
+      </ftl-holster>
+      <p style="font-size: 0.75rem; color: #64748b; margin-top: 0.5rem;">
+        Keyboard: T (toggle) | O (overlay) | S (side-by-side)
+      </p>
+    </div>
+  </ftl-belt>
+`;
+FigmaComparison.storyName = '🎨 Figma Comparison';
+FigmaComparison.tags = ['!autodocs', 'figma'];
+FigmaComparison.parameters = { controls: { disable: true } };

--- a/src/components/list/rr-list.stories.js
+++ b/src/components/list/rr-list.stories.js
@@ -158,12 +158,12 @@ export const FigmaComparison = () => html`
           Figma list (1044:2275) component set:
           - Layout: column, gap: 16px, padding: 16px
           - Fixed width: 272px
-          - 3 variants: simple, box, box-on-tint
+          - Shows: selected item, box variant, box-on-tint variant
         -->
         <div style="width: 272px; background: #ffffff; padding: 16px; box-sizing: border-box; display: flex; flex-direction: column; gap: 16px;">
-          <!-- simple variant -->
+          <!-- selected item (matches Figma first row) -->
           <rr-list variant="simple">
-            <rr-list-item>
+            <rr-list-item selected>
               <div style="background: rgba(255, 36, 189, 0.1); border: 2px solid #FF24BD; padding: 2px 8px; text-align: center; color: #FF24BD; font-weight: 700; font-size: 18px; line-height: 1.125; width: 100%; box-sizing: border-box;">SLOT</div>
             </rr-list-item>
           </rr-list>

--- a/src/components/list/rr-list.stories.js
+++ b/src/components/list/rr-list.stories.js
@@ -158,28 +158,29 @@ export const FigmaComparison = () => html`
           Figma list (1044:2275) component set:
           - Layout: column, gap: 16px, padding: 16px
           - Fixed width: 272px
-          - Shows: selected item, box variant, box-on-tint variant
+          - Shows: simple (with top border), box variant, box-on-tint variant
+          - Figma shows slot directly in list__main without list-item wrapper
         -->
         <div style="width: 272px; background: #ffffff; padding: 16px; box-sizing: border-box; display: flex; flex-direction: column; gap: 16px;">
-          <!-- selected item (matches Figma first row) -->
+          <!-- simple variant - slot directly in list with top border -->
           <rr-list variant="simple">
-            <rr-list-item selected>
-              <div style="background: rgba(255, 36, 189, 0.1); border: 2px solid #FF24BD; padding: 2px 8px; text-align: center; color: #FF24BD; font-weight: 700; font-size: 18px; line-height: 1.125; width: 100%; box-sizing: border-box;">SLOT</div>
-            </rr-list-item>
+            <div style="display: flex; flex-direction: column; justify-content: center; align-items: center; padding: 2px 8px; background: rgba(255, 36, 189, 0.1); border: 2px solid #FF24BD; box-sizing: border-box;">
+              <span style="color: #FF24BD; font-weight: 700; font-size: 18px; line-height: 1.125; text-align: center; width: 100%;">SLOT</span>
+            </div>
           </rr-list>
 
           <!-- box variant -->
           <rr-list variant="box">
-            <rr-list-item>
-              <div style="background: rgba(255, 36, 189, 0.1); border: 2px solid #FF24BD; padding: 2px 8px; text-align: center; color: #FF24BD; font-weight: 700; font-size: 18px; line-height: 1.125; width: 100%; box-sizing: border-box;">SLOT</div>
-            </rr-list-item>
+            <div style="display: flex; flex-direction: column; justify-content: center; align-items: center; padding: 2px 8px; background: rgba(255, 36, 189, 0.1); border: 2px solid #FF24BD; box-sizing: border-box;">
+              <span style="color: #FF24BD; font-weight: 700; font-size: 18px; line-height: 1.125; text-align: center; width: 100%;">SLOT</span>
+            </div>
           </rr-list>
 
           <!-- box-on-tint variant -->
           <rr-list variant="box-on-tint">
-            <rr-list-item>
-              <div style="background: rgba(255, 36, 189, 0.1); border: 2px solid #FF24BD; padding: 2px 8px; text-align: center; color: #FF24BD; font-weight: 700; font-size: 18px; line-height: 1.125; width: 100%; box-sizing: border-box;">SLOT</div>
-            </rr-list-item>
+            <div style="display: flex; flex-direction: column; justify-content: center; align-items: center; padding: 2px 8px; background: rgba(255, 36, 189, 0.1); border: 2px solid #FF24BD; box-sizing: border-box;">
+              <span style="color: #FF24BD; font-weight: 700; font-size: 18px; line-height: 1.125; text-align: center; width: 100%;">SLOT</span>
+            </div>
           </rr-list>
         </div>
       </ftl-holster>

--- a/src/components/list/rr-list.stories.js
+++ b/src/components/list/rr-list.stories.js
@@ -151,39 +151,45 @@ export const FigmaComparison = () => html`
   <ftl-belt access-token="${FIGMA_TOKEN}" file-id="${FIGMA_FILE_ID}">
     <div style="display: flex; flex-direction: column; gap: 1rem;">
       <p style="font-size: 0.875rem; color: #64748b; margin: 0;">
-        Our lists (Code) vs Figma design. Use Toggle/Overlay/Side-by-Side to compare.
+        Individual variant comparisons (Code vs Figma). Use Toggle/Overlay/Side-by-Side to compare.
       </p>
-      <ftl-holster node="1044:2275" style="display: inline-block;">
-        <!--
-          Figma list (1044:2275) component set:
-          - Layout: column, gap: 16px, padding: 16px
-          - Fixed width: 272px
-          - Shows: simple (with top border), box variant, box-on-tint variant
-          - Figma shows slot directly in list__main without list-item wrapper
-        -->
-        <div style="width: 272px; background: #ffffff; padding: 16px; box-sizing: border-box; display: flex; flex-direction: column; gap: 16px;">
-          <!-- simple variant - slot directly in list with top border -->
+
+      <!-- style=simple -->
+      <div style="display: flex; flex-direction: column; gap: 0.25rem;">
+        <span style="font-size: 0.75rem; color: #64748b;">style: simple</span>
+        <ftl-holster node="1044:2273" style="display: inline-block;">
           <rr-list variant="simple">
             <div style="display: flex; flex-direction: column; justify-content: center; align-items: center; padding: 2px 8px; background: rgba(255, 36, 189, 0.1); border: 2px solid #FF24BD; box-sizing: border-box;">
               <span style="color: #FF24BD; font-weight: 700; font-size: 18px; line-height: 1.125; text-align: center; width: 100%;">SLOT</span>
             </div>
           </rr-list>
+        </ftl-holster>
+      </div>
 
-          <!-- box variant -->
+      <!-- style=box -->
+      <div style="display: flex; flex-direction: column; gap: 0.25rem;">
+        <span style="font-size: 0.75rem; color: #64748b;">style: box</span>
+        <ftl-holster node="1044:2276" style="display: inline-block;">
           <rr-list variant="box">
             <div style="display: flex; flex-direction: column; justify-content: center; align-items: center; padding: 2px 8px; background: rgba(255, 36, 189, 0.1); border: 2px solid #FF24BD; box-sizing: border-box;">
               <span style="color: #FF24BD; font-weight: 700; font-size: 18px; line-height: 1.125; text-align: center; width: 100%;">SLOT</span>
             </div>
           </rr-list>
+        </ftl-holster>
+      </div>
 
-          <!-- box-on-tint variant -->
+      <!-- style=box-on-tint -->
+      <div style="display: flex; flex-direction: column; gap: 0.25rem;">
+        <span style="font-size: 0.75rem; color: #64748b;">style: box-on-tint</span>
+        <ftl-holster node="1045:2284" style="display: inline-block;">
           <rr-list variant="box-on-tint">
             <div style="display: flex; flex-direction: column; justify-content: center; align-items: center; padding: 2px 8px; background: rgba(255, 36, 189, 0.1); border: 2px solid #FF24BD; box-sizing: border-box;">
               <span style="color: #FF24BD; font-weight: 700; font-size: 18px; line-height: 1.125; text-align: center; width: 100%;">SLOT</span>
             </div>
           </rr-list>
-        </div>
-      </ftl-holster>
+        </ftl-holster>
+      </div>
+
       <p style="font-size: 0.75rem; color: #64748b; margin-top: 0.5rem;">
         Keyboard: T (toggle) | O (overlay) | S (side-by-side)
       </p>

--- a/src/components/list/rr-list.ts
+++ b/src/components/list/rr-list.ts
@@ -1,0 +1,80 @@
+/**
+ * RegelRecht List Component (Lit + TypeScript)
+ *
+ * A container component for displaying list items with optional styling.
+ *
+ * @element rr-list
+ * @attr {string} variant - List style variant: 'simple' | 'box' | 'box-on-tint' (default: 'simple')
+ *
+ * @slot - Default slot for list items (rr-list-item)
+ *
+ * @csspart list - The list container
+ * @csspart main - The main content area
+ */
+
+import { LitElement, html, css } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+
+type Variant = 'simple' | 'box' | 'box-on-tint';
+
+@customElement('rr-list')
+export class RRList extends LitElement {
+  static override styles = css`
+    :host {
+      display: flex;
+      flex-direction: column;
+    }
+
+    :host([hidden]) {
+      display: none;
+    }
+
+    .list__main {
+      display: flex;
+      flex-direction: column;
+    }
+
+    /* Variant: simple (default) - just a vertical stack with top border */
+    :host([variant="simple"]) .list__main,
+    :host(:not([variant])) .list__main {
+      border-top: 1px solid var(--semantics-divider-color, #d9dee4);
+    }
+
+    /* Variant: box - rounded background with padding */
+    :host([variant="box"]) .list__main {
+      background-color: var(--semantics-views-tinted-background-color, #f5f6f9);
+      border-radius: 12px;
+      gap: 8px;
+    }
+
+    /* Variant: box-on-tint - white background on tinted surface */
+    :host([variant="box-on-tint"]) .list__main {
+      background-color: var(--semantics-views-background-color, #ffffff);
+      border-radius: 12px;
+      gap: 8px;
+    }
+
+    /* Hide first item's divider in box variants */
+    :host([variant="box"]) ::slotted(rr-list-item:first-child),
+    :host([variant="box-on-tint"]) ::slotted(rr-list-item:first-child) {
+      --_list-item-divider-display: none;
+    }
+  `;
+
+  @property({ type: String, reflect: true })
+  variant: Variant = 'simple';
+
+  override render() {
+    return html`
+      <div class="list__main" part="main" role="list">
+        <slot></slot>
+      </div>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'rr-list': RRList;
+  }
+}

--- a/src/components/title-cell/rr-title-cell.stories.js
+++ b/src/components/title-cell/rr-title-cell.stories.js
@@ -1,0 +1,136 @@
+import { html } from 'lit';
+import './rr-title-cell.js';
+
+export default {
+  title: 'Components/Title Cell',
+  component: 'rr-title-cell',
+  tags: ['autodocs'],
+  parameters: {
+    design: {
+      type: 'figma',
+      url: 'https://www.figma.com/design/5DyHMXUNVxbgH7ZjhQxPZe/RR-Components?node-id=236-41079',
+    },
+  },
+  argTypes: {
+    size: {
+      control: 'select',
+      options: ['sm', 'md'],
+      description: 'Size of the title cell',
+    },
+    color: {
+      control: 'select',
+      options: ['default', 'white'],
+      description: 'Color variant of the title text',
+    },
+    horizontalAlignment: {
+      control: 'select',
+      options: ['left', 'right'],
+      description: 'Horizontal alignment of the title',
+    },
+    verticalAlignment: {
+      control: 'select',
+      options: ['top', 'center'],
+      description: 'Vertical alignment of the title',
+    },
+  },
+};
+
+export const Default = {
+  args: {
+    size: 'md',
+    color: 'default',
+    horizontalAlignment: 'left',
+    verticalAlignment: 'center',
+  },
+  render: (args) => html`
+    <rr-title-cell
+      size=${args.size}
+      color=${args.color}
+      horizontal-alignment=${args.horizontalAlignment}
+      vertical-alignment=${args.verticalAlignment}
+    >
+      Title cell
+    </rr-title-cell>
+  `,
+};
+
+export const SizeMD = {
+  args: { size: 'md' },
+  render: (args) => html`<rr-title-cell size=${args.size}>Title cell (MD)</rr-title-cell>`,
+};
+
+export const SizeSM = {
+  args: { size: 'sm' },
+  render: (args) => html`<rr-title-cell size=${args.size}>Title cell (SM)</rr-title-cell>`,
+};
+
+export const AlignmentRight = {
+  render: () => html`
+    <rr-title-cell horizontal-alignment="right" style="width: 200px; border: 1px dashed #ccc;">
+      Title cell
+    </rr-title-cell>
+  `,
+};
+
+export const ColorWhite = {
+  render: () => html`
+    <div style="background: #154273; padding: 16px;">
+      <rr-title-cell color="white">Title cell (White)</rr-title-cell>
+    </div>
+  `,
+};
+
+// Figma Comparison
+const FIGMA_TOKEN = import.meta.env.STORYBOOK_FIGMA_TOKEN || '';
+const FIGMA_FILE_ID = '5DyHMXUNVxbgH7ZjhQxPZe';
+
+export const FigmaComparison = () => html`
+  <ftl-belt access-token="${FIGMA_TOKEN}" file-id="${FIGMA_FILE_ID}">
+    <div style="display: flex; flex-direction: column; gap: 1rem;">
+      <p style="font-size: 0.875rem; color: #64748b; margin: 0;">
+        Our title cells (Code) vs Figma design. Use Toggle/Overlay/Side-by-Side to compare.
+      </p>
+      <ftl-holster node="236:41079" style="display: inline-block;">
+        <!--
+          Figma title-cell (236:41079) component set:
+          - Layout: column, gap: 16px, padding: 16px
+          - Fixed width: 308px
+          - 16 variants: 2 sizes (md/sm) x 2 colors (default/white) x 2 h-align x 2 v-align
+          - MD height: ~23px, SM height: ~20px per variant
+        -->
+        <div style="width: 308px; background: #ffffff; padding: 16px; box-sizing: border-box; display: flex; flex-direction: column; gap: 16px;">
+          <!-- MD, default color variants -->
+          <rr-title-cell size="md" vertical-alignment="center" horizontal-alignment="left">Title cell</rr-title-cell>
+          <rr-title-cell size="md" vertical-alignment="center" horizontal-alignment="right">Title cell</rr-title-cell>
+          <rr-title-cell size="md" vertical-alignment="top" horizontal-alignment="left">Title cell</rr-title-cell>
+          <rr-title-cell size="md" vertical-alignment="top" horizontal-alignment="right">Title cell</rr-title-cell>
+
+          <!-- SM, default color variants -->
+          <rr-title-cell size="sm" vertical-alignment="center" horizontal-alignment="left">Title cell</rr-title-cell>
+          <rr-title-cell size="sm" vertical-alignment="center" horizontal-alignment="right">Title cell</rr-title-cell>
+          <rr-title-cell size="sm" vertical-alignment="top" horizontal-alignment="left">Title cell</rr-title-cell>
+          <rr-title-cell size="sm" vertical-alignment="top" horizontal-alignment="right">Title cell</rr-title-cell>
+
+          <!-- MD, white color variants (no background in Figma - white text on transparent) -->
+          <rr-title-cell size="md" color="white" vertical-alignment="center" horizontal-alignment="left">Title cell</rr-title-cell>
+          <rr-title-cell size="md" color="white" vertical-alignment="center" horizontal-alignment="right">Title cell</rr-title-cell>
+          <rr-title-cell size="md" color="white" vertical-alignment="top" horizontal-alignment="left">Title cell</rr-title-cell>
+          <rr-title-cell size="md" color="white" vertical-alignment="top" horizontal-alignment="right">Title cell</rr-title-cell>
+
+          <!-- SM, white color variants -->
+          <rr-title-cell size="sm" color="white" vertical-alignment="center" horizontal-alignment="left">Title cell</rr-title-cell>
+          <rr-title-cell size="sm" color="white" vertical-alignment="center" horizontal-alignment="right">Title cell</rr-title-cell>
+          <rr-title-cell size="sm" color="white" vertical-alignment="top" horizontal-alignment="left">Title cell</rr-title-cell>
+          <rr-title-cell size="sm" color="white" vertical-alignment="top" horizontal-alignment="right">Title cell</rr-title-cell>
+          </div>
+        </div>
+      </ftl-holster>
+      <p style="font-size: 0.75rem; color: #64748b; margin-top: 0.5rem;">
+        Keyboard: T (toggle) | O (overlay) | S (side-by-side)
+      </p>
+    </div>
+  </ftl-belt>
+`;
+FigmaComparison.storyName = '🎨 Figma Comparison';
+FigmaComparison.tags = ['!autodocs', 'figma'];
+FigmaComparison.parameters = { controls: { disable: true } };

--- a/src/components/title-cell/rr-title-cell.ts
+++ b/src/components/title-cell/rr-title-cell.ts
@@ -1,0 +1,133 @@
+/**
+ * RegelRecht Title Cell Component (Lit + TypeScript)
+ *
+ * A cell component for displaying titles in lists with configurable alignment and size.
+ *
+ * @element rr-title-cell
+ * @attr {string} size - Cell size: 'sm' | 'md' (default: 'md')
+ * @attr {string} color - Text color variant: 'default' | 'white' (default: 'default')
+ * @attr {string} horizontal-alignment - Horizontal alignment: 'left' | 'right' (default: 'left')
+ * @attr {string} vertical-alignment - Vertical alignment: 'top' | 'center' (default: 'center')
+ *
+ * @slot - Default slot for title text content
+ *
+ * @csspart title - The title text container
+ */
+
+import { LitElement, html, css } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+
+type Size = 'sm' | 'md';
+type Color = 'default' | 'white';
+type HorizontalAlignment = 'left' | 'right';
+type VerticalAlignment = 'top' | 'center';
+
+@customElement('rr-title-cell')
+export class RRTitleCell extends LitElement {
+  static override styles = css`
+    :host {
+      display: flex;
+      flex-direction: column;
+      font-family: var(--rr-font-family-sans, 'RijksoverheidSans', system-ui, sans-serif);
+    }
+
+    :host([hidden]) {
+      display: none;
+    }
+
+    /* Vertical alignment */
+    :host([vertical-alignment="center"]),
+    :host(:not([vertical-alignment])) {
+      justify-content: center;
+    }
+
+    :host([vertical-alignment="top"]) {
+      justify-content: flex-start;
+    }
+
+    /* Horizontal alignment */
+    :host([horizontal-alignment="left"]),
+    :host(:not([horizontal-alignment])) {
+      align-items: flex-start;
+    }
+
+    :host([horizontal-alignment="right"]) {
+      align-items: flex-end;
+    }
+
+    .title-cell__title {
+      display: flex;
+      flex-direction: row;
+      gap: 8px;
+      width: 100%;
+    }
+
+    /* Text alignment based on horizontal-alignment */
+    :host([horizontal-alignment="right"]) .title-cell__title {
+      justify-content: flex-end;
+    }
+
+    .title-cell__text {
+      margin: 0;
+      font-weight: var(--primitives-font-weight-body-medium, 550);
+      line-height: 1.25;
+    }
+
+    /* Size: MD (default) - 18px font */
+    :host([size="md"]) .title-cell__text,
+    :host(:not([size])) .title-cell__text {
+      font-size: var(--primitives-font-size-body-m, 18px);
+    }
+
+    /* Size: SM - 16px font */
+    :host([size="sm"]) .title-cell__text {
+      font-size: var(--primitives-font-size-body-s, 16px);
+    }
+
+    /* Color: Default */
+    :host([color="default"]) .title-cell__text,
+    :host(:not([color])) .title-cell__text {
+      color: var(--semantics-content-color, #333a45);
+    }
+
+    /* Color: White */
+    :host([color="white"]) .title-cell__text {
+      color: var(--semantics-content-white-color, #ffffff);
+    }
+
+    /* Accessibility: High Contrast Mode */
+    @media (forced-colors: active) {
+      .title-cell__text {
+        forced-color-adjust: none;
+      }
+    }
+  `;
+
+  @property({ type: String, reflect: true })
+  size: Size = 'md';
+
+  @property({ type: String, reflect: true })
+  color: Color = 'default';
+
+  @property({ type: String, reflect: true, attribute: 'horizontal-alignment' })
+  horizontalAlignment: HorizontalAlignment = 'left';
+
+  @property({ type: String, reflect: true, attribute: 'vertical-alignment' })
+  verticalAlignment: VerticalAlignment = 'center';
+
+  override render() {
+    return html`
+      <div class="title-cell__title" part="title">
+        <span class="title-cell__text">
+          <slot></slot>
+        </span>
+      </div>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'rr-title-cell': RRTitleCell;
+  }
+}


### PR DESCRIPTION
## Summary

Adds new Lit + TypeScript cell and list components:
- `rr-label-cell`: Label text with color and alignment variants
- `rr-custom-cell`: Container for custom content with vertical alignment
- `rr-list`: List container with simple, box, and box-on-tint variants
- `rr-list-item`: List item with selection state and size variants

## Screenshots

### Label Cell

| Side-by-Side | Overlay |
|--------------|---------|
| ![side-by-side](https://0x0.st/PqoM.png) | ![overlay](https://0x0.st/Pqo2.png) |

### Custom Cell

| Side-by-Side | Overlay |
|--------------|---------|
| ![side-by-side](https://0x0.st/PqNE.png) | ![overlay](https://0x0.st/PqNw.png) |

### List

| Side-by-Side | Overlay |
|--------------|---------|
| ![side-by-side](https://0x0.st/PqzJ.png) | ![overlay](https://0x0.st/Pqzy.png) |

---

## How to Verify

1. Check the Side-by-Side screenshots to see Code (bottom) vs Figma (top)
2. Check the Overlay screenshots to see alignment at 50% opacity
3. Minor subpixel differences in anti-aliasing are expected