### PR TITLE
revert: reset version to 0.1.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@minbzk/storybook",
-  "version": "1.0.0",
+  "version": "0.1.11",
   "description": "Design System voor RegelRecht - Nederlandse Overheid",
   "type": "module",
   "main": "dist/components/rr-components.js",


### PR DESCRIPTION
## Summary

Reset package.json version from 1.0.0 back to 0.1.11.

## What happened

Semantic-release bumped to 1.0.0 because there were no existing version tags. It treated this as a first release.

## Fix applied

1. ✅ Deleted `v1.0.0` tag
2. ✅ Created `v0.1.11` tag at commit 56c3195 (before auto-versioning was added)
3. ⬅️ This PR: Reset package.json to 0.1.11

After merge, future commits will bump correctly:
- `feat:` → 0.2.0
- `fix:` → 0.1.12