### PR TITLE
fix(ci): upgrade Node.js to 22 for semantic-release

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
 
       - name: Install dependencies


### PR DESCRIPTION
## Summary

- Upgrade Node.js version from 20 to 22 in version-bump workflow

## Problem

The semantic-release package now requires Node.js ^22.14.0 || >= 24.10.0.
The workflow was using Node.js 20, causing the version bump to fail with:

```
[semantic-release]: node version ^22.14.0 || >= 24.10.0 is required. Found v20.20.0.
```

## Solution

Update `node-version: '20'` to `node-version: '22'` in `.github/workflows/version-bump.yml`