### PR TITLE
feat(tokens): migrate to new Figma token naming convention

### DIFF
--- a/src/components/base/base-component.js
+++ b/src/components/base/base-component.js
@@ -110,7 +110,7 @@ const ACCESSIBILITY_CSS = `
   }
 
   :focus-visible {
-    outline: var(--semantics-focus-ring-thickness, 2px) solid var(--semantics-focus-ring-color, #0f172a);
+    outline: var(--semantics-focus-rings-center-thickness, 2px) solid var(--semantics-focus-rings-center-color, #0f172a);
     outline-offset: 2px;
   }
 `;

--- a/src/components/base/base-component.js
+++ b/src/components/base/base-component.js
@@ -110,7 +110,7 @@ const ACCESSIBILITY_CSS = `
   }
 
   :focus-visible {
-    outline: var(--semantics-focus-rings-center-thickness, 2px) solid var(--semantics-focus-rings-center-color, #0f172a);
+    outline: var(--semantics-focus-rings-center-thickness) solid var(--semantics-focus-rings-center-color);
     outline-offset: 2px;
   }
 `;

--- a/src/components/box/rr-box.js
+++ b/src/components/box/rr-box.js
@@ -64,9 +64,9 @@ export class RRBox extends RRBaseComponent {
 
       .container {
         /* Use component tokens with custom property overrides */
-        background-color: var(--rr-box-background-color, var(--components-box-background-color, #f1f5f9));
-        border-radius: var(--rr-box-corner-radius, var(--_border-radius, var(--components-box-corner-radius, 11px)));
-        padding: var(--rr-box-padding, var(--_padding, var(--components-box-padding, 16px)));
+        background-color: var(--rr-box-background-color, var(--components-box-background-color));
+        border-radius: var(--rr-box-corner-radius, var(--_border-radius, var(--components-box-corner-radius)));
+        padding: var(--rr-box-padding, var(--_padding, var(--components-box-padding)));
 
         /* Allow content to flow naturally */
         box-sizing: border-box;

--- a/src/components/button/rr-button.stories.js
+++ b/src/components/button/rr-button.stories.js
@@ -636,12 +636,12 @@ export const FigmaComparison = () => html`
       </p>
       <ftl-holster node="20-27" style="display: inline-block;">
         <!--
-          Figma component set (20:27) is 832x436px with absolute positioned buttons.
+          Figma component set (20:27) is 832x376px with absolute positioned buttons.
           Columns: x=16, 179, 342, 478, 624, 760
-          Rows: y=16/76/136/196/256/316/376 (M), +6 for S, +10 for XS (vertical centering)
-          Row order: neutral-tinted, neutral-transparent, accent-filled, accent-tinted, accent-outlined, accent-transparent, danger-tinted
+          Rows: y=16/76/136/196/256/316 (M), +6 for S, +10 for XS (vertical centering)
+          Row order: neutral-tinted, neutral-transparent, accent-filled, accent-outlined, accent-transparent, danger-tinted
         -->
-        <div style="position: relative; width: 832px; height: 436px; background: #ffffff;">
+        <div style="position: relative; width: 832px; height: 376px; background: #ffffff;">
           <!-- Row 1: neutral-tinted (y=16/22/26) -->
           <rr-button variant="neutral-tinted" size="m" style="position: absolute; left: 16px; top: 16px;">Button</rr-button>
           <rr-button variant="neutral-tinted" size="m" disabled style="position: absolute; left: 179px; top: 16px;">Button</rr-button>
@@ -666,37 +666,29 @@ export const FigmaComparison = () => html`
           <rr-button variant="accent-filled" size="xs" style="position: absolute; left: 624px; top: 146px;">Button</rr-button>
           <rr-button variant="accent-filled" size="xs" disabled style="position: absolute; left: 760px; top: 146px;">Button</rr-button>
 
-          <!-- Row 4: accent-tinted (y=196/202/206) -->
-          <rr-button variant="accent-tinted" size="m" style="position: absolute; left: 16px; top: 196px;">Button</rr-button>
-          <rr-button variant="accent-tinted" size="m" disabled style="position: absolute; left: 179px; top: 196px;">Button</rr-button>
-          <rr-button variant="accent-tinted" size="s" style="position: absolute; left: 342px; top: 202px;">Button</rr-button>
-          <rr-button variant="accent-tinted" size="s" disabled style="position: absolute; left: 478px; top: 202px;">Button</rr-button>
-          <rr-button variant="accent-tinted" size="xs" style="position: absolute; left: 624px; top: 206px;">Button</rr-button>
-          <rr-button variant="accent-tinted" size="xs" disabled style="position: absolute; left: 760px; top: 206px;">Button</rr-button>
+          <!-- Row 4: accent-outlined (y=196/202/206) -->
+          <rr-button variant="accent-outlined" size="m" style="position: absolute; left: 16px; top: 196px;">Button</rr-button>
+          <rr-button variant="accent-outlined" size="m" disabled style="position: absolute; left: 179px; top: 196px;">Button</rr-button>
+          <rr-button variant="accent-outlined" size="s" style="position: absolute; left: 342px; top: 202px;">Button</rr-button>
+          <rr-button variant="accent-outlined" size="s" disabled style="position: absolute; left: 478px; top: 202px;">Button</rr-button>
+          <rr-button variant="accent-outlined" size="xs" style="position: absolute; left: 624px; top: 206px;">Button</rr-button>
+          <rr-button variant="accent-outlined" size="xs" disabled style="position: absolute; left: 760px; top: 206px;">Button</rr-button>
 
-          <!-- Row 5: accent-outlined (y=256/262/266) -->
-          <rr-button variant="accent-outlined" size="m" style="position: absolute; left: 16px; top: 256px;">Button</rr-button>
-          <rr-button variant="accent-outlined" size="m" disabled style="position: absolute; left: 179px; top: 256px;">Button</rr-button>
-          <rr-button variant="accent-outlined" size="s" style="position: absolute; left: 342px; top: 262px;">Button</rr-button>
-          <rr-button variant="accent-outlined" size="s" disabled style="position: absolute; left: 478px; top: 262px;">Button</rr-button>
-          <rr-button variant="accent-outlined" size="xs" style="position: absolute; left: 624px; top: 266px;">Button</rr-button>
-          <rr-button variant="accent-outlined" size="xs" disabled style="position: absolute; left: 760px; top: 266px;">Button</rr-button>
+          <!-- Row 5: accent-transparent (y=256/262/266) -->
+          <rr-button variant="accent-transparent" size="m" style="position: absolute; left: 16px; top: 256px;">Button</rr-button>
+          <rr-button variant="accent-transparent" size="m" disabled style="position: absolute; left: 179px; top: 256px;">Button</rr-button>
+          <rr-button variant="accent-transparent" size="s" style="position: absolute; left: 342px; top: 262px;">Button</rr-button>
+          <rr-button variant="accent-transparent" size="s" disabled style="position: absolute; left: 478px; top: 262px;">Button</rr-button>
+          <rr-button variant="accent-transparent" size="xs" style="position: absolute; left: 624px; top: 266px;">Button</rr-button>
+          <rr-button variant="accent-transparent" size="xs" disabled style="position: absolute; left: 760px; top: 266px;">Button</rr-button>
 
-          <!-- Row 6: accent-transparent (y=316/322/326) -->
-          <rr-button variant="accent-transparent" size="m" style="position: absolute; left: 16px; top: 316px;">Button</rr-button>
-          <rr-button variant="accent-transparent" size="m" disabled style="position: absolute; left: 179px; top: 316px;">Button</rr-button>
-          <rr-button variant="accent-transparent" size="s" style="position: absolute; left: 342px; top: 322px;">Button</rr-button>
-          <rr-button variant="accent-transparent" size="s" disabled style="position: absolute; left: 478px; top: 322px;">Button</rr-button>
-          <rr-button variant="accent-transparent" size="xs" style="position: absolute; left: 624px; top: 326px;">Button</rr-button>
-          <rr-button variant="accent-transparent" size="xs" disabled style="position: absolute; left: 760px; top: 326px;">Button</rr-button>
-
-          <!-- Row 7: danger-tinted (y=376/382/386) -->
-          <rr-button variant="danger-tinted" size="m" style="position: absolute; left: 16px; top: 376px;">Button</rr-button>
-          <rr-button variant="danger-tinted" size="m" disabled style="position: absolute; left: 179px; top: 376px;">Button</rr-button>
-          <rr-button variant="danger-tinted" size="s" style="position: absolute; left: 342px; top: 382px;">Button</rr-button>
-          <rr-button variant="danger-tinted" size="s" disabled style="position: absolute; left: 478px; top: 382px;">Button</rr-button>
-          <rr-button variant="danger-tinted" size="xs" style="position: absolute; left: 624px; top: 386px;">Button</rr-button>
-          <rr-button variant="danger-tinted" size="xs" disabled style="position: absolute; left: 760px; top: 386px;">Button</rr-button>
+          <!-- Row 6: danger-tinted (y=316/322/326) -->
+          <rr-button variant="danger-tinted" size="m" style="position: absolute; left: 16px; top: 316px;">Button</rr-button>
+          <rr-button variant="danger-tinted" size="m" disabled style="position: absolute; left: 179px; top: 316px;">Button</rr-button>
+          <rr-button variant="danger-tinted" size="s" style="position: absolute; left: 342px; top: 322px;">Button</rr-button>
+          <rr-button variant="danger-tinted" size="s" disabled style="position: absolute; left: 478px; top: 322px;">Button</rr-button>
+          <rr-button variant="danger-tinted" size="xs" style="position: absolute; left: 624px; top: 326px;">Button</rr-button>
+          <rr-button variant="danger-tinted" size="xs" disabled style="position: absolute; left: 760px; top: 326px;">Button</rr-button>
         </div>
       </ftl-holster>
       <p style="font-size: 0.75rem; color: #64748b; margin-top: 0.5rem;">

--- a/src/components/button/rr-button.ts
+++ b/src/components/button/rr-button.ts
@@ -60,7 +60,7 @@ export class RRButton extends LitElement {
       justify-content: center;
 
       /* Typography */
-      font-weight: var(--semantics-buttons-font-weight);
+      /* font-weight is included in font shorthand token */
       text-decoration: none;
 
       /* Animation */
@@ -81,28 +81,28 @@ export class RRButton extends LitElement {
       min-height: var(--semantics-controls-xs-min-size);
       /* Figma: padding 4px 6px (top/bottom 4, left/right 6) */
       padding: var(--primitives-space-4) var(--primitives-space-6);
-      font: var(--components-button-xs-font);
+      font: var(--semantics-buttons-xs-font);
       border-radius: var(--semantics-controls-xs-corner-radius);
       gap: var(--primitives-space-2);
     }
 
     /* Size: S */
     :host([size="s"]) .button {
-      min-height: var(--semantics-controls-s-min-size);
+      min-height: var(--semantics-controls-sm-min-size);
       /* Figma: padding 6px 8px (top/bottom 6, left/right 8) */
       padding: var(--primitives-space-6) var(--primitives-space-8);
-      font: var(--components-button-s-font);
-      border-radius: var(--semantics-controls-s-corner-radius);
+      font: var(--semantics-buttons-sm-font);
+      border-radius: var(--semantics-controls-sm-corner-radius);
       gap: var(--primitives-space-2);
     }
 
     /* Size: M (default) */
     :host([size="m"]) .button,
     :host(:not([size])) .button {
-      min-height: var(--semantics-controls-m-min-size);
+      min-height: var(--semantics-controls-md-min-size);
       padding: var(--primitives-space-12);
-      font: var(--components-button-m-font);
-      border-radius: var(--semantics-controls-m-corner-radius);
+      font: var(--semantics-buttons-md-font);
+      border-radius: var(--semantics-controls-md-corner-radius);
       gap: var(--primitives-space-4);
     }
 
@@ -110,7 +110,7 @@ export class RRButton extends LitElement {
     :host([variant="accent-filled"]) .button,
     :host(:not([variant])) .button {
       --_bg-color: var(--semantics-buttons-accent-filled-background-color);
-      --_text-color: var(--semantics-buttons-accent-filled-color);
+      --_text-color: var(--semantics-buttons-accent-filled-content-color);
     }
 
     :host([variant="accent-filled"]) .button:hover,
@@ -121,7 +121,7 @@ export class RRButton extends LitElement {
     /* Variant: accent-outlined - uses outline instead of border to avoid layout impact */
     :host([variant="accent-outlined"]) .button {
       --_bg-color: transparent;
-      --_text-color: var(--semantics-buttons-accent-outlined-color);
+      --_text-color: var(--semantics-buttons-accent-outlined-content-color);
       /* Don't use border variables - use outline instead */
       --_border-color: transparent;
       --_border-width: 0;
@@ -131,28 +131,28 @@ export class RRButton extends LitElement {
     }
 
     :host([variant="accent-outlined"]) .button:hover {
-      --_bg-color: var(--primitives-color-accent-15);
+      --_bg-color: var(--primitives-color-accent-150);
     }
 
     :host([variant="accent-outlined"]) .button:focus-visible {
-      outline: var(--semantics-focus-ring-thickness) solid var(--semantics-focus-ring-color);
+      outline: var(--semantics-focus-rings-center-thickness) solid var(--semantics-focus-rings-center-color);
       outline-offset: 2px;
     }
 
     /* Variant: accent-tinted */
     :host([variant="accent-tinted"]) .button {
       --_bg-color: var(--semantics-buttons-accent-tinted-background-color);
-      --_text-color: var(--semantics-buttons-accent-tinted-color);
+      --_text-color: var(--semantics-buttons-accent-tinted-content-color);
     }
 
     :host([variant="accent-tinted"]) .button:hover {
-      --_bg-color: var(--primitives-color-accent-30);
+      --_bg-color: var(--primitives-color-accent-300);
     }
 
     /* Variant: neutral-tinted */
     :host([variant="neutral-tinted"]) .button {
       --_bg-color: var(--semantics-buttons-neutral-tinted-background-color);
-      --_text-color: var(--semantics-buttons-neutral-tinted-color);
+      --_text-color: var(--semantics-buttons-neutral-tinted-content-color);
     }
 
     :host([variant="neutral-tinted"]) .button:hover {
@@ -162,17 +162,17 @@ export class RRButton extends LitElement {
     /* Variant: accent-transparent */
     :host([variant="accent-transparent"]) .button {
       --_bg-color: transparent;
-      --_text-color: var(--semantics-buttons-accent-transparent-color);
+      --_text-color: var(--semantics-buttons-accent-transparent-content-color);
     }
 
     :host([variant="accent-transparent"]) .button:hover {
-      --_bg-color: var(--primitives-color-accent-15);
+      --_bg-color: var(--primitives-color-accent-150);
     }
 
     /* Variant: neutral-transparent */
     :host([variant="neutral-transparent"]) .button {
       --_bg-color: transparent;
-      --_text-color: var(--semantics-buttons-neutral-tinted-color);
+      --_text-color: var(--semantics-buttons-neutral-tinted-content-color);
     }
 
     :host([variant="neutral-transparent"]) .button:hover {
@@ -181,17 +181,17 @@ export class RRButton extends LitElement {
 
     /* Variant: danger-tinted */
     :host([variant="danger-tinted"]) .button {
-      --_bg-color: var(--primitives-color-danger-15);
+      --_bg-color: var(--primitives-color-danger-150);
       --_text-color: var(--primitives-color-danger-100);
     }
 
     :host([variant="danger-tinted"]) .button:hover {
-      --_bg-color: var(--primitives-color-danger-30);
+      --_bg-color: var(--primitives-color-danger-300);
     }
 
     /* Focus state */
     .button:focus-visible {
-      outline: var(--semantics-focus-ring-thickness) solid var(--semantics-focus-ring-color);
+      outline: var(--semantics-focus-rings-center-thickness) solid var(--semantics-focus-rings-center-color);
       outline-offset: 2px;
     }
 

--- a/src/components/checkbox/rr-checkbox.ts
+++ b/src/components/checkbox/rr-checkbox.ts
@@ -90,9 +90,9 @@ export class RRCheckbox extends LitElement {
 
     /* Size: S (32px) */
     :host([size='s']) .box {
-      width: var(--semantics-controls-s-min-size);
-      height: var(--semantics-controls-s-min-size);
-      border-radius: var(--semantics-controls-s-corner-radius);
+      width: var(--semantics-controls-sm-min-size);
+      height: var(--semantics-controls-sm-min-size);
+      border-radius: var(--semantics-controls-sm-corner-radius);
     }
 
     :host([size='s']) .icon {
@@ -103,9 +103,9 @@ export class RRCheckbox extends LitElement {
     /* Size: M (44px - default) */
     :host([size='m']) .box,
     :host(:not([size])) .box {
-      width: var(--semantics-controls-m-min-size);
-      height: var(--semantics-controls-m-min-size);
-      border-radius: var(--semantics-controls-m-corner-radius);
+      width: var(--semantics-controls-md-min-size);
+      height: var(--semantics-controls-md-min-size);
+      border-radius: var(--semantics-controls-md-corner-radius);
     }
 
     :host([size='m']) .icon,
@@ -155,7 +155,7 @@ export class RRCheckbox extends LitElement {
     }
 
     :host(:focus-visible) .box {
-      outline: var(--semantics-focus-ring-thickness) solid var(--semantics-focus-ring-color);
+      outline: var(--semantics-focus-rings-center-thickness) solid var(--semantics-focus-rings-center-color);
       outline-offset: 2px;
     }
 

--- a/src/components/divider/rr-divider.ts
+++ b/src/components/divider/rr-divider.ts
@@ -25,19 +25,19 @@ export class RRDivider extends LitElement {
     }
 
     .divider {
-      background-color: var(--semantics-divider-color);
+      background-color: var(--semantics-dividers-color);
     }
 
     /* Horizontal orientation (default) */
     :host([orientation='horizontal']) .divider,
     :host(:not([orientation])) .divider {
       width: 100%;
-      height: var(--semantics-divider-thickness);
+      height: var(--semantics-dividers-thickness);
     }
 
     /* Vertical orientation */
     :host([orientation='vertical']) .divider {
-      width: var(--semantics-divider-thickness);
+      width: var(--semantics-dividers-thickness);
       height: 100%;
     }
 

--- a/src/components/icon-button/rr-icon-button.js
+++ b/src/components/icon-button/rr-icon-button.js
@@ -146,95 +146,95 @@ export class RRIconButton extends RRBaseComponent {
 
       /* Size: XS - Square 24x24 */
       :host([size="xs"]) .button {
-        width: var(--semantics-controls-xs-min-size, 24px);
-        height: var(--semantics-controls-xs-min-size, 24px);
-        min-width: var(--semantics-controls-xs-min-size, 24px);
-        min-height: var(--semantics-controls-xs-min-size, 24px);
-        border-radius: var(--semantics-controls-xs-corner-radius, 3px);
+        width: var(--semantics-controls-xs-min-size);
+        height: var(--semantics-controls-xs-min-size);
+        min-width: var(--semantics-controls-xs-min-size);
+        min-height: var(--semantics-controls-xs-min-size);
+        border-radius: var(--semantics-controls-xs-corner-radius);
       }
 
       /* Size: S - Square 32x32 */
       :host([size="s"]) .button {
-        width: var(--semantics-controls-sm-min-size, 32px);
-        height: var(--semantics-controls-sm-min-size, 32px);
-        min-width: var(--semantics-controls-sm-min-size, 32px);
-        min-height: var(--semantics-controls-sm-min-size, 32px);
-        border-radius: var(--semantics-controls-sm-corner-radius, 5px);
+        width: var(--semantics-controls-sm-min-size);
+        height: var(--semantics-controls-sm-min-size);
+        min-width: var(--semantics-controls-sm-min-size);
+        min-height: var(--semantics-controls-sm-min-size);
+        border-radius: var(--semantics-controls-sm-corner-radius);
       }
 
       /* Size: M - Square 44x44 (default) */
       :host([size="m"]) .button,
       :host(:not([size])) .button {
-        width: var(--semantics-controls-md-min-size, 44px);
-        height: var(--semantics-controls-md-min-size, 44px);
-        min-width: var(--semantics-controls-md-min-size, 44px);
-        min-height: var(--semantics-controls-md-min-size, 44px);
-        border-radius: var(--semantics-controls-md-corner-radius, 7px);
+        width: var(--semantics-controls-md-min-size);
+        height: var(--semantics-controls-md-min-size);
+        min-width: var(--semantics-controls-md-min-size);
+        min-height: var(--semantics-controls-md-min-size);
+        border-radius: var(--semantics-controls-md-corner-radius);
       }
 
       /* Variant: accent-filled (default) */
       :host([variant="accent-filled"]) .button,
       :host(:not([variant])) .button {
-        --_bg-color: var(--semantics-buttons-accent-filled-background-color, #154273);
-        --_text-color: var(--semantics-buttons-accent-filled-content-color, #ffffff);
+        --_bg-color: var(--semantics-buttons-accent-filled-background-color);
+        --_text-color: var(--semantics-buttons-accent-filled-content-color);
       }
 
       :host([variant="accent-filled"]) .button:hover,
       :host(:not([variant])) .button:hover {
-        --_bg-color: var(--primitives-color-accent-75, #4F7196);
+        --_bg-color: var(--primitives-color-accent-75);
       }
 
       /* Variant: accent-outlined */
       :host([variant="accent-outlined"]) .button {
         --_bg-color: transparent;
-        --_text-color: var(--semantics-buttons-accent-outlined-content-color, #154273);
-        --_border-color: var(--semantics-buttons-accent-outlined-border-color, #154273);
-        --_border-width: var(--semantics-buttons-accent-outlined-border-thickness, 2px);
+        --_text-color: var(--semantics-buttons-accent-outlined-content-color);
+        --_border-color: var(--semantics-buttons-accent-outlined-border-color);
+        --_border-width: var(--semantics-buttons-accent-outlined-border-thickness);
       }
 
       :host([variant="accent-outlined"]) .button:hover {
-        --_bg-color: var(--primitives-color-accent-150, #DCE3EA);
+        --_bg-color: var(--primitives-color-accent-150);
       }
 
       /* Variant: accent-tinted */
       :host([variant="accent-tinted"]) .button {
-        --_bg-color: var(--semantics-buttons-accent-tinted-background-color, #dce3ea);
-        --_text-color: var(--semantics-buttons-accent-tinted-content-color, #154273);
+        --_bg-color: var(--semantics-buttons-accent-tinted-background-color);
+        --_text-color: var(--semantics-buttons-accent-tinted-content-color);
       }
 
       :host([variant="accent-tinted"]) .button:hover {
-        --_bg-color: var(--primitives-color-accent-300, #B9C7D5);
+        --_bg-color: var(--primitives-color-accent-300);
       }
 
       /* Variant: neutral-tinted */
       :host([variant="neutral-tinted"]) .button {
-        --_bg-color: var(--semantics-buttons-neutral-tinted-background-color, #d8dee7);
-        --_text-color: var(--semantics-buttons-neutral-tinted-content-color, #1f252d);
+        --_bg-color: var(--semantics-buttons-neutral-tinted-background-color);
+        --_text-color: var(--semantics-buttons-neutral-tinted-content-color);
       }
 
       :host([variant="neutral-tinted"]) .button:hover {
-        --_bg-color: var(--primitives-color-neutral-300, #cbd5e1);
+        --_bg-color: var(--primitives-color-neutral-300);
       }
 
       /* Variant: accent-transparent */
       :host([variant="accent-transparent"]) .button {
         --_bg-color: transparent;
-        --_text-color: var(--semantics-buttons-accent-transparent-content-color, #154273);
+        --_text-color: var(--semantics-buttons-accent-transparent-content-color);
       }
 
       :host([variant="accent-transparent"]) .button:hover {
-        --_bg-color: var(--primitives-color-accent-150, #DCE3EA);
+        --_bg-color: var(--primitives-color-accent-150);
       }
 
       /* Focus state */
       .button:focus-visible {
-        outline: var(--semantics-focus-rings-center-thickness, 2px) solid var(--semantics-focus-rings-center-color, #0f172a);
+        outline: var(--semantics-focus-rings-center-thickness) solid var(--semantics-focus-rings-center-color);
         outline-offset: 2px;
       }
 
       /* Disabled state */
       :host([disabled]) .button {
-        opacity: calc(var(--primitives-opacity-disabled, 38) / 100);
+        opacity: calc(var(--primitives-opacity-disabled) / 100);
         cursor: not-allowed;
         pointer-events: none;
       }

--- a/src/components/icon-button/rr-icon-button.js
+++ b/src/components/icon-button/rr-icon-button.js
@@ -128,8 +128,8 @@ export class RRIconButton extends RRBaseComponent {
         align-items: center;
         justify-content: center;
 
-        /* Typography */
-        font: var(--components-icon-button-font, 550 14px/1.125 RijksSansVF, system-ui);
+        /* Typography - icon buttons have no text, font inherited for sizing context */
+        font: var(--semantics-buttons-md-font);
 
         /* Animation */
         transition: background-color 0.15s ease, color 0.15s ease, border-color 0.15s ease, transform 0.1s ease;
@@ -155,28 +155,28 @@ export class RRIconButton extends RRBaseComponent {
 
       /* Size: S - Square 32x32 */
       :host([size="s"]) .button {
-        width: var(--semantics-controls-s-min-size, 32px);
-        height: var(--semantics-controls-s-min-size, 32px);
-        min-width: var(--semantics-controls-s-min-size, 32px);
-        min-height: var(--semantics-controls-s-min-size, 32px);
-        border-radius: var(--semantics-controls-s-corner-radius, 5px);
+        width: var(--semantics-controls-sm-min-size, 32px);
+        height: var(--semantics-controls-sm-min-size, 32px);
+        min-width: var(--semantics-controls-sm-min-size, 32px);
+        min-height: var(--semantics-controls-sm-min-size, 32px);
+        border-radius: var(--semantics-controls-sm-corner-radius, 5px);
       }
 
       /* Size: M - Square 44x44 (default) */
       :host([size="m"]) .button,
       :host(:not([size])) .button {
-        width: var(--semantics-controls-m-min-size, 44px);
-        height: var(--semantics-controls-m-min-size, 44px);
-        min-width: var(--semantics-controls-m-min-size, 44px);
-        min-height: var(--semantics-controls-m-min-size, 44px);
-        border-radius: var(--semantics-controls-m-corner-radius, 7px);
+        width: var(--semantics-controls-md-min-size, 44px);
+        height: var(--semantics-controls-md-min-size, 44px);
+        min-width: var(--semantics-controls-md-min-size, 44px);
+        min-height: var(--semantics-controls-md-min-size, 44px);
+        border-radius: var(--semantics-controls-md-corner-radius, 7px);
       }
 
       /* Variant: accent-filled (default) */
       :host([variant="accent-filled"]) .button,
       :host(:not([variant])) .button {
         --_bg-color: var(--semantics-buttons-accent-filled-background-color, #154273);
-        --_text-color: var(--semantics-buttons-accent-filled-color, #ffffff);
+        --_text-color: var(--semantics-buttons-accent-filled-content-color, #ffffff);
       }
 
       :host([variant="accent-filled"]) .button:hover,
@@ -187,29 +187,29 @@ export class RRIconButton extends RRBaseComponent {
       /* Variant: accent-outlined */
       :host([variant="accent-outlined"]) .button {
         --_bg-color: transparent;
-        --_text-color: var(--semantics-buttons-accent-outlined-color, #154273);
+        --_text-color: var(--semantics-buttons-accent-outlined-content-color, #154273);
         --_border-color: var(--semantics-buttons-accent-outlined-border-color, #154273);
         --_border-width: var(--semantics-buttons-accent-outlined-border-thickness, 2px);
       }
 
       :host([variant="accent-outlined"]) .button:hover {
-        --_bg-color: var(--primitives-color-accent-15, #DCE3EA);
+        --_bg-color: var(--primitives-color-accent-150, #DCE3EA);
       }
 
       /* Variant: accent-tinted */
       :host([variant="accent-tinted"]) .button {
         --_bg-color: var(--semantics-buttons-accent-tinted-background-color, #dce3ea);
-        --_text-color: var(--semantics-buttons-accent-tinted-color, #154273);
+        --_text-color: var(--semantics-buttons-accent-tinted-content-color, #154273);
       }
 
       :host([variant="accent-tinted"]) .button:hover {
-        --_bg-color: var(--primitives-color-accent-30, #B9C7D5);
+        --_bg-color: var(--primitives-color-accent-300, #B9C7D5);
       }
 
       /* Variant: neutral-tinted */
       :host([variant="neutral-tinted"]) .button {
         --_bg-color: var(--semantics-buttons-neutral-tinted-background-color, #d8dee7);
-        --_text-color: var(--semantics-buttons-neutral-tinted-color, #1f252d);
+        --_text-color: var(--semantics-buttons-neutral-tinted-content-color, #1f252d);
       }
 
       :host([variant="neutral-tinted"]) .button:hover {
@@ -219,16 +219,16 @@ export class RRIconButton extends RRBaseComponent {
       /* Variant: accent-transparent */
       :host([variant="accent-transparent"]) .button {
         --_bg-color: transparent;
-        --_text-color: var(--semantics-buttons-accent-transparent-color, #154273);
+        --_text-color: var(--semantics-buttons-accent-transparent-content-color, #154273);
       }
 
       :host([variant="accent-transparent"]) .button:hover {
-        --_bg-color: var(--primitives-color-accent-15, #DCE3EA);
+        --_bg-color: var(--primitives-color-accent-150, #DCE3EA);
       }
 
       /* Focus state */
       .button:focus-visible {
-        outline: var(--semantics-focus-ring-thickness, 2px) solid var(--semantics-focus-ring-color, #0f172a);
+        outline: var(--semantics-focus-rings-center-thickness, 2px) solid var(--semantics-focus-rings-center-color, #0f172a);
         outline-offset: 2px;
       }
 

--- a/src/components/icon-button/rr-icon-button.ts
+++ b/src/components/icon-button/rr-icon-button.ts
@@ -53,8 +53,8 @@ export class RRIconButton extends LitElement {
       align-items: center;
       justify-content: center;
 
-      /* Typography */
-      font: var(--components-icon-button-font);
+      /* Typography - icon buttons have no text, font inherited for sizing context */
+      font: var(--semantics-buttons-md-font);
 
       /* Animation */
       transition:
@@ -84,28 +84,28 @@ export class RRIconButton extends LitElement {
 
     /* Size: S - Square 32x32, Figma: 6px border-radius */
     :host([size='s']) .button {
-      width: var(--semantics-controls-s-min-size);
-      height: var(--semantics-controls-s-min-size);
-      min-width: var(--semantics-controls-s-min-size);
-      min-height: var(--semantics-controls-s-min-size);
-      border-radius: var(--semantics-controls-s-corner-radius);
+      width: var(--semantics-controls-sm-min-size);
+      height: var(--semantics-controls-sm-min-size);
+      min-width: var(--semantics-controls-sm-min-size);
+      min-height: var(--semantics-controls-sm-min-size);
+      border-radius: var(--semantics-controls-sm-corner-radius);
     }
 
     /* Size: M - Square 44x44 (default), Figma: 8px border-radius */
     :host([size='m']) .button,
     :host(:not([size])) .button {
-      width: var(--semantics-controls-m-min-size);
-      height: var(--semantics-controls-m-min-size);
-      min-width: var(--semantics-controls-m-min-size);
-      min-height: var(--semantics-controls-m-min-size);
-      border-radius: var(--semantics-controls-m-corner-radius);
+      width: var(--semantics-controls-md-min-size);
+      height: var(--semantics-controls-md-min-size);
+      min-width: var(--semantics-controls-md-min-size);
+      min-height: var(--semantics-controls-md-min-size);
+      border-radius: var(--semantics-controls-md-corner-radius);
     }
 
     /* Variant: accent-filled (default) */
     :host([variant='accent-filled']) .button,
     :host(:not([variant])) .button {
       --_bg-color: var(--semantics-buttons-accent-filled-background-color);
-      --_text-color: var(--semantics-buttons-accent-filled-color);
+      --_text-color: var(--semantics-buttons-accent-filled-content-color);
     }
 
     :host([variant='accent-filled']) .button:hover:not(:disabled),
@@ -116,29 +116,29 @@ export class RRIconButton extends LitElement {
     /* Variant: accent-outlined */
     :host([variant='accent-outlined']) .button {
       --_bg-color: transparent;
-      --_text-color: var(--semantics-buttons-accent-outlined-color);
+      --_text-color: var(--semantics-buttons-accent-outlined-content-color);
       --_border-color: var(--semantics-buttons-accent-outlined-border-color);
       --_border-width: var(--semantics-buttons-accent-outlined-border-thickness);
     }
 
     :host([variant='accent-outlined']) .button:hover:not(:disabled) {
-      --_bg-color: var(--primitives-color-accent-15);
+      --_bg-color: var(--primitives-color-accent-150);
     }
 
     /* Variant: accent-tinted */
     :host([variant='accent-tinted']) .button {
       --_bg-color: var(--semantics-buttons-accent-tinted-background-color);
-      --_text-color: var(--semantics-buttons-accent-tinted-color);
+      --_text-color: var(--semantics-buttons-accent-tinted-content-color);
     }
 
     :host([variant='accent-tinted']) .button:hover:not(:disabled) {
-      --_bg-color: var(--primitives-color-accent-30);
+      --_bg-color: var(--primitives-color-accent-300);
     }
 
     /* Variant: neutral-tinted */
     :host([variant='neutral-tinted']) .button {
       --_bg-color: var(--semantics-buttons-neutral-tinted-background-color);
-      --_text-color: var(--semantics-buttons-neutral-tinted-color);
+      --_text-color: var(--semantics-buttons-neutral-tinted-content-color);
     }
 
     :host([variant='neutral-tinted']) .button:hover:not(:disabled) {
@@ -148,16 +148,16 @@ export class RRIconButton extends LitElement {
     /* Variant: accent-transparent */
     :host([variant='accent-transparent']) .button {
       --_bg-color: transparent;
-      --_text-color: var(--semantics-buttons-accent-transparent-color);
+      --_text-color: var(--semantics-buttons-accent-transparent-content-color);
     }
 
     :host([variant='accent-transparent']) .button:hover:not(:disabled) {
-      --_bg-color: var(--primitives-color-accent-15);
+      --_bg-color: var(--primitives-color-accent-150);
     }
 
     /* Focus state */
     .button:focus-visible {
-      outline: var(--semantics-focus-ring-thickness) solid var(--semantics-focus-ring-color);
+      outline: var(--semantics-focus-rings-center-thickness) solid var(--semantics-focus-rings-center-color);
       outline-offset: 2px;
     }
 

--- a/src/components/label-cell/rr-label-cell.ts
+++ b/src/components/label-cell/rr-label-cell.ts
@@ -38,7 +38,7 @@ export class RRLabelCell extends LitElement {
       margin: 0;
       padding: 0;
       font-weight: var(--primitives-font-weight-body-regular);
-      font-size: var(--primitives-font-size-body-m);
+      font-size: var(--primitives-font-size-100);
       line-height: 1.25; /* Figma: 1.25em = 22.5px */
     }
 
@@ -61,7 +61,7 @@ export class RRLabelCell extends LitElement {
 
     /* Color: White (#FFFFFF per Figma) */
     :host([color="white"]) .label-cell__text {
-      color: var(--semantics-content-white-color);
+      color: var(--primitives-color-neutral-1000);
     }
 
     /* Accessibility: High Contrast Mode */

--- a/src/components/list/rr-list-item.ts
+++ b/src/components/list/rr-list-item.ts
@@ -115,7 +115,7 @@ export class RRListItem extends LitElement {
       left: 0;
       right: 0;
       height: 1px;
-      background-color: var(--semantics-divider-color);
+      background-color: var(--semantics-dividers-color);
     }
 
     /* Hide divider when selected */
@@ -138,7 +138,7 @@ export class RRListItem extends LitElement {
 
     /* Accessibility: focus state */
     :host(:focus-visible) {
-      outline: var(--semantics-focus-ring-thickness) solid var(--semantics-focus-ring-color);
+      outline: var(--semantics-focus-rings-center-thickness) solid var(--semantics-focus-rings-center-color);
       outline-offset: 2px;
     }
   `;

--- a/src/components/list/rr-list.ts
+++ b/src/components/list/rr-list.ts
@@ -37,19 +37,19 @@ export class RRList extends LitElement {
     /* Variant: simple (default) - just a vertical stack with top border */
     :host([variant="simple"]) .list__main,
     :host(:not([variant])) .list__main {
-      border-top: 1px solid var(--semantics-divider-color);
+      border-top: 1px solid var(--semantics-dividers-color);
     }
 
     /* Variant: box - rounded background with padding */
     :host([variant="box"]) .list__main {
-      background-color: var(--semantics-views-tinted-background-color);
+      background-color: var(--semantics-surfaces-tinted-background-color);
       border-radius: 12px;
       gap: 8px;
     }
 
     /* Variant: box-on-tint - white background on tinted surface */
     :host([variant="box-on-tint"]) .list__main {
-      background-color: var(--semantics-views-background-color);
+      background-color: var(--semantics-surfaces-background-color);
       border-radius: 12px;
       gap: 8px;
     }

--- a/src/components/menu-bar/rr-menu-bar.js
+++ b/src/components/menu-bar/rr-menu-bar.js
@@ -428,22 +428,22 @@ export class RRMenuBar extends RRBaseComponent {
       }
 
       .title {
-        padding: var(--primitives-space-8, 8px) var(--primitives-space-16, 16px);
+        padding: var(--primitives-space-8) var(--primitives-space-16);
         margin: 0;
       }
 
       /* Title size variants */
       :host([size="s"]) .title {
-        font: var(--components-menu-bar-title-item-s-font, 550 18px/1.125 RijksSansVF, system-ui);
+        font: var(--components-menu-bar-title-item-s-font);
       }
 
       :host([size="m"]) .title,
       :host(:not([size])) .title {
-        font: var(--components-menu-bar-title-item-m-font, 550 20px/1.125 RijksSansVF, system-ui);
+        font: var(--components-menu-bar-title-item-m-font);
       }
 
       :host([size="l"]) .title {
-        font: var(--components-menu-bar-title-item-l-font, 550 23px/1.125 RijksSansVF, system-ui);
+        font: var(--components-menu-bar-title-item-l-font);
       }
 
       .menu {
@@ -471,22 +471,22 @@ export class RRMenuBar extends RRBaseComponent {
       .overflow-button {
         display: none;
         align-items: center;
-        gap: var(--primitives-space-4, 4px);
-        padding: var(--primitives-space-8, 8px) var(--primitives-space-16, 16px);
+        gap: var(--primitives-space-4);
+        padding: var(--primitives-space-8) var(--primitives-space-16);
         background: none;
         border: none;
-        color: var(--components-menu-bar-menu-item-color, #154273);
-        font: var(--components-menu-bar-menu-item-font, 550 18px/1.125 RijksSansVF, system-ui);
+        color: var(--components-menu-bar-menu-item-color);
+        font: var(--components-menu-bar-menu-item-font);
         cursor: pointer;
         white-space: nowrap;
       }
 
       .overflow-button:hover {
-        background-color: var(--primitives-color-neutral-100, #f1f5f9);
+        background-color: var(--primitives-color-neutral-100);
       }
 
       .overflow-button:focus-visible {
-        outline: var(--semantics-focus-rings-center-thickness, 2px) solid var(--semantics-focus-rings-center-color, #0f172a);
+        outline: var(--semantics-focus-rings-center-thickness) solid var(--semantics-focus-rings-center-color);
         outline-offset: -2px;
       }
 
@@ -508,12 +508,12 @@ export class RRMenuBar extends RRBaseComponent {
         right: 0;
         margin-top: 4px;
         min-width: 200px;
-        background: var(--primitives-color-neutral-0, #ffffff);
-        border: 1px solid var(--semantics-dividers-color, #e2e8f0);
-        border-radius: var(--semantics-controls-md-corner-radius, 7px);
+        background: var(--primitives-color-neutral-0);
+        border: 1px solid var(--semantics-dividers-color);
+        border-radius: var(--semantics-controls-md-corner-radius);
         box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
         z-index: 10000;
-        padding: var(--primitives-space-4, 4px) 0;
+        padding: var(--primitives-space-4) 0;
       }
 
       .overflow-dropdown.open {
@@ -523,22 +523,22 @@ export class RRMenuBar extends RRBaseComponent {
       .overflow-item {
         display: block;
         width: 100%;
-        padding: var(--primitives-space-8, 8px) var(--primitives-space-16, 16px);
+        padding: var(--primitives-space-8) var(--primitives-space-16);
         background: none;
         border: none;
-        color: var(--components-menu-bar-menu-item-color, #154273);
-        font: var(--components-menu-bar-menu-item-font, 550 18px/1.125 RijksSansVF, system-ui);
+        color: var(--components-menu-bar-menu-item-color);
+        font: var(--components-menu-bar-menu-item-font);
         text-align: left;
         cursor: pointer;
         white-space: nowrap;
       }
 
       .overflow-item:hover {
-        background-color: var(--primitives-color-neutral-100, #f1f5f9);
+        background-color: var(--primitives-color-neutral-100);
       }
 
       .overflow-item:focus-visible {
-        outline: var(--semantics-focus-rings-center-thickness, 2px) solid var(--semantics-focus-rings-center-color, #0f172a);
+        outline: var(--semantics-focus-rings-center-thickness) solid var(--semantics-focus-rings-center-color);
         outline-offset: -2px;
       }
     `;

--- a/src/components/menu-bar/rr-menu-bar.js
+++ b/src/components/menu-bar/rr-menu-bar.js
@@ -452,7 +452,7 @@ export class RRMenuBar extends RRBaseComponent {
         align-items: stretch;
         gap: 0;
         /* Bottom border per Figma default-global-menu-bar */
-        border-bottom: var(--rr-menu-bar-border, var(--semantics-divider-thickness) solid var(--semantics-divider-color));
+        border-bottom: var(--rr-menu-bar-border, var(--semantics-dividers-thickness) solid var(--semantics-dividers-color));
         position: relative;
         width: 100%;
         min-width: 0;
@@ -486,7 +486,7 @@ export class RRMenuBar extends RRBaseComponent {
       }
 
       .overflow-button:focus-visible {
-        outline: var(--semantics-focus-ring-thickness, 2px) solid var(--semantics-focus-ring-color, #0f172a);
+        outline: var(--semantics-focus-rings-center-thickness, 2px) solid var(--semantics-focus-rings-center-color, #0f172a);
         outline-offset: -2px;
       }
 
@@ -509,8 +509,8 @@ export class RRMenuBar extends RRBaseComponent {
         margin-top: 4px;
         min-width: 200px;
         background: var(--primitives-color-neutral-0, #ffffff);
-        border: 1px solid var(--semantics-divider-color, #e2e8f0);
-        border-radius: var(--semantics-controls-m-corner-radius, 7px);
+        border: 1px solid var(--semantics-dividers-color, #e2e8f0);
+        border-radius: var(--semantics-controls-md-corner-radius, 7px);
         box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
         z-index: 10000;
         padding: var(--primitives-space-4, 4px) 0;
@@ -538,7 +538,7 @@ export class RRMenuBar extends RRBaseComponent {
       }
 
       .overflow-item:focus-visible {
-        outline: var(--semantics-focus-ring-thickness, 2px) solid var(--semantics-focus-ring-color, #0f172a);
+        outline: var(--semantics-focus-rings-center-thickness, 2px) solid var(--semantics-focus-rings-center-color, #0f172a);
         outline-offset: -2px;
       }
     `;

--- a/src/components/menu-bar/rr-menu-bar.ts
+++ b/src/components/menu-bar/rr-menu-bar.ts
@@ -86,7 +86,7 @@ export class RRMenuBar extends LitElement {
       /* Bottom border per Figma default-global-menu-bar */
       border-bottom: var(
         --rr-menu-bar-border,
-        var(--semantics-divider-thickness) solid var(--semantics-divider-color)
+        var(--semantics-dividers-thickness) solid var(--semantics-dividers-color)
       );
       position: relative;
       width: 100%;
@@ -121,7 +121,7 @@ export class RRMenuBar extends LitElement {
     }
 
     .overflow-button:focus-visible {
-      outline: var(--semantics-focus-ring-thickness) solid var(--semantics-focus-ring-color);
+      outline: var(--semantics-focus-rings-center-thickness) solid var(--semantics-focus-rings-center-color);
       outline-offset: -2px;
     }
 
@@ -144,8 +144,8 @@ export class RRMenuBar extends LitElement {
       margin-top: 4px;
       min-width: 200px;
       background: var(--primitives-color-neutral-0);
-      border: 1px solid var(--semantics-divider-color);
-      border-radius: var(--semantics-controls-m-corner-radius);
+      border: 1px solid var(--semantics-dividers-color);
+      border-radius: var(--semantics-controls-md-corner-radius);
       box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
       z-index: 10000;
       padding: var(--primitives-space-4) 0;
@@ -173,7 +173,7 @@ export class RRMenuBar extends LitElement {
     }
 
     .overflow-item:focus-visible {
-      outline: var(--semantics-focus-ring-thickness) solid var(--semantics-focus-ring-color);
+      outline: var(--semantics-focus-rings-center-thickness) solid var(--semantics-focus-rings-center-color);
       outline-offset: -2px;
     }
 

--- a/src/components/menu-bar/rr-menu-item.js
+++ b/src/components/menu-bar/rr-menu-item.js
@@ -141,12 +141,12 @@ export class RRMenuItem extends RRBaseComponent {
         cursor: pointer;
 
         /* Typography */
-        font: var(--components-menu-bar-menu-item-font, 550 18px/1.125 RijksSansVF, system-ui);
-        color: var(--rr-menu-item-color, var(--components-menu-bar-menu-item-color, #154273));
+        font: var(--components-menu-bar-menu-item-font);
+        color: var(--rr-menu-item-color, var(--components-menu-bar-menu-item-color));
         text-align: left;
 
         /* Spacing */
-        padding: var(--primitives-space-8, 8px) var(--primitives-space-16, 16px);
+        padding: var(--primitives-space-8) var(--primitives-space-16);
 
         /* Animation */
         transition: background-color 0.15s ease, color 0.15s ease;
@@ -159,14 +159,14 @@ export class RRMenuItem extends RRBaseComponent {
         left: 0;
         right: 0;
         height: 0;
-        background-color: var(--components-menu-bar-menu-item-is-hovered-indicator-color, #d8dee7);
+        background-color: var(--components-menu-bar-menu-item-is-hovered-indicator-color);
         transition: height 0.15s ease;
         pointer-events: none;
         z-index: 0;
       }
 
       .menu-item:hover:not(:disabled) .hover-indicator {
-        height: var(--components-menu-bar-menu-item-is-hovered-indicator-height, 32px);
+        height: var(--components-menu-bar-menu-item-is-hovered-indicator-height);
       }
 
       /* Selection indicator */
@@ -176,14 +176,14 @@ export class RRMenuItem extends RRBaseComponent {
         left: 0;
         right: 0;
         height: 0;
-        background-color: var(--components-menu-bar-menu-item-is-selected-indicator-color, #154273);
+        background-color: var(--components-menu-bar-menu-item-is-selected-indicator-color);
         transition: height 0.15s ease;
         pointer-events: none;
         z-index: 1;
       }
 
       :host([selected]) .selection-indicator {
-        height: var(--components-menu-bar-menu-item-is-selected-indicator-height, 4px);
+        height: var(--components-menu-bar-menu-item-is-selected-indicator-height);
       }
 
       /* Content wrapper for z-index layering */
@@ -194,13 +194,13 @@ export class RRMenuItem extends RRBaseComponent {
 
       /* Focus state */
       .menu-item:focus-visible {
-        outline: var(--semantics-focus-rings-center-thickness, 2px) solid var(--semantics-focus-rings-center-color, #0f172a);
+        outline: var(--semantics-focus-rings-center-thickness) solid var(--semantics-focus-rings-center-color);
         outline-offset: 2px;
       }
 
       /* Disabled state */
       :host([disabled]) .menu-item {
-        opacity: calc(var(--primitives-opacity-disabled, 38) / 100);
+        opacity: calc(var(--primitives-opacity-disabled) / 100);
         cursor: not-allowed;
         pointer-events: none;
       }

--- a/src/components/menu-bar/rr-menu-item.js
+++ b/src/components/menu-bar/rr-menu-item.js
@@ -194,7 +194,7 @@ export class RRMenuItem extends RRBaseComponent {
 
       /* Focus state */
       .menu-item:focus-visible {
-        outline: var(--semantics-focus-ring-thickness, 2px) solid var(--semantics-focus-ring-color, #0f172a);
+        outline: var(--semantics-focus-rings-center-thickness, 2px) solid var(--semantics-focus-rings-center-color, #0f172a);
         outline-offset: 2px;
       }
 

--- a/src/components/menu-bar/rr-menu-item.ts
+++ b/src/components/menu-bar/rr-menu-item.ts
@@ -112,7 +112,7 @@ export class RRMenuItem extends LitElement {
 
     /* Focus state */
     .menu-item:focus-visible {
-      outline: var(--semantics-focus-ring-thickness) solid var(--semantics-focus-ring-color);
+      outline: var(--semantics-focus-rings-center-thickness) solid var(--semantics-focus-rings-center-color);
       outline-offset: 2px;
     }
 

--- a/src/components/radio/rr-radio.js
+++ b/src/components/radio/rr-radio.js
@@ -283,28 +283,28 @@ export class RRRadio extends RRBaseComponent {
 
       /* Size: S (32px) */
       :host([size="s"]) .radio {
-        width: var(--semantics-controls-s-min-size, 32px);
-        height: var(--semantics-controls-s-min-size, 32px);
+        width: var(--semantics-controls-sm-min-size, 32px);
+        height: var(--semantics-controls-sm-min-size, 32px);
       }
 
       :host([size="s"]) .radio-inner {
         /* Inner dot is ~37.5% of outer radio size (12px / 32px = 0.375) */
-        width: calc(var(--semantics-controls-s-min-size, 32px) * 0.375);
-        height: calc(var(--semantics-controls-s-min-size, 32px) * 0.375);
+        width: calc(var(--semantics-controls-sm-min-size, 32px) * 0.375);
+        height: calc(var(--semantics-controls-sm-min-size, 32px) * 0.375);
       }
 
       /* Size: M (44px - default) */
       :host([size="m"]) .radio,
       :host(:not([size])) .radio {
-        width: var(--semantics-controls-m-min-size, 44px);
-        height: var(--semantics-controls-m-min-size, 44px);
+        width: var(--semantics-controls-md-min-size, 44px);
+        height: var(--semantics-controls-md-min-size, 44px);
       }
 
       :host([size="m"]) .radio-inner,
       :host(:not([size])) .radio-inner {
         /* Inner dot is ~36% of outer radio size (16px / 44px = 0.36) */
-        width: calc(var(--semantics-controls-m-min-size, 44px) * 0.36);
-        height: calc(var(--semantics-controls-m-min-size, 44px) * 0.36);
+        width: calc(var(--semantics-controls-md-min-size, 44px) * 0.36);
+        height: calc(var(--semantics-controls-md-min-size, 44px) * 0.36);
       }
 
       /* Inner dot (only visible when checked) */
@@ -331,7 +331,7 @@ export class RRRadio extends RRBaseComponent {
 
       /* Focus state */
       :host(:focus-visible) .radio {
-        outline: var(--semantics-focus-ring-thickness, 2px) solid var(--semantics-focus-ring-color, #000000);
+        outline: var(--semantics-focus-rings-center-thickness, 2px) solid var(--semantics-focus-rings-center-color, #000000);
         outline-offset: 2px;
       }
 

--- a/src/components/radio/rr-radio.js
+++ b/src/components/radio/rr-radio.js
@@ -244,7 +244,7 @@ export class RRRadio extends RRBaseComponent {
 
       :host([disabled]) {
         cursor: not-allowed;
-        opacity: calc(var(--primitives-opacity-disabled, 38) / 100);
+        opacity: calc(var(--primitives-opacity-disabled) / 100);
       }
 
       /* The visual radio button */
@@ -259,11 +259,11 @@ export class RRRadio extends RRBaseComponent {
         border-radius: 50%;
 
         /* Border */
-        border: var(--components-radio-button-border-thickness, 2px) solid
-                var(--rr-radio-border-color, var(--components-radio-button-border-color, #475569));
+        border: var(--components-radio-button-border-thickness) solid
+                var(--rr-radio-border-color, var(--components-radio-button-border-color));
 
         /* Background */
-        background-color: var(--rr-radio-background-color, var(--components-radio-button-background-color, #ffffff));
+        background-color: var(--rr-radio-background-color, var(--components-radio-button-background-color));
 
         /* Transition */
         transition: background-color 0.15s ease, border-color 0.15s ease;
@@ -271,48 +271,48 @@ export class RRRadio extends RRBaseComponent {
 
       /* Size: XS (24px) */
       :host([size="xs"]) .radio {
-        width: var(--semantics-controls-xs-min-size, 24px);
-        height: var(--semantics-controls-xs-min-size, 24px);
+        width: var(--semantics-controls-xs-min-size);
+        height: var(--semantics-controls-xs-min-size);
       }
 
       :host([size="xs"]) .radio-inner {
         /* Inner dot is ~33% of outer radio size (8px / 24px = 0.33) */
-        width: calc(var(--semantics-controls-xs-min-size, 24px) * 0.33);
-        height: calc(var(--semantics-controls-xs-min-size, 24px) * 0.33);
+        width: calc(var(--semantics-controls-xs-min-size) * 0.33);
+        height: calc(var(--semantics-controls-xs-min-size) * 0.33);
       }
 
       /* Size: S (32px) */
       :host([size="s"]) .radio {
-        width: var(--semantics-controls-sm-min-size, 32px);
-        height: var(--semantics-controls-sm-min-size, 32px);
+        width: var(--semantics-controls-sm-min-size);
+        height: var(--semantics-controls-sm-min-size);
       }
 
       :host([size="s"]) .radio-inner {
         /* Inner dot is ~37.5% of outer radio size (12px / 32px = 0.375) */
-        width: calc(var(--semantics-controls-sm-min-size, 32px) * 0.375);
-        height: calc(var(--semantics-controls-sm-min-size, 32px) * 0.375);
+        width: calc(var(--semantics-controls-sm-min-size) * 0.375);
+        height: calc(var(--semantics-controls-sm-min-size) * 0.375);
       }
 
       /* Size: M (44px - default) */
       :host([size="m"]) .radio,
       :host(:not([size])) .radio {
-        width: var(--semantics-controls-md-min-size, 44px);
-        height: var(--semantics-controls-md-min-size, 44px);
+        width: var(--semantics-controls-md-min-size);
+        height: var(--semantics-controls-md-min-size);
       }
 
       :host([size="m"]) .radio-inner,
       :host(:not([size])) .radio-inner {
         /* Inner dot is ~36% of outer radio size (16px / 44px = 0.36) */
-        width: calc(var(--semantics-controls-md-min-size, 44px) * 0.36);
-        height: calc(var(--semantics-controls-md-min-size, 44px) * 0.36);
+        width: calc(var(--semantics-controls-md-min-size) * 0.36);
+        height: calc(var(--semantics-controls-md-min-size) * 0.36);
       }
 
       /* Inner dot (only visible when checked) */
       .radio-inner {
         border-radius: 50%;
-        background-color: var(--components-radio-button-is-selected-inner-shape-border-color, #ffffff);
-        border: var(--components-radio-button-is-selected-inner-shape-border-thickness, 2px) solid
-                var(--components-radio-button-is-selected-inner-shape-border-color, #ffffff);
+        background-color: var(--components-radio-button-is-selected-inner-shape-border-color);
+        border: var(--components-radio-button-is-selected-inner-shape-border-thickness) solid
+                var(--components-radio-button-is-selected-inner-shape-border-color);
         opacity: 0;
         transform: scale(0);
         transition: opacity 0.15s ease, transform 0.15s ease;
@@ -320,8 +320,8 @@ export class RRRadio extends RRBaseComponent {
 
       /* Checked state */
       :host([checked]) .radio {
-        background-color: var(--components-radio-button-is-selected-background-color, #154273);
-        border-color: var(--components-radio-button-is-selected-background-color, #154273);
+        background-color: var(--components-radio-button-is-selected-background-color);
+        border-color: var(--components-radio-button-is-selected-background-color);
       }
 
       :host([checked]) .radio-inner {
@@ -331,19 +331,19 @@ export class RRRadio extends RRBaseComponent {
 
       /* Focus state */
       :host(:focus-visible) .radio {
-        outline: var(--semantics-focus-rings-center-thickness, 2px) solid var(--semantics-focus-rings-center-color, #000000);
+        outline: var(--semantics-focus-rings-center-thickness) solid var(--semantics-focus-rings-center-color);
         outline-offset: 2px;
       }
 
       /* Hover state (only when not disabled)
          Note: Using primitive token as no semantic radio hover token exists in design system */
       :host(:not([disabled]):hover) .radio {
-        border-color: var(--primitives-color-accent-75, #4F7196);
+        border-color: var(--primitives-color-accent-75);
       }
 
       :host(:not([disabled])[checked]:hover) .radio {
-        background-color: var(--primitives-color-accent-75, #4F7196);
-        border-color: var(--primitives-color-accent-75, #4F7196);
+        background-color: var(--primitives-color-accent-75);
+        border-color: var(--primitives-color-accent-75);
       }
 
       /* Hidden native input for form integration */

--- a/src/components/radio/rr-radio.ts
+++ b/src/components/radio/rr-radio.ts
@@ -92,8 +92,8 @@ export class RRRadio extends LitElement {
 
     /* Size: S (32px) */
     :host([size='s']) .radio {
-      width: var(--semantics-controls-s-min-size);
-      height: var(--semantics-controls-s-min-size);
+      width: var(--semantics-controls-sm-min-size);
+      height: var(--semantics-controls-sm-min-size);
     }
 
     :host([size='s']) .radio__inner {
@@ -105,8 +105,8 @@ export class RRRadio extends LitElement {
     /* Size: M (44px - default) */
     :host([size='m']) .radio,
     :host(:not([size])) .radio {
-      width: var(--semantics-controls-m-min-size);
-      height: var(--semantics-controls-m-min-size);
+      width: var(--semantics-controls-md-min-size);
+      height: var(--semantics-controls-md-min-size);
     }
 
     :host([size='m']) .radio__inner,
@@ -155,7 +155,7 @@ export class RRRadio extends LitElement {
     }
 
     :host(:focus-visible) .radio {
-      outline: var(--semantics-focus-ring-thickness) solid var(--semantics-focus-ring-color);
+      outline: var(--semantics-focus-rings-center-thickness) solid var(--semantics-focus-rings-center-color);
       outline-offset: 2px;
     }
 

--- a/src/components/switch/rr-switch.js
+++ b/src/components/switch/rr-switch.js
@@ -229,22 +229,22 @@ export class RRSwitch extends RRBaseComponent {
       /* Size: M (default) - Figma specs: 56x32px */
       :host([size="m"]) .switch,
       :host(:not([size])) .switch {
-        width: calc(var(--semantics-controls-s-min-size, 32px) * 1.75);
-        height: var(--semantics-controls-s-min-size, 32px);
-        border-radius: calc(var(--semantics-controls-s-min-size, 32px) / 2);
+        width: calc(var(--semantics-controls-sm-min-size, 32px) * 1.75);
+        height: var(--semantics-controls-sm-min-size, 32px);
+        border-radius: calc(var(--semantics-controls-sm-min-size, 32px) / 2);
         padding: 2px;
       }
 
       :host([size="m"]) .thumb,
       :host(:not([size])) .thumb {
-        width: calc(var(--semantics-controls-s-min-size, 32px) - 8px);
-        height: calc(var(--semantics-controls-s-min-size, 32px) - 8px);
+        width: calc(var(--semantics-controls-sm-min-size, 32px) - 8px);
+        height: calc(var(--semantics-controls-sm-min-size, 32px) - 8px);
         border-radius: 50%; /* Circular thumb per Figma */
       }
 
       :host([size="m"][checked]) .thumb,
       :host(:not([size])[checked]) .thumb {
-        transform: translateX(calc((var(--semantics-controls-s-min-size, 32px) * 1.75) - var(--semantics-controls-s-min-size, 32px)));
+        transform: translateX(calc((var(--semantics-controls-sm-min-size, 32px) * 1.75) - var(--semantics-controls-sm-min-size, 32px)));
       }
 
       /* Checked state */
@@ -260,7 +260,7 @@ export class RRSwitch extends RRBaseComponent {
 
       /* Focus state */
       :host(:focus-visible) .switch {
-        outline: var(--semantics-focus-ring-thickness, 2px) solid var(--semantics-focus-ring-color, #0f172a);
+        outline: var(--semantics-focus-rings-center-thickness, 2px) solid var(--semantics-focus-rings-center-color, #0f172a);
         outline-offset: 2px;
       }
 

--- a/src/components/switch/rr-switch.js
+++ b/src/components/switch/rr-switch.js
@@ -148,7 +148,7 @@ export class RRSwitch extends RRBaseComponent {
 
       :host([disabled]) {
         cursor: not-allowed;
-        opacity: calc(var(--primitives-opacity-disabled, 38) / 100);
+        opacity: calc(var(--primitives-opacity-disabled) / 100);
       }
 
       .switch-container {
@@ -172,8 +172,8 @@ export class RRSwitch extends RRBaseComponent {
         display: inline-flex;
         align-items: center;
         box-sizing: border-box;
-        background-color: var(--rr-switch-background-color, var(--components-switch-background-color, #ffffff));
-        border: var(--components-switch-border-thickness, 2px) solid var(--components-switch-border-color, #475569);
+        background-color: var(--rr-switch-background-color, var(--components-switch-background-color));
+        border: var(--components-switch-border-thickness) solid var(--components-switch-border-color);
         transition: background-color 0.2s ease, border-color 0.2s ease;
         cursor: inherit;
       }
@@ -184,83 +184,83 @@ export class RRSwitch extends RRBaseComponent {
         align-items: center;
         justify-content: center;
         box-sizing: border-box;
-        background-color: var(--rr-switch-thumb-color, var(--components-switch-thumb-background-color, #ffffff));
-        border: var(--components-switch-thumb-border-thickness, 2px) solid var(--components-switch-thumb-border-color, #475569);
+        background-color: var(--rr-switch-thumb-color, var(--components-switch-thumb-background-color));
+        border: var(--components-switch-thumb-border-thickness) solid var(--components-switch-thumb-border-color);
         transition: transform 0.2s ease, background-color 0.2s ease, border-color 0.2s ease;
         will-change: transform;
       }
 
       /* Size: XS */
       :host([size="xs"]) .switch {
-        width: calc(var(--semantics-controls-xs-min-size, 24px) * 1.6);
-        height: calc(var(--semantics-controls-xs-min-size, 24px) * 0.833);
-        border-radius: calc(var(--semantics-controls-xs-min-size, 24px) * 0.5);
+        width: calc(var(--semantics-controls-xs-min-size) * 1.6);
+        height: calc(var(--semantics-controls-xs-min-size) * 0.833);
+        border-radius: calc(var(--semantics-controls-xs-min-size) * 0.5);
         padding: 2px;
       }
 
       :host([size="xs"]) .thumb {
-        width: calc(var(--semantics-controls-xs-min-size, 24px) * 0.5);
-        height: calc(var(--semantics-controls-xs-min-size, 24px) * 0.5);
+        width: calc(var(--semantics-controls-xs-min-size) * 0.5);
+        height: calc(var(--semantics-controls-xs-min-size) * 0.5);
         border-radius: 50%; /* Circular thumb per Figma */
       }
 
       :host([size="xs"][checked]) .thumb {
-        transform: translateX(calc(var(--semantics-controls-xs-min-size, 24px) * 0.5));
+        transform: translateX(calc(var(--semantics-controls-xs-min-size) * 0.5));
       }
 
       /* Size: S - Figma specs: 44x24px */
       :host([size="s"]) .switch {
-        width: calc(var(--semantics-controls-xs-min-size, 24px) * 1.833);
-        height: var(--semantics-controls-xs-min-size, 24px);
-        border-radius: calc(var(--semantics-controls-xs-min-size, 24px) / 2);
+        width: calc(var(--semantics-controls-xs-min-size) * 1.833);
+        height: var(--semantics-controls-xs-min-size);
+        border-radius: calc(var(--semantics-controls-xs-min-size) / 2);
         padding: 2px;
       }
 
       :host([size="s"]) .thumb {
-        width: calc(var(--semantics-controls-xs-min-size, 24px) - 8px);
-        height: calc(var(--semantics-controls-xs-min-size, 24px) - 8px);
+        width: calc(var(--semantics-controls-xs-min-size) - 8px);
+        height: calc(var(--semantics-controls-xs-min-size) - 8px);
         border-radius: 50%; /* Circular thumb per Figma */
       }
 
       :host([size="s"][checked]) .thumb {
-        transform: translateX(calc((var(--semantics-controls-xs-min-size, 24px) * 1.833) - var(--semantics-controls-xs-min-size, 24px)));
+        transform: translateX(calc((var(--semantics-controls-xs-min-size) * 1.833) - var(--semantics-controls-xs-min-size)));
       }
 
       /* Size: M (default) - Figma specs: 56x32px */
       :host([size="m"]) .switch,
       :host(:not([size])) .switch {
-        width: calc(var(--semantics-controls-sm-min-size, 32px) * 1.75);
-        height: var(--semantics-controls-sm-min-size, 32px);
-        border-radius: calc(var(--semantics-controls-sm-min-size, 32px) / 2);
+        width: calc(var(--semantics-controls-sm-min-size) * 1.75);
+        height: var(--semantics-controls-sm-min-size);
+        border-radius: calc(var(--semantics-controls-sm-min-size) / 2);
         padding: 2px;
       }
 
       :host([size="m"]) .thumb,
       :host(:not([size])) .thumb {
-        width: calc(var(--semantics-controls-sm-min-size, 32px) - 8px);
-        height: calc(var(--semantics-controls-sm-min-size, 32px) - 8px);
+        width: calc(var(--semantics-controls-sm-min-size) - 8px);
+        height: calc(var(--semantics-controls-sm-min-size) - 8px);
         border-radius: 50%; /* Circular thumb per Figma */
       }
 
       :host([size="m"][checked]) .thumb,
       :host(:not([size])[checked]) .thumb {
-        transform: translateX(calc((var(--semantics-controls-sm-min-size, 32px) * 1.75) - var(--semantics-controls-sm-min-size, 32px)));
+        transform: translateX(calc((var(--semantics-controls-sm-min-size) * 1.75) - var(--semantics-controls-sm-min-size)));
       }
 
       /* Checked state */
       :host([checked]) .switch {
-        background-color: var(--components-switch-is-selected-background-color, #154273);
-        border-color: var(--components-switch-is-selected-background-color, #154273);
+        background-color: var(--components-switch-is-selected-background-color);
+        border-color: var(--components-switch-is-selected-background-color);
       }
 
       :host([checked]) .thumb {
-        background-color: var(--components-switch-is-selected-thumb-background-color, #ffffff);
-        border-color: var(--components-switch-is-selected-background-color, #154273);
+        background-color: var(--components-switch-is-selected-thumb-background-color);
+        border-color: var(--components-switch-is-selected-background-color);
       }
 
       /* Focus state */
       :host(:focus-visible) .switch {
-        outline: var(--semantics-focus-rings-center-thickness, 2px) solid var(--semantics-focus-rings-center-color, #0f172a);
+        outline: var(--semantics-focus-rings-center-thickness) solid var(--semantics-focus-rings-center-color);
         outline-offset: 2px;
       }
 

--- a/src/components/switch/rr-switch.ts
+++ b/src/components/switch/rr-switch.ts
@@ -82,22 +82,22 @@ export class RRSwitch extends LitElement {
     /* Size: M (default) - Figma specs: 56x32px */
     :host([size='m']) .switch,
     :host(:not([size])) .switch {
-      width: calc(var(--semantics-controls-s-min-size) * 1.75);
-      height: var(--semantics-controls-s-min-size);
-      border-radius: calc(var(--semantics-controls-s-min-size) / 2);
+      width: calc(var(--semantics-controls-sm-min-size) * 1.75);
+      height: var(--semantics-controls-sm-min-size);
+      border-radius: calc(var(--semantics-controls-sm-min-size) / 2);
       padding: 2px;
     }
 
     :host([size='m']) .switch__thumb,
     :host(:not([size])) .switch__thumb {
-      width: calc(var(--semantics-controls-s-min-size) - 8px);
-      height: calc(var(--semantics-controls-s-min-size) - 8px);
+      width: calc(var(--semantics-controls-sm-min-size) - 8px);
+      height: calc(var(--semantics-controls-sm-min-size) - 8px);
     }
 
     :host([size='m'][checked]) .switch__thumb,
     :host(:not([size])[checked]) .switch__thumb {
       transform: translateX(
-        calc((var(--semantics-controls-s-min-size) * 1.75) - var(--semantics-controls-s-min-size))
+        calc((var(--semantics-controls-sm-min-size) * 1.75) - var(--semantics-controls-sm-min-size))
       );
     }
 
@@ -114,7 +114,7 @@ export class RRSwitch extends LitElement {
 
     /* Focus state */
     :host(:focus-visible) .switch {
-      outline: var(--semantics-focus-ring-thickness) solid var(--semantics-focus-ring-color);
+      outline: var(--semantics-focus-rings-center-thickness) solid var(--semantics-focus-rings-center-color);
       outline-offset: 2px;
     }
 

--- a/src/components/title-cell/rr-title-cell.ts
+++ b/src/components/title-cell/rr-title-cell.ts
@@ -76,12 +76,12 @@ export class RRTitleCell extends LitElement {
     /* Size: MD (default) - 18px font */
     :host([size="md"]) .title-cell__text,
     :host(:not([size])) .title-cell__text {
-      font-size: var(--primitives-font-size-body-m);
+      font-size: var(--primitives-font-size-100);
     }
 
     /* Size: SM - 16px font */
     :host([size="sm"]) .title-cell__text {
-      font-size: var(--primitives-font-size-body-s);
+      font-size: var(--primitives-font-size-90);
     }
 
     /* Color: Default */
@@ -92,7 +92,7 @@ export class RRTitleCell extends LitElement {
 
     /* Color: White */
     :host([color="white"]) .title-cell__text {
-      color: var(--semantics-content-white-color);
+      color: var(--primitives-color-neutral-1000);
     }
 
     /* Accessibility: High Contrast Mode */

--- a/src/components/toggle-button/rr-toggle-button.ts
+++ b/src/components/toggle-button/rr-toggle-button.ts
@@ -70,7 +70,8 @@ export class RRToggleButton extends LitElement {
     /* Size: XS */
     :host([size="xs"]) .button {
       min-height: var(--semantics-controls-xs-min-size);
-      padding: var(--primitives-space-4) var(--primitives-space-12);
+      /* Horizontal padding includes compensation for Figma's spacer gaps (2px × 2) */
+      padding: var(--primitives-space-4) var(--primitives-space-14);
       font: var(--semantics-buttons-xs-font);
       border-radius: var(--semantics-controls-xs-corner-radius);
       gap: var(--primitives-space-2);
@@ -79,7 +80,8 @@ export class RRToggleButton extends LitElement {
     /* Size: S */
     :host([size="s"]) .button {
       min-height: var(--semantics-controls-sm-min-size);
-      padding: var(--primitives-space-6);
+      /* Horizontal padding includes compensation for Figma's spacer gaps (2px × 2) */
+      padding: var(--primitives-space-6) var(--primitives-space-8);
       font: var(--semantics-buttons-sm-font);
       border-radius: var(--semantics-controls-sm-corner-radius);
       gap: var(--primitives-space-2);
@@ -89,7 +91,8 @@ export class RRToggleButton extends LitElement {
     :host([size="m"]) .button,
     :host(:not([size])) .button {
       min-height: var(--semantics-controls-md-min-size);
-      padding: var(--primitives-space-8) var(--primitives-space-10);
+      /* Horizontal padding includes compensation for Figma's spacer gaps (4px × 2) */
+      padding: var(--primitives-space-8) var(--primitives-space-14);
       font: var(--semantics-buttons-md-font);
       border-radius: var(--semantics-controls-md-corner-radius);
       gap: var(--primitives-space-4);

--- a/src/components/toggle-button/rr-toggle-button.ts
+++ b/src/components/toggle-button/rr-toggle-button.ts
@@ -51,7 +51,7 @@ export class RRToggleButton extends LitElement {
       justify-content: center;
 
       /* Typography */
-      font-weight: var(--semantics-buttons-font-weight);
+      /* font-weight is included in font shorthand token */
       text-decoration: none;
       white-space: nowrap;
 
@@ -59,8 +59,8 @@ export class RRToggleButton extends LitElement {
       transition: background-color 0.15s ease, color 0.15s ease, transform 0.1s ease;
 
       /* Default state - using component tokens */
-      background-color: var(--rr-toggle-button-background-color, var(--components-toggle-button-background-color));
-      color: var(--rr-toggle-button-content-color, var(--components-toggle-button-content-color));
+      background-color: var(--rr-toggle-button-background-color, var(--semantics-buttons-neutral-tinted-background-color));
+      color: var(--rr-toggle-button-content-color, var(--semantics-buttons-neutral-tinted-content-color));
     }
 
     .button:active:not(:disabled) {
@@ -71,51 +71,51 @@ export class RRToggleButton extends LitElement {
     :host([size="xs"]) .button {
       min-height: var(--semantics-controls-xs-min-size);
       padding: var(--primitives-space-4) var(--primitives-space-12);
-      font: var(--components-button-xs-font);
+      font: var(--semantics-buttons-xs-font);
       border-radius: var(--semantics-controls-xs-corner-radius);
       gap: var(--primitives-space-2);
     }
 
     /* Size: S */
     :host([size="s"]) .button {
-      min-height: var(--semantics-controls-s-min-size);
+      min-height: var(--semantics-controls-sm-min-size);
       padding: var(--primitives-space-6);
-      font: var(--components-button-s-font);
-      border-radius: var(--semantics-controls-s-corner-radius);
+      font: var(--semantics-buttons-sm-font);
+      border-radius: var(--semantics-controls-sm-corner-radius);
       gap: var(--primitives-space-2);
     }
 
     /* Size: M (default) */
     :host([size="m"]) .button,
     :host(:not([size])) .button {
-      min-height: var(--semantics-controls-m-min-size);
+      min-height: var(--semantics-controls-md-min-size);
       padding: var(--primitives-space-8) var(--primitives-space-10);
-      font: var(--components-button-m-font);
-      border-radius: var(--semantics-controls-m-corner-radius);
+      font: var(--semantics-buttons-md-font);
+      border-radius: var(--semantics-controls-md-corner-radius);
       gap: var(--primitives-space-4);
     }
 
     /* Hover state */
     .button:hover:not(:disabled) {
-      background-color: var(--components-toggle-button-is-hovered-background-color);
-      color: var(--components-toggle-button-is-hovered-content-color);
+      background-color: var(--semantics-buttons-neutral-tinted-is-hovered-background-color);
+      color: var(--semantics-buttons-neutral-tinted-is-hovered-content-color);
     }
 
     /* Selected state */
     :host([selected]) .button {
-      background-color: var(--components-toggle-button-is-selected-background-color);
-      color: var(--components-toggle-button-is-selected-content-color);
+      background-color: var(--semantics-buttons-neutral-tinted-is-selected-backround-color);
+      color: var(--semantics-buttons-neutral-tinted-is-selected-content-color);
     }
 
     /* Selected hover state - stays selected color on hover */
     :host([selected]) .button:hover:not(:disabled) {
       background-color: var(--primitives-color-accent-75);
-      color: var(--components-toggle-button-is-selected-content-color);
+      color: var(--semantics-buttons-neutral-tinted-is-selected-content-color);
     }
 
     /* Focus state */
     .button:focus-visible {
-      outline: var(--semantics-focus-ring-thickness) solid var(--semantics-focus-ring-color);
+      outline: var(--semantics-focus-rings-center-thickness) solid var(--semantics-focus-rings-center-color);
       outline-offset: 2px;
     }
 

--- a/src/components/top-navigation-bar/rr-back-button.ts
+++ b/src/components/top-navigation-bar/rr-back-button.ts
@@ -47,26 +47,26 @@ export class RRBackButton extends LitElement {
     .back-button {
       display: inline-flex;
       align-items: center;
-      gap: var(--primitives-space-8, 8px);
-      padding: var(--primitives-space-8, 8px) var(--primitives-space-16, 16px);
+      gap: var(--primitives-space-8);
+      padding: var(--primitives-space-8) var(--primitives-space-16);
       background: none;
       border: none;
-      color: var(--primitives-color-accent-100, #154273);
-      font: var(--components-menu-bar-menu-item-font, 550 18px/1.125 RijksSansVF, system-ui);
+      color: var(--primitives-color-accent-100);
+      font: var(--components-menu-bar-menu-item-font);
       text-decoration: none;
       cursor: pointer;
-      border-radius: var(--semantics-controls-md-corner-radius, 7px);
+      border-radius: var(--semantics-controls-md-corner-radius);
       transition: background-color 0.15s ease;
       white-space: nowrap;
     }
 
     .back-button:hover {
-      background-color: var(--primitives-color-neutral-100, #f1f5f9);
+      background-color: var(--primitives-color-neutral-100);
     }
 
     .back-button:focus-visible {
-      outline: var(--semantics-focus-rings-center-thickness, 2px) solid
-        var(--semantics-focus-rings-center-color, #0f172a);
+      outline: var(--semantics-focus-rings-center-thickness) solid
+        var(--semantics-focus-rings-center-color);
       outline-offset: 2px;
     }
 
@@ -78,7 +78,7 @@ export class RRBackButton extends LitElement {
 
     /* Size variants */
     :host([container='s']) .back-button {
-      padding: var(--primitives-space-8, 8px);
+      padding: var(--primitives-space-8);
       font-size: 16px;
     }
 

--- a/src/components/top-navigation-bar/rr-back-button.ts
+++ b/src/components/top-navigation-bar/rr-back-button.ts
@@ -55,7 +55,7 @@ export class RRBackButton extends LitElement {
       font: var(--components-menu-bar-menu-item-font, 550 18px/1.125 RijksSansVF, system-ui);
       text-decoration: none;
       cursor: pointer;
-      border-radius: var(--semantics-controls-m-corner-radius, 7px);
+      border-radius: var(--semantics-controls-md-corner-radius, 7px);
       transition: background-color 0.15s ease;
       white-space: nowrap;
     }
@@ -65,8 +65,8 @@ export class RRBackButton extends LitElement {
     }
 
     .back-button:focus-visible {
-      outline: var(--semantics-focus-ring-thickness, 2px) solid
-        var(--semantics-focus-ring-color, #0f172a);
+      outline: var(--semantics-focus-rings-center-thickness, 2px) solid
+        var(--semantics-focus-rings-center-color, #0f172a);
       outline-offset: 2px;
     }
 

--- a/src/components/top-navigation-bar/rr-nav-logo.ts
+++ b/src/components/top-navigation-bar/rr-nav-logo.ts
@@ -34,13 +34,13 @@ export class RRNavLogo extends LitElement {
     :host {
       display: flex;
       align-items: center;
-      gap: var(--primitives-space-16, 16px);
+      gap: var(--primitives-space-16);
     }
 
     .logo-container {
       display: flex;
       align-items: center;
-      gap: var(--primitives-space-16, 16px);
+      gap: var(--primitives-space-16);
     }
 
     .logo {
@@ -48,7 +48,7 @@ export class RRNavLogo extends LitElement {
       align-items: center;
       justify-content: center;
       flex-shrink: 0;
-      color: var(--primitives-color-accent-100, #154273);
+      color: var(--primitives-color-accent-100);
     }
 
     /* Logo sizes per container */
@@ -77,7 +77,7 @@ export class RRNavLogo extends LitElement {
     .wordmark {
       display: flex;
       flex-direction: column;
-      gap: var(--primitives-space-2, 2px);
+      gap: var(--primitives-space-2);
     }
 
     :host(:not([has-wordmark])) .wordmark {
@@ -85,22 +85,22 @@ export class RRNavLogo extends LitElement {
     }
 
     .title {
-      font: var(--components-menu-bar-title-item-m-font, 550 20px/1.125 RijksSansVF, system-ui);
-      color: var(--primitives-color-neutral-900, #0f172a);
+      font: var(--components-menu-bar-title-item-m-font);
+      color: var(--primitives-color-neutral-900);
       margin: 0;
     }
 
     :host([container='s']) .title {
-      font: var(--components-menu-bar-title-item-s-font, 550 18px/1.125 RijksSansVF, system-ui);
+      font: var(--components-menu-bar-title-item-s-font);
     }
 
     :host([container='l']) .title {
-      font: var(--components-menu-bar-title-item-l-font, 550 23px/1.125 RijksSansVF, system-ui);
+      font: var(--components-menu-bar-title-item-l-font);
     }
 
     .subtitle {
       font: 400 16px/1.25 var(--rr-font-family-sans, RijksSansVF, system-ui);
-      color: var(--primitives-color-neutral-700, #334155);
+      color: var(--primitives-color-neutral-700);
       margin: 0;
     }
 
@@ -114,7 +114,7 @@ export class RRNavLogo extends LitElement {
 
     .supporting-text {
       font: 400 14px/1.25 var(--rr-font-family-sans, RijksSansVF, system-ui);
-      color: var(--primitives-color-accent-100, #154273);
+      color: var(--primitives-color-accent-100);
       margin: 0;
     }
 

--- a/src/components/top-navigation-bar/rr-top-navigation-bar.ts
+++ b/src/components/top-navigation-bar/rr-top-navigation-bar.ts
@@ -92,18 +92,18 @@ export class RRTopNavigationBar extends LitElement {
       left: 50%;
       transform: translateX(-50%);
       z-index: 1000;
-      background-color: var(--primitives-color-accent-100, #154273);
+      background-color: var(--primitives-color-accent-100);
       color: #ffffff;
-      padding: var(--primitives-space-8, 8px) var(--primitives-space-16, 16px);
-      font: var(--components-menu-bar-menu-item-font, 550 18px/1.125 RijksSansVF, system-ui);
+      padding: var(--primitives-space-8) var(--primitives-space-16);
+      font: var(--components-menu-bar-menu-item-font);
       text-decoration: none;
-      border-radius: var(--semantics-controls-md-corner-radius, 7px);
+      border-radius: var(--semantics-controls-md-corner-radius);
     }
 
     .skip-link:focus {
-      top: var(--primitives-space-8, 8px);
-      outline: var(--semantics-focus-rings-center-thickness, 2px) solid
-        var(--semantics-focus-rings-center-color, #0f172a);
+      top: var(--primitives-space-8);
+      outline: var(--semantics-focus-rings-center-thickness) solid
+        var(--semantics-focus-rings-center-color);
       outline-offset: 2px;
     }
 
@@ -113,22 +113,22 @@ export class RRTopNavigationBar extends LitElement {
       width: 100%;
       margin: 0 auto;
       background-color: #ffffff;
-      border-bottom: var(--semantics-dividers-thickness, 2px) solid
-        var(--semantics-dividers-color, #e2e8f0);
+      border-bottom: var(--semantics-dividers-thickness) solid
+        var(--semantics-dividers-color);
     }
 
     /* Container fills available width - no max-width constraints */
     :host([container='s']) .container {
-      min-width: var(--primitives-breakpoint-sm-min, 320px);
+      min-width: var(--primitives-breakpoint-sm-min);
     }
 
     :host([container='m']) .container,
     :host(:not([container])) .container {
-      min-width: var(--primitives-breakpoint-md-min, 641px);
+      min-width: var(--primitives-breakpoint-md-min);
     }
 
     :host([container='l']) .container {
-      min-width: var(--primitives-breakpoint-lg-min, 1008px);
+      min-width: var(--primitives-breakpoint-lg-min);
     }
 
     /* Logo bar - white background with centered logo */
@@ -159,19 +159,19 @@ export class RRTopNavigationBar extends LitElement {
 
     /* Responsive padding - base padding, spacers handle the rest */
     :host([container='s']) .nav-bar {
-      padding-left: var(--primitives-space-4, 4px);
-      padding-right: var(--primitives-space-4, 4px);
+      padding-left: var(--primitives-space-4);
+      padding-right: var(--primitives-space-4);
     }
 
     :host([container='m']) .nav-bar,
     :host(:not([container])) .nav-bar {
-      padding-left: var(--primitives-space-8, 8px);
-      padding-right: var(--primitives-space-8, 8px);
+      padding-left: var(--primitives-space-8);
+      padding-right: var(--primitives-space-8);
     }
 
     :host([container='l']) .nav-bar {
-      padding-left: var(--primitives-space-8, 8px);
-      padding-right: var(--primitives-space-8, 8px);
+      padding-left: var(--primitives-space-8);
+      padding-right: var(--primitives-space-8);
     }
 
     .nav-left {
@@ -195,20 +195,20 @@ export class RRTopNavigationBar extends LitElement {
 
     /* Navigation title */
     .nav-title {
-      font: var(--components-menu-bar-title-item-m-font, 550 20px/1.125 RijksSansVF, system-ui);
-      color: var(--primitives-color-neutral-900, #0f172a);
+      font: var(--components-menu-bar-title-item-m-font);
+      color: var(--primitives-color-neutral-900);
       /* Match Figma title-item padding: 0px 8px (8px on left AND right) */
-      padding-left: var(--primitives-space-8, 8px);
-      padding-right: var(--primitives-space-8, 8px);
+      padding-left: var(--primitives-space-8);
+      padding-right: var(--primitives-space-8);
       white-space: nowrap;
     }
 
     :host([container='s']) .nav-title {
-      font: var(--components-menu-bar-title-item-s-font, 550 18px/1.125 RijksSansVF, system-ui);
+      font: var(--components-menu-bar-title-item-s-font);
     }
 
     :host([container='l']) .nav-title {
-      font: var(--components-menu-bar-title-item-l-font, 550 23px/1.125 RijksSansVF, system-ui);
+      font: var(--components-menu-bar-title-item-l-font);
     }
 
     /* Menu bar integration - remove its own border as nav-bar provides structure */
@@ -248,7 +248,7 @@ export class RRTopNavigationBar extends LitElement {
 
     :host([has-back-button]) rr-back-button {
       display: inline-flex;
-      margin-right: var(--primitives-space-8, 8px);
+      margin-right: var(--primitives-space-8);
     }
   `;
 

--- a/src/components/top-navigation-bar/rr-top-navigation-bar.ts
+++ b/src/components/top-navigation-bar/rr-top-navigation-bar.ts
@@ -97,13 +97,13 @@ export class RRTopNavigationBar extends LitElement {
       padding: var(--primitives-space-8, 8px) var(--primitives-space-16, 16px);
       font: var(--components-menu-bar-menu-item-font, 550 18px/1.125 RijksSansVF, system-ui);
       text-decoration: none;
-      border-radius: var(--semantics-controls-m-corner-radius, 7px);
+      border-radius: var(--semantics-controls-md-corner-radius, 7px);
     }
 
     .skip-link:focus {
       top: var(--primitives-space-8, 8px);
-      outline: var(--semantics-focus-ring-thickness, 2px) solid
-        var(--semantics-focus-ring-color, #0f172a);
+      outline: var(--semantics-focus-rings-center-thickness, 2px) solid
+        var(--semantics-focus-rings-center-color, #0f172a);
       outline-offset: 2px;
     }
 
@@ -113,22 +113,22 @@ export class RRTopNavigationBar extends LitElement {
       width: 100%;
       margin: 0 auto;
       background-color: #ffffff;
-      border-bottom: var(--semantics-divider-thickness, 2px) solid
-        var(--semantics-divider-color, #e2e8f0);
+      border-bottom: var(--semantics-dividers-thickness, 2px) solid
+        var(--semantics-dividers-color, #e2e8f0);
     }
 
     /* Container fills available width - no max-width constraints */
     :host([container='s']) .container {
-      min-width: var(--primitives-breakpoint-s-min, 320px);
+      min-width: var(--primitives-breakpoint-sm-min, 320px);
     }
 
     :host([container='m']) .container,
     :host(:not([container])) .container {
-      min-width: var(--primitives-breakpoint-m-min, 641px);
+      min-width: var(--primitives-breakpoint-md-min, 641px);
     }
 
     :host([container='l']) .container {
-      min-width: var(--primitives-breakpoint-l-min, 1008px);
+      min-width: var(--primitives-breakpoint-lg-min, 1008px);
     }
 
     /* Logo bar - white background with centered logo */

--- a/src/components/top-navigation-bar/rr-utility-menu-bar.js
+++ b/src/components/top-navigation-bar/rr-utility-menu-bar.js
@@ -191,7 +191,7 @@ export class RRUtilityMenuBar extends RRBaseComponent {
       :host {
         display: flex;
         align-items: center;
-        gap: var(--primitives-space-8, 8px);
+        gap: var(--primitives-space-8);
       }
 
       :host([hidden]) {
@@ -205,31 +205,31 @@ export class RRUtilityMenuBar extends RRBaseComponent {
       .container {
         display: flex;
         align-items: center;
-        gap: var(--primitives-space-8, 8px);
+        gap: var(--primitives-space-8);
       }
 
       /* Utility buttons */
       .utility-button {
         display: flex;
         align-items: center;
-        gap: var(--primitives-space-8, 8px);
-        padding: var(--primitives-space-8, 8px) var(--primitives-space-16, 16px);
+        gap: var(--primitives-space-8);
+        padding: var(--primitives-space-8) var(--primitives-space-16);
         background: none;
         border: none;
-        color: var(--primitives-color-accent-100, #154273);
-        font: var(--components-menu-bar-menu-item-font, 550 18px/1.125 RijksSansVF, system-ui);
+        color: var(--primitives-color-accent-100);
+        font: var(--components-menu-bar-menu-item-font);
         cursor: pointer;
-        border-radius: var(--semantics-controls-md-corner-radius, 7px);
+        border-radius: var(--semantics-controls-md-corner-radius);
         transition: background-color 0.15s ease;
         white-space: nowrap;
       }
 
       .utility-button:hover {
-        background-color: var(--primitives-color-neutral-100, #f1f5f9);
+        background-color: var(--primitives-color-neutral-100);
       }
 
       .utility-button:focus-visible {
-        outline: var(--semantics-focus-rings-center-thickness, 2px) solid var(--semantics-focus-rings-center-color, #0f172a);
+        outline: var(--semantics-focus-rings-center-thickness) solid var(--semantics-focus-rings-center-color);
         outline-offset: 2px;
       }
 
@@ -263,7 +263,7 @@ export class RRUtilityMenuBar extends RRBaseComponent {
 
       /* Size adjustments */
       :host([container="s"]) .utility-button {
-        padding: var(--primitives-space-8, 8px);
+        padding: var(--primitives-space-8);
       }
     `;
   }

--- a/src/components/top-navigation-bar/rr-utility-menu-bar.js
+++ b/src/components/top-navigation-bar/rr-utility-menu-bar.js
@@ -219,7 +219,7 @@ export class RRUtilityMenuBar extends RRBaseComponent {
         color: var(--primitives-color-accent-100, #154273);
         font: var(--components-menu-bar-menu-item-font, 550 18px/1.125 RijksSansVF, system-ui);
         cursor: pointer;
-        border-radius: var(--semantics-controls-m-corner-radius, 7px);
+        border-radius: var(--semantics-controls-md-corner-radius, 7px);
         transition: background-color 0.15s ease;
         white-space: nowrap;
       }
@@ -229,7 +229,7 @@ export class RRUtilityMenuBar extends RRBaseComponent {
       }
 
       .utility-button:focus-visible {
-        outline: var(--semantics-focus-ring-thickness, 2px) solid var(--semantics-focus-ring-color, #0f172a);
+        outline: var(--semantics-focus-rings-center-thickness, 2px) solid var(--semantics-focus-rings-center-color, #0f172a);
         outline-offset: 2px;
       }
 

--- a/src/components/top-navigation-bar/rr-utility-menu-bar.ts
+++ b/src/components/top-navigation-bar/rr-utility-menu-bar.ts
@@ -131,7 +131,7 @@ export class RRUtilityMenuBar extends LitElement {
     }
 
     .utility-button:focus-visible {
-      outline: var(--semantics-focus-ring-thickness, 2px) solid var(--semantics-focus-ring-color, #0f172a);
+      outline: var(--semantics-focus-rings-center-thickness, 2px) solid var(--semantics-focus-rings-center-color, #0f172a);
       outline-offset: 2px;
     }
 

--- a/src/components/top-navigation-bar/rr-utility-menu-bar.ts
+++ b/src/components/top-navigation-bar/rr-utility-menu-bar.ts
@@ -113,13 +113,13 @@ export class RRUtilityMenuBar extends LitElement {
     .utility-button {
       display: flex;
       align-items: center;
-      gap: var(--primitives-space-4, 4px);
-      padding: 0 var(--primitives-space-8, 8px);
+      gap: var(--primitives-space-4);
+      padding: 0 var(--primitives-space-8);
       height: 44px;
       background: none;
       border: none;
-      color: var(--components-menu-bar-menu-item-color, #154273);
-      font: var(--components-menu-bar-menu-item-font, 550 18px/1.125 RijksSansVF, system-ui);
+      color: var(--components-menu-bar-menu-item-color);
+      font: var(--components-menu-bar-menu-item-font);
       cursor: pointer;
       border-radius: 0;
       transition: background-color 0.15s ease;
@@ -127,11 +127,11 @@ export class RRUtilityMenuBar extends LitElement {
     }
 
     .utility-button:hover {
-      background-color: var(--primitives-color-neutral-100, #f1f5f9);
+      background-color: var(--primitives-color-neutral-100);
     }
 
     .utility-button:focus-visible {
-      outline: var(--semantics-focus-rings-center-thickness, 2px) solid var(--semantics-focus-rings-center-color, #0f172a);
+      outline: var(--semantics-focus-rings-center-thickness) solid var(--semantics-focus-rings-center-color);
       outline-offset: 2px;
     }
 
@@ -165,7 +165,7 @@ export class RRUtilityMenuBar extends LitElement {
 
     /* Size adjustments */
     :host([container='s']) .utility-button {
-      padding: var(--primitives-space-8, 8px);
+      padding: var(--primitives-space-8);
     }
 
     /* Accessibility: Reduced motion */

--- a/src/parser/figma-variables-parser.js
+++ b/src/parser/figma-variables-parser.js
@@ -15,8 +15,11 @@ export const figmaVariablesParser = {
 
     // Process all collections
     for (const collection of figmaTokens.collections || []) {
-      for (const mode of collection.modes || []) {
-        for (const variable of mode.variables || []) {
+      // Only use Light mode - find mode with "Light" in name, or use first mode as fallback
+      const lightMode = collection.modes?.find(m => m.name.includes('Light')) || collection.modes?.[0];
+      if (!lightMode) continue;
+
+      for (const variable of lightMode.variables || []) {
           const pathParts = variable.name.split('/');
           let current = result;
 
@@ -45,7 +48,6 @@ export const figmaVariablesParser = {
 
           current[tokenName] = token;
         }
-      }
     }
 
     return result;

--- a/tokens/rr-tokens.json
+++ b/tokens/rr-tokens.json
@@ -6,15 +6,69 @@
       "name": "Themes",
       "modes": [
         {
-          "name": "Rijksoverheid",
+          "name": "Rijksoverheid (Light)",
           "variables": [
+            {
+              "name": "components/list/item/sm/padding-block",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/space/8"
+              }
+            },
+            {
+              "name": "components/list/item/md/padding-block",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/space/12"
+              }
+            },
+            {
+              "name": "components/list/item/is-selected/corner-radius",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/corner-radius/md"
+              }
+            },
+            {
+              "name": "components/list/item/is-selected/background-color",
+              "type": "color",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/color/accent/750 (reference)"
+              }
+            },
+            {
+              "name": "components/list/item/is-selected/content/color",
+              "type": "color",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/color/neutral/0"
+              }
+            },
             {
               "name": "components/menu-bar/menu-item/color",
               "type": "color",
               "isAlias": true,
               "value": {
                 "collection": "Themes",
-                "name": "primitives/color/accent/100"
+                "name": "primitives/color/accent/750 (reference)"
+              }
+            },
+            {
+              "name": "components/menu-bar/menu-item/is-selected/color",
+              "type": "color",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/color/accent/750 (reference)"
               }
             },
             {
@@ -23,7 +77,7 @@
               "isAlias": true,
               "value": {
                 "collection": "Themes",
-                "name": "primitives/color/accent/100"
+                "name": "primitives/color/accent/750 (reference)"
               }
             },
             {
@@ -41,7 +95,7 @@
               "isAlias": true,
               "value": {
                 "collection": "Themes",
-                "name": "primitives/color/neutral/200"
+                "name": "primitives/color/neutral/100"
               }
             },
             {
@@ -74,7 +128,7 @@
               "isAlias": true,
               "value": {
                 "collection": "Themes",
-                "name": "semantics/views/background-color"
+                "name": "semantics/surfaces/background-color"
               }
             },
             {
@@ -83,7 +137,7 @@
               "isAlias": true,
               "value": {
                 "collection": "Themes",
-                "name": "primitives/color/accent/100"
+                "name": "primitives/color/accent/700"
               }
             },
             {
@@ -92,7 +146,7 @@
               "isAlias": true,
               "value": {
                 "collection": "Themes",
-                "name": "semantics/content/white/color"
+                "name": "primitives/color/neutral/0"
               }
             },
             {
@@ -116,7 +170,7 @@
               "isAlias": true,
               "value": {
                 "collection": "Themes",
-                "name": "semantics/views/background-color"
+                "name": "semantics/surfaces/background-color"
               }
             },
             {
@@ -125,7 +179,7 @@
               "isAlias": true,
               "value": {
                 "collection": "Themes",
-                "name": "primitives/color/accent/100"
+                "name": "primitives/color/accent/700"
               }
             },
             {
@@ -140,7 +194,7 @@
               "isAlias": true,
               "value": {
                 "collection": "Themes",
-                "name": "semantics/content/white/color"
+                "name": "primitives/color/neutral/0"
               }
             },
             {
@@ -164,7 +218,7 @@
               "isAlias": true,
               "value": {
                 "collection": "Themes",
-                "name": "semantics/views/background-color"
+                "name": "semantics/surfaces/background-color"
               }
             },
             {
@@ -188,7 +242,7 @@
               "isAlias": true,
               "value": {
                 "collection": "Themes",
-                "name": "semantics/views/background-color"
+                "name": "semantics/surfaces/background-color"
               }
             },
             {
@@ -206,7 +260,7 @@
               "isAlias": true,
               "value": {
                 "collection": "Themes",
-                "name": "primitives/color/accent/100"
+                "name": "primitives/color/accent/700"
               }
             },
             {
@@ -215,7 +269,7 @@
               "isAlias": true,
               "value": {
                 "collection": "Themes",
-                "name": "semantics/content/white/color"
+                "name": "primitives/color/neutral/0"
               }
             },
             {
@@ -224,61 +278,7 @@
               "isAlias": true,
               "value": {
                 "collection": "Themes",
-                "name": "primitives/color/accent/100"
-              }
-            },
-            {
-              "name": "components/toggle-button/content/color",
-              "type": "color",
-              "isAlias": true,
-              "value": {
-                "collection": "Themes",
-                "name": "semantics/buttons/neutral-tinted/color"
-              }
-            },
-            {
-              "name": "components/toggle-button/is-hovered/background-color",
-              "type": "color",
-              "isAlias": true,
-              "value": {
-                "collection": "Themes",
-                "name": "primitives/color/neutral/300"
-              }
-            },
-            {
-              "name": "components/toggle-button/is-hovered/content/color",
-              "type": "color",
-              "isAlias": true,
-              "value": {
-                "collection": "Themes",
-                "name": "primitives/color/neutral/900"
-              }
-            },
-            {
-              "name": "components/toggle-button/is-selected/background-color",
-              "type": "color",
-              "isAlias": true,
-              "value": {
-                "collection": "Themes",
-                "name": "primitives/color/accent/100"
-              }
-            },
-            {
-              "name": "components/toggle-button/is-selected/content/color",
-              "type": "color",
-              "isAlias": true,
-              "value": {
-                "collection": "Themes",
-                "name": "semantics/content/white/color"
-              }
-            },
-            {
-              "name": "components/toggle-button/background-color",
-              "type": "color",
-              "isAlias": true,
-              "value": {
-                "collection": "Themes",
-                "name": "semantics/buttons/neutral-tinted/background-color"
+                "name": "primitives/color/accent/700"
               }
             },
             {
@@ -287,52 +287,16 @@
               "isAlias": true,
               "value": {
                 "collection": "Themes",
-                "name": "semantics/views/tinted/background-color"
+                "name": "semantics/surfaces/tinted/background-color"
               }
             },
             {
-              "name": "semantics/content/color",
+              "name": "components/box/is-on-tinted/background-color",
               "type": "color",
               "isAlias": true,
               "value": {
                 "collection": "Themes",
-                "name": "primitives/color/neutral/800"
-              }
-            },
-            {
-              "name": "semantics/content/white/color",
-              "type": "color",
-              "isAlias": true,
-              "value": {
-                "collection": "Themes",
-                "name": "primitives/color/neutral/0"
-              }
-            },
-            {
-              "name": "semantics/content/secondary/color",
-              "type": "color",
-              "isAlias": true,
-              "value": {
-                "collection": "Themes",
-                "name": "primitives/color/neutral/600"
-              }
-            },
-            {
-              "name": "semantics/views/background-color",
-              "type": "color",
-              "isAlias": true,
-              "value": {
-                "collection": "Themes",
-                "name": "primitives/color/neutral/0"
-              }
-            },
-            {
-              "name": "semantics/views/tinted/background-color",
-              "type": "color",
-              "isAlias": true,
-              "value": {
-                "collection": "Themes",
-                "name": "primitives/color/neutral/100"
+                "name": "semantics/surfaces/background-color"
               }
             },
             {
@@ -341,7 +305,7 @@
               "isAlias": true,
               "value": {
                 "collection": "Themes",
-                "name": "primitives/corner-radius/l"
+                "name": "primitives/corner-radius/xl"
               }
             },
             {
@@ -354,21 +318,102 @@
               }
             },
             {
+              "name": "components/top-title-bar/button-bar-divider/color",
+              "type": "color",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/color/neutral/150"
+              }
+            },
+            {
+              "name": "components/toolbar/sm/gap",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/space/6"
+              }
+            },
+            {
+              "name": "components/grab-handle/background-color",
+              "type": "color",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/color/neutral/100"
+              }
+            },
+            {
+              "name": "components/form/gap",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/space/16"
+              }
+            },
+            {
+              "name": "components/toolbar/md/gap",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/space/8"
+              }
+            },
+            {
+              "name": "components/grab-handle/color",
+              "type": "color",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/color/neutral/500"
+              }
+            },
+            {
+              "name": "semantics/surfaces/background-color",
+              "type": "color",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/color/neutral/0"
+              }
+            },
+            {
+              "name": "semantics/surfaces/tinted/background-color",
+              "type": "color",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/color/neutral/25"
+              }
+            },
+            {
+              "name": "semantics/content/color",
+              "type": "color",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/color/neutral/800"
+              }
+            },
+            {
+              "name": "semantics/content/secondary/color",
+              "type": "color",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/color/neutral/600"
+              }
+            },
+            {
               "name": "semantics/links/color",
               "type": "color",
               "isAlias": true,
               "value": {
                 "collection": "Themes",
-                "name": "primitives/color/accent/100"
-              }
-            },
-            {
-              "name": "semantics/divider/color",
-              "type": "color",
-              "isAlias": true,
-              "value": {
-                "collection": "Themes",
-                "name": "primitives/color/neutral/200"
+                "name": "primitives/color/accent/700"
               }
             },
             {
@@ -390,13 +435,7 @@
               }
             },
             {
-              "name": "semantics/controls/xs/focus-ring/corner-radius",
-              "type": "number",
-              "isAlias": false,
-              "value": 7
-            },
-            {
-              "name": "semantics/controls/s/min-size",
+              "name": "semantics/controls/sm/min-size",
               "type": "number",
               "isAlias": true,
               "value": {
@@ -405,22 +444,16 @@
               }
             },
             {
-              "name": "semantics/controls/s/corner-radius",
+              "name": "semantics/controls/sm/corner-radius",
               "type": "number",
               "isAlias": true,
               "value": {
                 "collection": "Themes",
-                "name": "primitives/corner-radius/s"
+                "name": "primitives/corner-radius/sm"
               }
             },
             {
-              "name": "semantics/controls/s/focus-ring/corner-radius",
-              "type": "number",
-              "isAlias": false,
-              "value": 9
-            },
-            {
-              "name": "semantics/controls/m/min-size",
+              "name": "semantics/controls/md/min-size",
               "type": "number",
               "isAlias": true,
               "value": {
@@ -429,22 +462,121 @@
               }
             },
             {
-              "name": "semantics/controls/m/corner-radius",
+              "name": "semantics/controls/md/corner-radius",
               "type": "number",
               "isAlias": true,
               "value": {
                 "collection": "Themes",
-                "name": "primitives/corner-radius/m"
+                "name": "primitives/corner-radius/md"
               }
             },
             {
-              "name": "semantics/divider/thickness",
-              "type": "number",
-              "isAlias": false,
-              "value": 2
+              "name": "semantics/buttons/neutral-tinted/divider/color",
+              "type": "color",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/color/neutral/250"
+              }
             },
             {
-              "name": "semantics/input-fields/background-color",
+              "name": "semantics/buttons/neutral-tinted/end-fade/start-color",
+              "type": "color",
+              "isAlias": false,
+              "value": "#D7DEEA00"
+            },
+            {
+              "name": "semantics/buttons/neutral-tinted/end-fade/end-color",
+              "type": "color",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "semantics/buttons/neutral-tinted/background-color"
+              }
+            },
+            {
+              "name": "semantics/buttons/sm/divider/length",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/space/20"
+              }
+            },
+            {
+              "name": "semantics/buttons/md/divider/length",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/space/28"
+              }
+            },
+            {
+              "name": "semantics/buttons/neutral-tinted/background-color",
+              "type": "color",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/color/neutral/100"
+              }
+            },
+            {
+              "name": "semantics/buttons/neutral-tinted/content/color",
+              "type": "color",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/color/neutral/900"
+              }
+            },
+            {
+              "name": "semantics/buttons/neutral-tinted/is-hovered/background-color",
+              "type": "color",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/color/neutral/150"
+              }
+            },
+            {
+              "name": "semantics/buttons/neutral-tinted/is-hovered/content/color",
+              "type": "color",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/color/neutral/1000"
+              }
+            },
+            {
+              "name": "semantics/buttons/neutral-tinted/is-active/content/color",
+              "type": "color",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/color/neutral/1000"
+              }
+            },
+            {
+              "name": "semantics/buttons/neutral-tinted/is-active/background-color",
+              "type": "color",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/color/neutral/200"
+              }
+            },
+            {
+              "name": "semantics/buttons/neutral-tinted/is-selected/backround-color",
+              "type": "color",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/color/accent/750 (reference)"
+              }
+            },
+            {
+              "name": "semantics/buttons/neutral-tinted/is-selected/content/color",
               "type": "color",
               "isAlias": true,
               "value": {
@@ -453,22 +585,211 @@
               }
             },
             {
-              "name": "semantics/buttons/m/font-size",
-              "type": "number",
-              "isAlias": true,
-              "value": {
-                "collection": "Themes",
-                "name": "primitives/font-size/body-m"
-              }
-            },
-            {
-              "name": "semantics/input-fields/border-color",
+              "name": "semantics/buttons/neutral-transparent/content/color",
               "type": "color",
               "isAlias": true,
               "value": {
                 "collection": "Themes",
-                "name": "primitives/color/neutral/600"
+                "name": "primitives/color/neutral/900"
               }
+            },
+            {
+              "name": "semantics/buttons/neutral-transparent/is-active/content/color",
+              "type": "color",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/color/neutral/1000"
+              }
+            },
+            {
+              "name": "semantics/buttons/neutral-transparent/is-hovered/background-color",
+              "type": "color",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/color/neutral/150"
+              }
+            },
+            {
+              "name": "semantics/buttons/neutral-transparent/is-hovered/content/color",
+              "type": "color",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/color/neutral/1000"
+              }
+            },
+            {
+              "name": "semantics/buttons/neutral-transparent/is-active/background-color",
+              "type": "color",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/color/neutral/200"
+              }
+            },
+            {
+              "name": "semantics/buttons/neutral-transparent/is-selected/backround-color",
+              "type": "color",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/color/accent/750 (reference)"
+              }
+            },
+            {
+              "name": "semantics/buttons/neutral-transparent/is-selected/content/color",
+              "type": "color",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/color/neutral/0"
+              }
+            },
+            {
+              "name": "semantics/buttons/accent-filled/content/color",
+              "type": "color",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/color/neutral/0"
+              }
+            },
+            {
+              "name": "semantics/buttons/accent-filled/background-color",
+              "type": "color",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/color/accent/750 (reference)"
+              }
+            },
+            {
+              "name": "semantics/buttons/accent-filled/is-hovered/content/color",
+              "type": "color",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/color/neutral/0"
+              }
+            },
+            {
+              "name": "semantics/buttons/accent-filled/is-hovered/background-color",
+              "type": "color",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/color/accent/800"
+              }
+            },
+            {
+              "name": "semantics/buttons/accent-tinted/content/color",
+              "type": "color",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/color/accent/750 (reference)"
+              }
+            },
+            {
+              "name": "semantics/buttons/accent-tinted/background-color",
+              "type": "color",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/color/accent/100"
+              }
+            },
+            {
+              "name": "semantics/buttons/accent-tinted/is-hovered/content/color",
+              "type": "color",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/color/accent/750 (reference)"
+              }
+            },
+            {
+              "name": "semantics/buttons/accent-tinted/is-hovered/background-color",
+              "type": "color",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/color/accent/150"
+              }
+            },
+            {
+              "name": "semantics/buttons/accent-outlined/content/color",
+              "type": "color",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/color/accent/750 (reference)"
+              }
+            },
+            {
+              "name": "semantics/buttons/accent-outlined/border-color",
+              "type": "color",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/color/accent/750 (reference)"
+              }
+            },
+            {
+              "name": "semantics/buttons/accent-outlined/border-thickness",
+              "type": "number",
+              "isAlias": false,
+              "value": 2
+            },
+            {
+              "name": "semantics/buttons/accent-transparent/content/color",
+              "type": "color",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/color/accent/750 (reference)"
+              }
+            },
+            {
+              "name": "semantics/buttons/danger-tinted/content/color",
+              "type": "color",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/color/danger/600"
+              }
+            },
+            {
+              "name": "semantics/buttons/danger-tinted/background-color",
+              "type": "color",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/color/danger/100"
+              }
+            },
+            {
+              "name": "semantics/input-fields/border-thickness",
+              "type": "number",
+              "isAlias": false,
+              "value": 2
+            },
+            {
+              "name": "semantics/dividers/color",
+              "type": "color",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/color/neutral/100"
+              }
+            },
+            {
+              "name": "semantics/dividers/thickness",
+              "type": "number",
+              "isAlias": false,
+              "value": 1
             },
             {
               "name": "semantics/input-fields/placeholder/color",
@@ -480,97 +801,37 @@
               }
             },
             {
-              "name": "semantics/input-fields/border-thickness",
-              "type": "number",
+              "name": "semantics/input-fields/end-fade/start-color",
+              "type": "color",
               "isAlias": false,
-              "value": 2
+              "value": "#FFFFFF00"
             },
             {
-              "name": "semantics/buttons/s/font-size",
-              "type": "number",
-              "isAlias": true,
-              "value": {
-                "collection": "Themes",
-                "name": "primitives/font-size/body-m"
-              }
-            },
-            {
-              "name": "semantics/buttons/neutral-tinted/color",
+              "name": "semantics/input-fields/background-color",
               "type": "color",
               "isAlias": true,
               "value": {
                 "collection": "Themes",
-                "name": "primitives/color/neutral/900"
+                "name": "semantics/surfaces/background-color"
               }
             },
             {
-              "name": "semantics/buttons/neutral-tinted/background-color",
+              "name": "semantics/input-fields/border-color",
               "type": "color",
               "isAlias": true,
               "value": {
                 "collection": "Themes",
-                "name": "primitives/color/neutral/200"
+                "name": "primitives/color/neutral/500"
               }
             },
             {
-              "name": "semantics/buttons/accent-filled/color",
+              "name": "semantics/input-fields/end-fade/end-color",
               "type": "color",
               "isAlias": true,
               "value": {
                 "collection": "Themes",
-                "name": "primitives/color/neutral/0"
+                "name": "semantics/input-fields/background-color"
               }
-            },
-            {
-              "name": "semantics/buttons/accent-tinted/color",
-              "type": "color",
-              "isAlias": true,
-              "value": {
-                "collection": "Themes",
-                "name": "primitives/color/accent/100"
-              }
-            },
-            {
-              "name": "semantics/buttons/accent-tinted/background-color",
-              "type": "color",
-              "isAlias": true,
-              "value": {
-                "collection": "Themes",
-                "name": "primitives/color/accent/15"
-              }
-            },
-            {
-              "name": "semantics/buttons/accent-filled/background-color",
-              "type": "color",
-              "isAlias": true,
-              "value": {
-                "collection": "Themes",
-                "name": "primitives/color/accent/100"
-              }
-            },
-            {
-              "name": "semantics/buttons/accent-outlined/color",
-              "type": "color",
-              "isAlias": true,
-              "value": {
-                "collection": "Themes",
-                "name": "primitives/color/accent/100"
-              }
-            },
-            {
-              "name": "semantics/buttons/accent-outlined/border-color",
-              "type": "color",
-              "isAlias": true,
-              "value": {
-                "collection": "Themes",
-                "name": "primitives/color/accent/100"
-              }
-            },
-            {
-              "name": "semantics/buttons/accent-outlined/border-thickness",
-              "type": "number",
-              "isAlias": false,
-              "value": 2
             },
             {
               "name": "semantics/input-fields/is-valid/border-color",
@@ -578,16 +839,16 @@
               "isAlias": true,
               "value": {
                 "collection": "Themes",
-                "name": "primitives/color/success/100"
+                "name": "primitives/color/success/500"
               }
             },
             {
-              "name": "semantics/input-fields/is-valid/icon-color",
+              "name": "semantics/input-fields/is-valid/icon/color",
               "type": "color",
               "isAlias": true,
               "value": {
                 "collection": "Themes",
-                "name": "primitives/color/success/100"
+                "name": "primitives/color/success/500"
               }
             },
             {
@@ -596,34 +857,124 @@
               "isAlias": true,
               "value": {
                 "collection": "Themes",
-                "name": "primitives/color/danger/100"
+                "name": "primitives/color/danger/500"
               }
             },
             {
-              "name": "semantics/input-fields/is-invalid/icon-color",
+              "name": "semantics/input-fields/is-read-only/background-color",
               "type": "color",
               "isAlias": true,
               "value": {
                 "collection": "Themes",
-                "name": "primitives/color/danger/100"
+                "name": "primitives/color/neutral/50"
               }
             },
             {
-              "name": "semantics/sections/s/margin-inline",
+              "name": "semantics/input-fields/is-read-only/border-color",
+              "type": "color",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/color/neutral/50"
+              }
+            },
+            {
+              "name": "semantics/input-fields/is-invalid/icon/color",
+              "type": "color",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/color/danger/500"
+              }
+            },
+            {
+              "name": "semantics/page-sections/body/max-width",
               "type": "number",
               "isAlias": true,
               "value": {
                 "collection": "Themes",
-                "name": "primitives/space/20"
+                "name": "primitives/area/1280"
               }
             },
             {
-              "name": "semantics/buttons/accent-transparent/color",
-              "type": "color",
+              "name": "semantics/page-sections/sm/margin-inline",
+              "type": "number",
               "isAlias": true,
               "value": {
                 "collection": "Themes",
-                "name": "primitives/color/accent/100"
+                "name": "primitives/space/16"
+              }
+            },
+            {
+              "name": "semantics/page-sections/sm/margin-block",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/space/16"
+              }
+            },
+            {
+              "name": "semantics/page-sections/sm/gap",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/space/16"
+              }
+            },
+            {
+              "name": "semantics/page-sections/md/margin-inline",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/space/32"
+              }
+            },
+            {
+              "name": "semantics/page-sections/md/margin-block",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/space/24"
+              }
+            },
+            {
+              "name": "semantics/page-sections/md/gap",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/space/24"
+              }
+            },
+            {
+              "name": "semantics/page-sections/lg/margin-inline",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/space/48"
+              }
+            },
+            {
+              "name": "semantics/page-sections/lg/margin-block",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/space/32"
+              }
+            },
+            {
+              "name": "semantics/page-sections/lg/gap",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/space/24"
               }
             },
             {
@@ -636,43 +987,16 @@
               }
             },
             {
-              "name": "semantics/focus-ring/color",
+              "name": "semantics/focus-rings/inner/color",
               "type": "color",
               "isAlias": true,
               "value": {
                 "collection": "Themes",
-                "name": "primitives/color/neutral/1000"
+                "name": "semantics/surfaces/background-color"
               }
             },
             {
-              "name": "semantics/sections/s/margin-block",
-              "type": "number",
-              "isAlias": true,
-              "value": {
-                "collection": "Themes",
-                "name": "primitives/space/20"
-              }
-            },
-            {
-              "name": "semantics/sections/s/gap",
-              "type": "number",
-              "isAlias": true,
-              "value": {
-                "collection": "Themes",
-                "name": "primitives/space/16"
-              }
-            },
-            {
-              "name": "semantics/sections/max-width",
-              "type": "number",
-              "isAlias": true,
-              "value": {
-                "collection": "Themes",
-                "name": "primitives/area/1280"
-              }
-            },
-            {
-              "name": "semantics/focus-ring/thickness",
+              "name": "semantics/focus-rings/inner/thickness",
               "type": "number",
               "isAlias": true,
               "value": {
@@ -681,12 +1005,21 @@
               }
             },
             {
-              "name": "semantics/buttons/font-weight",
-              "type": "string",
+              "name": "semantics/focus-rings/center/color",
+              "type": "color",
               "isAlias": true,
               "value": {
                 "collection": "Themes",
-                "name": "primitives/font-weight/body/semi-bold"
+                "name": "primitives/color/accent/550"
+              }
+            },
+            {
+              "name": "semantics/focus-rings/center/thickness",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/space/4"
               }
             },
             {
@@ -696,22 +1029,40 @@
               "value": "#FFFFFF"
             },
             {
+              "name": "primitives/color/neutral/25",
+              "type": "color",
+              "isAlias": false,
+              "value": "#F5F6F9"
+            },
+            {
               "name": "primitives/color/neutral/50",
               "type": "color",
               "isAlias": false,
-              "value": "#F8FAFC"
+              "value": "#EBEEF2"
+            },
+            {
+              "name": "primitives/color/neutral/75",
+              "type": "color",
+              "isAlias": false,
+              "value": "#E2E6EB"
             },
             {
               "name": "primitives/color/neutral/100",
               "type": "color",
               "isAlias": false,
-              "value": "#F1F5F9"
+              "value": "#D9DEE4"
             },
             {
               "name": "primitives/font-family/body",
               "type": "string",
               "isAlias": false,
               "value": "RijksSansVF"
+            },
+            {
+              "name": "primitives/color/neutral/150",
+              "type": "color",
+              "isAlias": false,
+              "value": "#C9CED8"
             },
             {
               "name": "primitives/font-family/body-fallback",
@@ -759,49 +1110,97 @@
               "name": "primitives/color/neutral/200",
               "type": "color",
               "isAlias": false,
-              "value": "#D8DEE7"
+              "value": "#B8C0CB"
+            },
+            {
+              "name": "primitives/color/neutral/250",
+              "type": "color",
+              "isAlias": false,
+              "value": "#A9B2C0"
             },
             {
               "name": "primitives/color/neutral/300",
               "type": "color",
               "isAlias": false,
-              "value": "#CBD5E1"
+              "value": "#9BA5B5"
+            },
+            {
+              "name": "primitives/color/neutral/350",
+              "type": "color",
+              "isAlias": false,
+              "value": "#8D98AA"
             },
             {
               "name": "primitives/color/neutral/400",
               "type": "color",
               "isAlias": false,
-              "value": "#94A3B8"
+              "value": "#808DA0"
+            },
+            {
+              "name": "primitives/color/neutral/450",
+              "type": "color",
+              "isAlias": false,
+              "value": "#738197"
             },
             {
               "name": "primitives/color/neutral/500",
               "type": "color",
               "isAlias": false,
-              "value": "#64748B"
+              "value": "#67778D"
+            },
+            {
+              "name": "primitives/color/neutral/550",
+              "type": "color",
+              "isAlias": false,
+              "value": "#5D6C81"
             },
             {
               "name": "primitives/color/neutral/600",
               "type": "color",
               "isAlias": false,
-              "value": "#475569"
+              "value": "#556275"
+            },
+            {
+              "name": "primitives/color/neutral/650",
+              "type": "color",
+              "isAlias": false,
+              "value": "#4C5869"
             },
             {
               "name": "primitives/color/neutral/700",
               "type": "color",
               "isAlias": false,
-              "value": "#334155"
+              "value": "#444E5D"
+            },
+            {
+              "name": "primitives/color/neutral/750",
+              "type": "color",
+              "isAlias": false,
+              "value": "#3B4451"
             },
             {
               "name": "primitives/color/neutral/800",
               "type": "color",
               "isAlias": false,
-              "value": "#1E293B"
+              "value": "#333A45"
+            },
+            {
+              "name": "primitives/color/neutral/850",
+              "type": "color",
+              "isAlias": false,
+              "value": "#2A3039"
             },
             {
               "name": "primitives/color/neutral/900",
               "type": "color",
               "isAlias": false,
-              "value": "#1F252D"
+              "value": "#20252B"
+            },
+            {
+              "name": "primitives/color/neutral/950",
+              "type": "color",
+              "isAlias": false,
+              "value": "#14171A"
             },
             {
               "name": "primitives/color/neutral/1000",
@@ -810,520 +1209,778 @@
               "value": "#000000"
             },
             {
-              "name": "primitives/color/accent/100",
+              "name": "primitives/color/accent/0",
               "type": "color",
-              "isAlias": true,
-              "value": {
-                "collection": "Themes",
-                "name": "primitives/color/lintblauw/100"
-              }
+              "isAlias": false,
+              "value": "#FFFFFF"
+            },
+            {
+              "name": "primitives/color/accent/25",
+              "type": "color",
+              "isAlias": false,
+              "value": "#F3F6FF"
+            },
+            {
+              "name": "primitives/color/accent/50",
+              "type": "color",
+              "isAlias": false,
+              "value": "#E7EEFF"
             },
             {
               "name": "primitives/color/accent/75",
               "type": "color",
-              "isAlias": true,
-              "value": {
-                "collection": "Themes",
-                "name": "primitives/color/lintblauw/75"
-              }
+              "isAlias": false,
+              "value": "#DBE5FF"
             },
             {
-              "name": "primitives/color/accent/60",
+              "name": "primitives/color/accent/100",
               "type": "color",
-              "isAlias": true,
-              "value": {
-                "collection": "Themes",
-                "name": "primitives/color/lintblauw/60"
-              }
+              "isAlias": false,
+              "value": "#CFDDFF"
             },
             {
-              "name": "primitives/color/accent/45",
+              "name": "primitives/color/accent/150",
               "type": "color",
-              "isAlias": true,
-              "value": {
-                "collection": "Themes",
-                "name": "primitives/color/lintblauw/45"
-              }
+              "isAlias": false,
+              "value": "#B8CEFF"
             },
             {
-              "name": "primitives/color/accent/30",
+              "name": "primitives/color/accent/200",
               "type": "color",
-              "isAlias": true,
-              "value": {
-                "collection": "Themes",
-                "name": "primitives/color/lintblauw/30"
-              }
+              "isAlias": false,
+              "value": "#A2C0FB"
             },
             {
-              "name": "primitives/color/accent/15",
+              "name": "primitives/color/accent/250",
               "type": "color",
-              "isAlias": true,
-              "value": {
-                "collection": "Themes",
-                "name": "primitives/color/lintblauw/15"
-              }
+              "isAlias": false,
+              "value": "#94B2EC"
             },
             {
-              "name": "primitives/color/success/100",
+              "name": "primitives/color/accent/300",
               "type": "color",
-              "isAlias": true,
-              "value": {
-                "collection": "Themes",
-                "name": "primitives/color/groen/100"
-              }
+              "isAlias": false,
+              "value": "#86A5DE"
+            },
+            {
+              "name": "primitives/color/accent/350",
+              "type": "color",
+              "isAlias": false,
+              "value": "#7998D1"
+            },
+            {
+              "name": "primitives/color/accent/400",
+              "type": "color",
+              "isAlias": false,
+              "value": "#6D8CC4"
+            },
+            {
+              "name": "primitives/color/accent/450",
+              "type": "color",
+              "isAlias": false,
+              "value": "#6181B8"
+            },
+            {
+              "name": "primitives/color/accent/500",
+              "type": "color",
+              "isAlias": false,
+              "value": "#5576AC"
+            },
+            {
+              "name": "primitives/color/success/0",
+              "type": "color",
+              "isAlias": false,
+              "value": "#FFFFFF"
+            },
+            {
+              "name": "primitives/color/success/25",
+              "type": "color",
+              "isAlias": false,
+              "value": "#E3FFCE"
+            },
+            {
+              "name": "primitives/color/success/50",
+              "type": "color",
+              "isAlias": false,
+              "value": "#C1FF99"
             },
             {
               "name": "primitives/color/success/75",
               "type": "color",
-              "isAlias": true,
-              "value": {
-                "collection": "Themes",
-                "name": "primitives/color/groen/75"
-              }
+              "isAlias": false,
+              "value": "#ADFA7F"
             },
             {
-              "name": "primitives/color/success/60",
+              "name": "primitives/color/success/100",
               "type": "color",
-              "isAlias": true,
-              "value": {
-                "collection": "Themes",
-                "name": "primitives/color/groen/60"
-              }
+              "isAlias": false,
+              "value": "#A5F178"
             },
             {
-              "name": "primitives/color/success/45",
+              "name": "primitives/color/success/150",
               "type": "color",
-              "isAlias": true,
-              "value": {
-                "collection": "Themes",
-                "name": "primitives/color/groen/45"
-              }
+              "isAlias": false,
+              "value": "#95E169"
             },
             {
-              "name": "primitives/color/success/30",
+              "name": "primitives/color/success/200",
               "type": "color",
-              "isAlias": true,
-              "value": {
-                "collection": "Themes",
-                "name": "primitives/color/groen/30"
-              }
+              "isAlias": false,
+              "value": "#87D25B"
             },
             {
-              "name": "primitives/color/success/15",
+              "name": "primitives/color/accent/550",
               "type": "color",
-              "isAlias": true,
-              "value": {
-                "collection": "Themes",
-                "name": "primitives/color/groen/15"
-              }
+              "isAlias": false,
+              "value": "#4A6CA1"
             },
             {
-              "name": "primitives/color/warning/100",
+              "name": "primitives/color/accent/600",
               "type": "color",
-              "isAlias": true,
-              "value": {
-                "collection": "Themes",
-                "name": "primitives/color/oranje/100"
-              }
+              "isAlias": false,
+              "value": "#3F6296"
+            },
+            {
+              "name": "primitives/color/success/250",
+              "type": "color",
+              "isAlias": false,
+              "value": "#78C44E"
+            },
+            {
+              "name": "primitives/color/success/300",
+              "type": "color",
+              "isAlias": false,
+              "value": "#6BB641"
+            },
+            {
+              "name": "primitives/color/success/350",
+              "type": "color",
+              "isAlias": false,
+              "value": "#5EAA34"
+            },
+            {
+              "name": "primitives/color/accent/650",
+              "type": "color",
+              "isAlias": false,
+              "value": "#33588B"
+            },
+            {
+              "name": "primitives/color/success/400",
+              "type": "color",
+              "isAlias": false,
+              "value": "#519D28"
+            },
+            {
+              "name": "primitives/color/success/450",
+              "type": "color",
+              "isAlias": false,
+              "value": "#44911A"
+            },
+            {
+              "name": "primitives/color/accent/700",
+              "type": "color",
+              "isAlias": false,
+              "value": "#274E81"
+            },
+            {
+              "name": "primitives/color/success/500",
+              "type": "color",
+              "isAlias": false,
+              "value": "#38860A"
+            },
+            {
+              "name": "primitives/color/success/550",
+              "type": "color",
+              "isAlias": false,
+              "value": "#2F7B00"
+            },
+            {
+              "name": "primitives/color/success/600",
+              "type": "color",
+              "isAlias": false,
+              "value": "#296F00"
+            },
+            {
+              "name": "primitives/color/success/650",
+              "type": "color",
+              "isAlias": false,
+              "value": "#256400"
+            },
+            {
+              "name": "primitives/color/warning/0",
+              "type": "color",
+              "isAlias": false,
+              "value": "#FFFFFF"
+            },
+            {
+              "name": "primitives/color/warning/25",
+              "type": "color",
+              "isAlias": false,
+              "value": "#FFF4EE"
+            },
+            {
+              "name": "primitives/color/success/700",
+              "type": "color",
+              "isAlias": false,
+              "value": "#205900"
+            },
+            {
+              "name": "primitives/color/warning/50",
+              "type": "color",
+              "isAlias": false,
+              "value": "#FFEADD"
             },
             {
               "name": "primitives/color/warning/75",
               "type": "color",
-              "isAlias": true,
-              "value": {
-                "collection": "Themes",
-                "name": "primitives/color/oranje/75"
-              }
+              "isAlias": false,
+              "value": "#FFDFCC"
             },
             {
-              "name": "primitives/color/warning/60",
+              "name": "primitives/color/warning/100",
               "type": "color",
-              "isAlias": true,
-              "value": {
-                "collection": "Themes",
-                "name": "primitives/color/oranje/60"
-              }
+              "isAlias": false,
+              "value": "#FFD5BA"
             },
             {
-              "name": "primitives/color/warning/45",
+              "name": "primitives/color/warning/150",
               "type": "color",
-              "isAlias": true,
-              "value": {
-                "collection": "Themes",
-                "name": "primitives/color/oranje/45"
-              }
+              "isAlias": false,
+              "value": "#FFC197"
             },
             {
-              "name": "primitives/color/warning/30",
+              "name": "primitives/color/success/750",
               "type": "color",
-              "isAlias": true,
-              "value": {
-                "collection": "Themes",
-                "name": "primitives/color/oranje/30"
-              }
+              "isAlias": false,
+              "value": "#1B4E00"
             },
             {
-              "name": "primitives/color/warning/15",
+              "name": "primitives/color/warning/200",
               "type": "color",
-              "isAlias": true,
-              "value": {
-                "collection": "Themes",
-                "name": "primitives/color/oranje/15"
-              }
+              "isAlias": false,
+              "value": "#FFAC72"
             },
             {
-              "name": "primitives/color/danger/100",
+              "name": "primitives/color/warning/250",
               "type": "color",
-              "isAlias": true,
-              "value": {
-                "collection": "Themes",
-                "name": "primitives/color/rood/100"
-              }
+              "isAlias": false,
+              "value": "#FF9849"
+            },
+            {
+              "name": "primitives/color/success/800",
+              "type": "color",
+              "isAlias": false,
+              "value": "#174300"
+            },
+            {
+              "name": "primitives/color/success/850",
+              "type": "color",
+              "isAlias": false,
+              "value": "#153700"
+            },
+            {
+              "name": "primitives/color/success/900",
+              "type": "color",
+              "isAlias": false,
+              "value": "#132A00"
+            },
+            {
+              "name": "primitives/color/warning/300",
+              "type": "color",
+              "isAlias": false,
+              "value": "#FA8521"
+            },
+            {
+              "name": "primitives/color/warning/350",
+              "type": "color",
+              "isAlias": false,
+              "value": "#EB7810"
+            },
+            {
+              "name": "primitives/color/success/950",
+              "type": "color",
+              "isAlias": false,
+              "value": "#0E1A00"
+            },
+            {
+              "name": "primitives/color/warning/400",
+              "type": "color",
+              "isAlias": false,
+              "value": "#DB6D00"
+            },
+            {
+              "name": "primitives/color/success/1000",
+              "type": "color",
+              "isAlias": false,
+              "value": "#000000"
+            },
+            {
+              "name": "primitives/color/warning/450",
+              "type": "color",
+              "isAlias": false,
+              "value": "#CA6400"
+            },
+            {
+              "name": "primitives/color/warning/500",
+              "type": "color",
+              "isAlias": false,
+              "value": "#BA5B00"
+            },
+            {
+              "name": "primitives/color/warning/550",
+              "type": "color",
+              "isAlias": false,
+              "value": "#AA5300"
+            },
+            {
+              "name": "primitives/color/warning/600",
+              "type": "color",
+              "isAlias": false,
+              "value": "#9A4B00"
+            },
+            {
+              "name": "primitives/color/warning/650",
+              "type": "color",
+              "isAlias": false,
+              "value": "#8B4300"
+            },
+            {
+              "name": "primitives/color/warning/700",
+              "type": "color",
+              "isAlias": false,
+              "value": "#7D3B00"
+            },
+            {
+              "name": "primitives/color/warning/750",
+              "type": "color",
+              "isAlias": false,
+              "value": "#6E3400"
+            },
+            {
+              "name": "primitives/color/warning/800",
+              "type": "color",
+              "isAlias": false,
+              "value": "#5E2C00"
+            },
+            {
+              "name": "primitives/color/warning/850",
+              "type": "color",
+              "isAlias": false,
+              "value": "#4D2500"
+            },
+            {
+              "name": "primitives/color/warning/900",
+              "type": "color",
+              "isAlias": false,
+              "value": "#3B1D00"
+            },
+            {
+              "name": "primitives/color/warning/950",
+              "type": "color",
+              "isAlias": false,
+              "value": "#241300"
+            },
+            {
+              "name": "primitives/color/warning/1000",
+              "type": "color",
+              "isAlias": false,
+              "value": "#000000"
+            },
+            {
+              "name": "primitives/color/danger/0",
+              "type": "color",
+              "isAlias": false,
+              "value": "#FFFFFF"
+            },
+            {
+              "name": "primitives/color/danger/25",
+              "type": "color",
+              "isAlias": false,
+              "value": "#FFF4F1"
+            },
+            {
+              "name": "primitives/color/highlight/0",
+              "type": "color",
+              "isAlias": false,
+              "value": "#FFFFFF"
+            },
+            {
+              "name": "primitives/color/highlight/25",
+              "type": "color",
+              "isAlias": false,
+              "value": "#FFF5E9"
+            },
+            {
+              "name": "primitives/color/highlight/50",
+              "type": "color",
+              "isAlias": false,
+              "value": "#FFEBD1"
+            },
+            {
+              "name": "primitives/color/highlight/75",
+              "type": "color",
+              "isAlias": false,
+              "value": "#FFE1B9"
+            },
+            {
+              "name": "primitives/color/highlight/100",
+              "type": "color",
+              "isAlias": false,
+              "value": "#FFD79F"
+            },
+            {
+              "name": "primitives/color/highlight/150",
+              "type": "color",
+              "isAlias": false,
+              "value": "#FFC460"
+            },
+            {
+              "name": "primitives/color/highlight/200",
+              "type": "color",
+              "isAlias": false,
+              "value": "#FAB207"
+            },
+            {
+              "name": "primitives/color/highlight/250",
+              "type": "color",
+              "isAlias": false,
+              "value": "#E9A500"
+            },
+            {
+              "name": "primitives/color/highlight/300",
+              "type": "color",
+              "isAlias": false,
+              "value": "#D89800"
+            },
+            {
+              "name": "primitives/color/highlight/350",
+              "type": "color",
+              "isAlias": false,
+              "value": "#C78D00"
+            },
+            {
+              "name": "primitives/color/highlight/400",
+              "type": "color",
+              "isAlias": false,
+              "value": "#B88200"
+            },
+            {
+              "name": "primitives/color/highlight/450",
+              "type": "color",
+              "isAlias": false,
+              "value": "#A97700"
+            },
+            {
+              "name": "primitives/color/highlight/500",
+              "type": "color",
+              "isAlias": false,
+              "value": "#9B6D00"
+            },
+            {
+              "name": "primitives/color/highlight/550",
+              "type": "color",
+              "isAlias": false,
+              "value": "#8E6300"
+            },
+            {
+              "name": "primitives/color/highlight/600",
+              "type": "color",
+              "isAlias": false,
+              "value": "#815A00"
+            },
+            {
+              "name": "primitives/color/highlight/650",
+              "type": "color",
+              "isAlias": false,
+              "value": "#745000"
+            },
+            {
+              "name": "primitives/color/highlight/700",
+              "type": "color",
+              "isAlias": false,
+              "value": "#684700"
+            },
+            {
+              "name": "primitives/color/highlight/750",
+              "type": "color",
+              "isAlias": false,
+              "value": "#5B3E00"
+            },
+            {
+              "name": "primitives/color/highlight/800",
+              "type": "color",
+              "isAlias": false,
+              "value": "#4E3500"
+            },
+            {
+              "name": "primitives/color/highlight/850",
+              "type": "color",
+              "isAlias": false,
+              "value": "#412C00"
+            },
+            {
+              "name": "primitives/color/highlight/900",
+              "type": "color",
+              "isAlias": false,
+              "value": "#322100"
+            },
+            {
+              "name": "primitives/color/highlight/950",
+              "type": "color",
+              "isAlias": false,
+              "value": "#1F1500"
+            },
+            {
+              "name": "primitives/color/highlight/1000",
+              "type": "color",
+              "isAlias": false,
+              "value": "#000000"
+            },
+            {
+              "name": "primitives/color/reference/coolgray",
+              "type": "color",
+              "isAlias": false,
+              "value": "#64748B"
+            },
+            {
+              "name": "primitives/color/danger/50",
+              "type": "color",
+              "isAlias": false,
+              "value": "#FFE9E4"
             },
             {
               "name": "primitives/color/danger/75",
               "type": "color",
-              "isAlias": true,
-              "value": {
-                "collection": "Themes",
-                "name": "primitives/color/rood/75"
-              }
+              "isAlias": false,
+              "value": "#FFDED7"
             },
             {
-              "name": "primitives/color/danger/60",
+              "name": "primitives/color/danger/100",
               "type": "color",
-              "isAlias": true,
-              "value": {
-                "collection": "Themes",
-                "name": "primitives/color/rood/60"
-              }
+              "isAlias": false,
+              "value": "#FFD4CA"
             },
             {
-              "name": "primitives/color/danger/45",
+              "name": "primitives/color/danger/150",
               "type": "color",
-              "isAlias": true,
-              "value": {
-                "collection": "Themes",
-                "name": "primitives/color/rood/45"
-              }
+              "isAlias": false,
+              "value": "#FFBFB0"
             },
             {
-              "name": "primitives/color/danger/30",
+              "name": "primitives/color/danger/200",
               "type": "color",
-              "isAlias": true,
-              "value": {
-                "collection": "Themes",
-                "name": "primitives/color/rood/30"
-              }
+              "isAlias": false,
+              "value": "#FFAA97"
             },
             {
-              "name": "primitives/color/danger/15",
+              "name": "primitives/color/danger/250",
               "type": "color",
-              "isAlias": true,
-              "value": {
-                "collection": "Themes",
-                "name": "primitives/color/rood/15"
-              }
+              "isAlias": false,
+              "value": "#FF947E"
             },
             {
-              "name": "primitives/color/lintblauw/100",
+              "name": "primitives/color/danger/300",
+              "type": "color",
+              "isAlias": false,
+              "value": "#FF7E65"
+            },
+            {
+              "name": "primitives/color/danger/350",
+              "type": "color",
+              "isAlias": false,
+              "value": "#FF654C"
+            },
+            {
+              "name": "primitives/color/danger/400",
+              "type": "color",
+              "isAlias": false,
+              "value": "#F94F38"
+            },
+            {
+              "name": "primitives/color/danger/450",
+              "type": "color",
+              "isAlias": false,
+              "value": "#EB412E"
+            },
+            {
+              "name": "primitives/color/danger/500",
+              "type": "color",
+              "isAlias": false,
+              "value": "#DD3424"
+            },
+            {
+              "name": "primitives/color/danger/550",
+              "type": "color",
+              "isAlias": false,
+              "value": "#CF241A"
+            },
+            {
+              "name": "primitives/color/danger/600",
+              "type": "color",
+              "isAlias": false,
+              "value": "#C21110"
+            },
+            {
+              "name": "primitives/color/danger/650",
+              "type": "color",
+              "isAlias": false,
+              "value": "#B20009"
+            },
+            {
+              "name": "primitives/color/danger/700",
+              "type": "color",
+              "isAlias": false,
+              "value": "#A00007"
+            },
+            {
+              "name": "primitives/color/danger/750",
+              "type": "color",
+              "isAlias": false,
+              "value": "#8D0004"
+            },
+            {
+              "name": "primitives/color/danger/800",
+              "type": "color",
+              "isAlias": false,
+              "value": "#7B0000"
+            },
+            {
+              "name": "primitives/color/danger/850",
+              "type": "color",
+              "isAlias": false,
+              "value": "#640800"
+            },
+            {
+              "name": "primitives/color/danger/900",
+              "type": "color",
+              "isAlias": false,
+              "value": "#4B0D00"
+            },
+            {
+              "name": "primitives/color/danger/950",
+              "type": "color",
+              "isAlias": false,
+              "value": "#2C0D00"
+            },
+            {
+              "name": "primitives/color/danger/1000",
+              "type": "color",
+              "isAlias": false,
+              "value": "#000000"
+            },
+            {
+              "name": "primitives/color/reference/lintblauw",
               "type": "color",
               "isAlias": false,
               "value": "#154273"
             },
             {
-              "name": "primitives/color/lintblauw/75",
-              "type": "color",
-              "isAlias": false,
-              "value": "#4F7196"
-            },
-            {
-              "name": "primitives/color/lintblauw/60",
-              "type": "color",
-              "isAlias": false,
-              "value": "#738EAB"
-            },
-            {
-              "name": "primitives/color/lintblauw/45",
-              "type": "color",
-              "isAlias": false,
-              "value": "#95A9C0"
-            },
-            {
-              "name": "primitives/color/lintblauw/30",
-              "type": "color",
-              "isAlias": false,
-              "value": "#B8C6D5"
-            },
-            {
-              "name": "primitives/color/paars/100",
+              "name": "primitives/color/reference/paars",
               "type": "color",
               "isAlias": false,
               "value": "#42145F"
             },
             {
-              "name": "primitives/color/violet/100",
+              "name": "primitives/color/reference/violet",
               "type": "color",
               "isAlias": false,
               "value": "#A90061"
             },
             {
-              "name": "primitives/color/robijnrood/100",
+              "name": "primitives/color/reference/robijnrood",
               "type": "color",
               "isAlias": false,
               "value": "#CA005D"
             },
             {
-              "name": "primitives/color/roze/100",
+              "name": "primitives/color/reference/roze",
               "type": "color",
               "isAlias": false,
               "value": "#F092CD"
             },
             {
-              "name": "primitives/color/roze/75",
-              "type": "color",
-              "isAlias": false,
-              "value": "#F4ADD9"
-            },
-            {
-              "name": "primitives/color/roze/60",
-              "type": "color",
-              "isAlias": false,
-              "value": "#F6BDE1"
-            },
-            {
-              "name": "primitives/color/roze/45",
-              "type": "color",
-              "isAlias": false,
-              "value": "#F8CEE8"
-            },
-            {
-              "name": "primitives/color/roze/30",
-              "type": "color",
-              "isAlias": false,
-              "value": "#FBDEF0"
-            },
-            {
-              "name": "primitives/color/roze/15",
-              "type": "color",
-              "isAlias": false,
-              "value": "#FDEFF8"
-            },
-            {
-              "name": "primitives/color/robijnrood/75",
-              "type": "color",
-              "isAlias": false,
-              "value": "#D74085"
-            },
-            {
-              "name": "primitives/color/robijnrood/60",
-              "type": "color",
-              "isAlias": false,
-              "value": "#DF669D"
-            },
-            {
-              "name": "primitives/color/robijnrood/45",
-              "type": "color",
-              "isAlias": false,
-              "value": "#E78CB6"
-            },
-            {
-              "name": "primitives/color/robijnrood/30",
-              "type": "color",
-              "isAlias": false,
-              "value": "#EFB2CE"
-            },
-            {
-              "name": "primitives/color/robijnrood/15",
-              "type": "color",
-              "isAlias": false,
-              "value": "#F7D9E7"
-            },
-            {
-              "name": "primitives/color/violet/75",
-              "type": "color",
-              "isAlias": false,
-              "value": "#BE4088"
-            },
-            {
-              "name": "primitives/color/violet/60",
-              "type": "color",
-              "isAlias": false,
-              "value": "#CB66A0"
-            },
-            {
-              "name": "primitives/color/violet/45",
-              "type": "color",
-              "isAlias": false,
-              "value": "#D88CB7"
-            },
-            {
-              "name": "primitives/color/violet/30",
-              "type": "color",
-              "isAlias": false,
-              "value": "#E5B2CF"
-            },
-            {
-              "name": "primitives/color/violet/15",
-              "type": "color",
-              "isAlias": false,
-              "value": "#F2D9E7"
-            },
-            {
-              "name": "primitives/color/paars/75",
-              "type": "color",
-              "isAlias": false,
-              "value": "#714F87"
-            },
-            {
-              "name": "primitives/color/paars/60",
-              "type": "color",
-              "isAlias": false,
-              "value": "#8D729F"
-            },
-            {
-              "name": "primitives/color/paars/45",
-              "type": "color",
-              "isAlias": false,
-              "value": "#A995B7"
-            },
-            {
-              "name": "primitives/color/paars/30",
-              "type": "color",
-              "isAlias": false,
-              "value": "#C6B8CE"
-            },
-            {
-              "name": "primitives/color/paars/15",
-              "type": "color",
-              "isAlias": false,
-              "value": "#E3DCE7"
-            },
-            {
-              "name": "primitives/color/rood/100",
+              "name": "primitives/color/reference/rood",
               "type": "color",
               "isAlias": false,
               "value": "#D52B1E"
             },
             {
-              "name": "primitives/color/lintblauw/15",
-              "type": "color",
-              "isAlias": false,
-              "value": "#DCE3EA"
-            },
-            {
-              "name": "primitives/color/rood/75",
-              "type": "color",
-              "isAlias": false,
-              "value": "#DF6056"
-            },
-            {
-              "name": "primitives/color/rood/60",
-              "type": "color",
-              "isAlias": false,
-              "value": "#E67F78"
-            },
-            {
-              "name": "primitives/color/rood/45",
-              "type": "color",
-              "isAlias": false,
-              "value": "#EC9F99"
-            },
-            {
-              "name": "primitives/color/rood/30",
-              "type": "color",
-              "isAlias": false,
-              "value": "#F2BFBB"
-            },
-            {
-              "name": "primitives/color/rood/15",
-              "type": "color",
-              "isAlias": false,
-              "value": "#F9DFDD"
-            },
-            {
-              "name": "primitives/font-size/display-a",
+              "name": "primitives/font-size/1000",
               "type": "number",
               "isAlias": false,
               "value": 52
             },
             {
-              "name": "primitives/font-size/display-b",
+              "name": "primitives/font-size/900",
               "type": "number",
               "isAlias": false,
               "value": 46
             },
             {
-              "name": "primitives/font-size/display-c",
+              "name": "primitives/font-size/800",
               "type": "number",
               "isAlias": false,
               "value": 41
             },
             {
-              "name": "primitives/font-size/display-d",
+              "name": "primitives/font-size/700",
               "type": "number",
               "isAlias": false,
               "value": 36
             },
             {
-              "name": "primitives/font-size/display-e",
+              "name": "primitives/font-size/600",
               "type": "number",
               "isAlias": false,
               "value": 32
             },
             {
-              "name": "primitives/font-size/display-f",
+              "name": "primitives/font-size/500",
               "type": "number",
               "isAlias": false,
               "value": 29
             },
             {
-              "name": "primitives/font-size/display-g",
+              "name": "primitives/font-size/400",
               "type": "number",
               "isAlias": false,
               "value": 26
             },
             {
-              "name": "primitives/font-size/display-h",
+              "name": "primitives/font-size/300",
               "type": "number",
               "isAlias": false,
               "value": 23
             },
             {
-              "name": "primitives/font-size/display-i",
+              "name": "primitives/font-size/200",
               "type": "number",
               "isAlias": false,
               "value": 20
             },
             {
-              "name": "primitives/font-size/display-j",
+              "name": "primitives/font-size/100",
               "type": "number",
               "isAlias": false,
               "value": 18
             },
             {
-              "name": "primitives/font-size/body-l",
-              "type": "number",
-              "isAlias": false,
-              "value": 20
-            },
-            {
-              "name": "primitives/font-size/body-m",
-              "type": "number",
-              "isAlias": false,
-              "value": 18
-            },
-            {
-              "name": "primitives/font-size/body-s",
+              "name": "primitives/font-size/90",
               "type": "number",
               "isAlias": false,
               "value": 16
             },
             {
-              "name": "primitives/font-size/body-xs",
+              "name": "primitives/font-size/80",
               "type": "number",
               "isAlias": false,
               "value": 14
+            },
+            {
+              "name": "primitives/font-size/70",
+              "type": "number",
+              "isAlias": false,
+              "value": 12
             },
             {
               "name": "primitives/line-height/loose",
@@ -1392,10 +2049,22 @@
               "value": 12
             },
             {
+              "name": "primitives/space/14",
+              "type": "number",
+              "isAlias": false,
+              "value": 14
+            },
+            {
               "name": "primitives/space/16",
               "type": "number",
               "isAlias": false,
               "value": 16
+            },
+            {
+              "name": "primitives/space/18",
+              "type": "number",
+              "isAlias": false,
+              "value": 18
             },
             {
               "name": "primitives/space/20",
@@ -1495,21 +2164,21 @@
             },
             {
               "name": "primitives/font-weight/body/semi-bold",
-              "type": "number",
+              "type": "string",
               "isAlias": false,
-              "value": 550
+              "value": "SemiBold"
             },
             {
               "name": "primitives/font-weight/body/bold",
               "type": "string",
               "isAlias": false,
-              "value": "Bold"
+              "value": "SemiBold"
             },
             {
               "name": "primitives/font-weight/body/extra-bold",
               "type": "string",
               "isAlias": false,
-              "value": "ExtraBold"
+              "value": "Bold"
             },
             {
               "name": "primitives/font-weight/body/black",
@@ -1608,31 +2277,31 @@
               "value": 1440
             },
             {
-              "name": "primitives/breakpoint/s-min",
+              "name": "primitives/breakpoint/sm-min",
               "type": "number",
               "isAlias": false,
               "value": 320
             },
             {
-              "name": "primitives/breakpoint/s-max",
+              "name": "primitives/breakpoint/sm-max",
               "type": "number",
               "isAlias": false,
               "value": 640
             },
             {
-              "name": "primitives/breakpoint/m-min",
+              "name": "primitives/breakpoint/md-min",
               "type": "number",
               "isAlias": false,
               "value": 641
             },
             {
-              "name": "primitives/breakpoint/m-max",
+              "name": "primitives/breakpoint/md-max",
               "type": "number",
               "isAlias": false,
               "value": 1007
             },
             {
-              "name": "primitives/breakpoint/l-min",
+              "name": "primitives/breakpoint/lg-min",
               "type": "number",
               "isAlias": false,
               "value": 1008
@@ -1647,7 +2316,7 @@
               "name": "primitives/corner-radius/xxs",
               "type": "number",
               "isAlias": false,
-              "value": 1
+              "value": 2
             },
             {
               "name": "primitives/corner-radius/xs",
@@ -1656,34 +2325,40 @@
               "value": 4
             },
             {
-              "name": "primitives/corner-radius/s",
+              "name": "primitives/corner-radius/sm",
               "type": "number",
               "isAlias": false,
               "value": 6
             },
             {
-              "name": "primitives/corner-radius/m",
+              "name": "primitives/corner-radius/md",
               "type": "number",
               "isAlias": false,
-              "value": 8
+              "value": 9
             },
             {
-              "name": "primitives/corner-radius/l",
+              "name": "primitives/corner-radius/lg",
               "type": "number",
               "isAlias": false,
-              "value": 11
+              "value": 12
             },
             {
               "name": "primitives/corner-radius/xl",
               "type": "number",
               "isAlias": false,
-              "value": 15
+              "value": 16
             },
             {
               "name": "primitives/corner-radius/xxl",
               "type": "number",
               "isAlias": false,
-              "value": 21
+              "value": 20
+            },
+            {
+              "name": "primitives/corner-radius/xxxl",
+              "type": "number",
+              "isAlias": false,
+              "value": 24
             },
             {
               "name": "primitives/corner-radius/full",
@@ -1863,13 +2538,13 @@
               "name": "primitives/font-weight/display/bold",
               "type": "string",
               "isAlias": false,
-              "value": "Bold"
+              "value": "SemiBold"
             },
             {
               "name": "primitives/font-weight/display/extra-bold",
               "type": "string",
               "isAlias": false,
-              "value": "ExtraBold"
+              "value": "Bold"
             },
             {
               "name": "primitives/font-weight/display/black",
@@ -1878,553 +2553,88 @@
               "value": "ExtraBold"
             },
             {
-              "name": "primitives/color/oranje/100",
+              "name": "primitives/color/reference/oranje",
               "type": "color",
               "isAlias": false,
               "value": "#E17000"
             },
             {
-              "name": "primitives/color/oranje/75",
-              "type": "color",
-              "isAlias": false,
-              "value": "#E89440"
-            },
-            {
-              "name": "primitives/color/oranje/60",
-              "type": "color",
-              "isAlias": false,
-              "value": "#EDA966"
-            },
-            {
-              "name": "primitives/color/oranje/45",
-              "type": "color",
-              "isAlias": false,
-              "value": "#F1BE8C"
-            },
-            {
-              "name": "primitives/color/oranje/30",
-              "type": "color",
-              "isAlias": false,
-              "value": "#F6D4B2"
-            },
-            {
-              "name": "primitives/color/oranje/15",
-              "type": "color",
-              "isAlias": false,
-              "value": "#FBEAD9"
-            },
-            {
-              "name": "primitives/color/donkergeel/100",
+              "name": "primitives/color/reference/donkergeel",
               "type": "color",
               "isAlias": false,
               "value": "#FFB612"
             },
             {
-              "name": "primitives/color/donkergeel/75",
-              "type": "color",
-              "isAlias": false,
-              "value": "#FDC84D"
-            },
-            {
-              "name": "primitives/color/donkergeel/60",
-              "type": "color",
-              "isAlias": false,
-              "value": "#FDD370"
-            },
-            {
-              "name": "primitives/color/donkergeel/45",
-              "type": "color",
-              "isAlias": false,
-              "value": "#FDDE94"
-            },
-            {
-              "name": "primitives/color/donkergeel/30",
-              "type": "color",
-              "isAlias": false,
-              "value": "#FEE9B7"
-            },
-            {
-              "name": "primitives/color/donkergeel/15",
-              "type": "color",
-              "isAlias": false,
-              "value": "#FEF4DB"
-            },
-            {
-              "name": "primitives/color/geel/100",
+              "name": "primitives/color/reference/geel",
               "type": "color",
               "isAlias": false,
               "value": "#F9E11E"
             },
             {
-              "name": "primitives/color/geel/75",
-              "type": "color",
-              "isAlias": false,
-              "value": "#FAE856"
-            },
-            {
-              "name": "primitives/color/geel/60",
-              "type": "color",
-              "isAlias": false,
-              "value": "#FBED78"
-            },
-            {
-              "name": "primitives/color/geel/45",
-              "type": "color",
-              "isAlias": false,
-              "value": "#FCF199"
-            },
-            {
-              "name": "primitives/color/geel/30",
-              "type": "color",
-              "isAlias": false,
-              "value": "#FDF6BB"
-            },
-            {
-              "name": "primitives/color/geel/15",
-              "type": "color",
-              "isAlias": false,
-              "value": "#FEFBDD"
-            },
-            {
-              "name": "primitives/color/donkerbruin/100",
+              "name": "primitives/color/reference/donkerbruin",
               "type": "color",
               "isAlias": false,
               "value": "#673327"
             },
             {
-              "name": "primitives/color/donkerbruin/75",
-              "type": "color",
-              "isAlias": false,
-              "value": "#8D665D"
-            },
-            {
-              "name": "primitives/color/donkerbruin/60",
-              "type": "color",
-              "isAlias": false,
-              "value": "#A3847D"
-            },
-            {
-              "name": "primitives/color/donkerbruin/45",
-              "type": "color",
-              "isAlias": false,
-              "value": "#BAA39D"
-            },
-            {
-              "name": "primitives/color/donkerbruin/30",
-              "type": "color",
-              "isAlias": false,
-              "value": "#D1C1BD"
-            },
-            {
-              "name": "primitives/color/donkerbruin/15",
-              "type": "color",
-              "isAlias": false,
-              "value": "#E8E0DF"
-            },
-            {
-              "name": "primitives/color/bruin/100",
+              "name": "primitives/color/reference/bruin",
               "type": "color",
               "isAlias": false,
               "value": "#94710A"
             },
             {
-              "name": "primitives/color/bruin/75",
-              "type": "color",
-              "isAlias": false,
-              "value": "#AF9447"
-            },
-            {
-              "name": "primitives/color/bruin/60",
-              "type": "color",
-              "isAlias": false,
-              "value": "#BFA96C"
-            },
-            {
-              "name": "primitives/color/bruin/45",
-              "type": "color",
-              "isAlias": false,
-              "value": "#CFBF90"
-            },
-            {
-              "name": "primitives/color/bruin/30",
-              "type": "color",
-              "isAlias": false,
-              "value": "#DFD4B5"
-            },
-            {
-              "name": "primitives/color/bruin/15",
-              "type": "color",
-              "isAlias": false,
-              "value": "#EFEADA"
-            },
-            {
-              "name": "primitives/color/donkergroen/100",
+              "name": "primitives/color/reference/donkergroen",
               "type": "color",
               "isAlias": false,
               "value": "#275937"
             },
             {
-              "name": "primitives/color/donkergroen/75",
-              "type": "color",
-              "isAlias": false,
-              "value": "#5D8269"
-            },
-            {
-              "name": "primitives/color/donkergroen/60",
-              "type": "color",
-              "isAlias": false,
-              "value": "#7D9B87"
-            },
-            {
-              "name": "primitives/color/donkergroen/45",
-              "type": "color",
-              "isAlias": false,
-              "value": "#9DB4A4"
-            },
-            {
-              "name": "primitives/color/donkergroen/30",
-              "type": "color",
-              "isAlias": false,
-              "value": "#BDCDC2"
-            },
-            {
-              "name": "primitives/color/donkergroen/15",
-              "type": "color",
-              "isAlias": false,
-              "value": "#DEE6E1"
-            },
-            {
-              "name": "primitives/color/groen/100",
+              "name": "primitives/color/reference/groen",
               "type": "color",
               "isAlias": false,
               "value": "#39870C"
             },
             {
-              "name": "primitives/color/groen/75",
-              "type": "color",
-              "isAlias": false,
-              "value": "#6AA549"
-            },
-            {
-              "name": "primitives/color/groen/60",
-              "type": "color",
-              "isAlias": false,
-              "value": "#88B76D"
-            },
-            {
-              "name": "primitives/color/groen/45",
-              "type": "color",
-              "isAlias": false,
-              "value": "#A5C991"
-            },
-            {
-              "name": "primitives/color/groen/30",
-              "type": "color",
-              "isAlias": false,
-              "value": "#C3DBB5"
-            },
-            {
-              "name": "primitives/color/groen/15",
-              "type": "color",
-              "isAlias": false,
-              "value": "#E1EDDA"
-            },
-            {
-              "name": "primitives/color/mosgroen/100",
+              "name": "primitives/color/reference/mosgroen",
               "type": "color",
               "isAlias": false,
               "value": "#777B00"
             },
             {
-              "name": "primitives/color/mosgroen/75",
-              "type": "color",
-              "isAlias": false,
-              "value": "#999C40"
-            },
-            {
-              "name": "primitives/color/mosgroen/60",
-              "type": "color",
-              "isAlias": false,
-              "value": "#ADAF66"
-            },
-            {
-              "name": "primitives/color/mosgroen/45",
-              "type": "color",
-              "isAlias": false,
-              "value": "#C1C38C"
-            },
-            {
-              "name": "primitives/color/mosgroen/30",
-              "type": "color",
-              "isAlias": false,
-              "value": "#D6D7B2"
-            },
-            {
-              "name": "primitives/color/mosgroen/15",
-              "type": "color",
-              "isAlias": false,
-              "value": "#EBEBD9"
-            },
-            {
-              "name": "primitives/color/mintgroen/100",
+              "name": "primitives/color/reference/mintgroen",
               "type": "color",
               "isAlias": false,
               "value": "#76D2B6"
             },
             {
-              "name": "primitives/color/mintgroen/75",
-              "type": "color",
-              "isAlias": false,
-              "value": "#98DDC8"
-            },
-            {
-              "name": "primitives/color/mintgroen/60",
-              "type": "color",
-              "isAlias": false,
-              "value": "#ACE4D3"
-            },
-            {
-              "name": "primitives/color/mintgroen/45",
-              "type": "color",
-              "isAlias": false,
-              "value": "#C1EBDE"
-            },
-            {
-              "name": "primitives/color/mintgroen/30",
-              "type": "color",
-              "isAlias": false,
-              "value": "#D5F1E9"
-            },
-            {
-              "name": "primitives/color/mintgroen/15",
-              "type": "color",
-              "isAlias": false,
-              "value": "#EAF8F4"
-            },
-            {
-              "name": "primitives/color/donkerblauw/100",
+              "name": "primitives/color/reference/donkerblauw",
               "type": "color",
               "isAlias": false,
               "value": "#01689B"
             },
             {
-              "name": "primitives/color/donkerblauw/75",
-              "type": "color",
-              "isAlias": false,
-              "value": "#408EB4"
-            },
-            {
-              "name": "primitives/color/donkerblauw/60",
-              "type": "color",
-              "isAlias": false,
-              "value": "#66A4C3"
-            },
-            {
-              "name": "primitives/color/donkerblauw/45",
-              "type": "color",
-              "isAlias": false,
-              "value": "#8CBBD2"
-            },
-            {
-              "name": "primitives/color/donkerblauw/30",
-              "type": "color",
-              "isAlias": false,
-              "value": "#B2D1E1"
-            },
-            {
-              "name": "primitives/color/donkerblauw/15",
-              "type": "color",
-              "isAlias": false,
-              "value": "#D9E8F0"
-            },
-            {
-              "name": "primitives/color/hemelblauw/100",
+              "name": "primitives/color/reference/hemelblauw",
               "type": "color",
               "isAlias": false,
               "value": "#007BC7"
             },
             {
-              "name": "primitives/color/hemelblauw/75",
-              "type": "color",
-              "isAlias": false,
-              "value": "#409CD5"
-            },
-            {
-              "name": "primitives/color/hemelblauw/60",
-              "type": "color",
-              "isAlias": false,
-              "value": "#66AFDD"
-            },
-            {
-              "name": "primitives/color/hemelblauw/45",
-              "type": "color",
-              "isAlias": false,
-              "value": "#8CC3E6"
-            },
-            {
-              "name": "primitives/color/hemelblauw/30",
-              "type": "color",
-              "isAlias": false,
-              "value": "#B2D7EE"
-            },
-            {
-              "name": "primitives/color/hemelblauw/15",
-              "type": "color",
-              "isAlias": false,
-              "value": "#D9EBF7"
-            },
-            {
-              "name": "primitives/color/lichtblauw/100",
+              "name": "primitives/color/reference/lichtblauw",
               "type": "color",
               "isAlias": false,
               "value": "#8FCAE7"
             },
             {
-              "name": "primitives/color/lichtblauw/75",
-              "type": "color",
-              "isAlias": false,
-              "value": "#ABD7ED"
-            },
-            {
-              "name": "primitives/color/lichtblauw/60",
-              "type": "color",
-              "isAlias": false,
-              "value": "#BCDFF0"
-            },
-            {
-              "name": "primitives/color/lichtblauw/45",
-              "type": "color",
-              "isAlias": false,
-              "value": "#CCE7F4"
-            },
-            {
-              "name": "primitives/color/lichtblauw/30",
-              "type": "color",
-              "isAlias": false,
-              "value": "#DDEFF8"
-            },
-            {
-              "name": "primitives/color/lichtblauw/15",
-              "type": "color",
-              "isAlias": false,
-              "value": "#EEF7FC"
-            },
-            {
-              "name": "semantics/controls/m/focus-ring/corner-radius",
-              "type": "number",
-              "isAlias": false,
-              "value": 11
-            },
-            {
-              "name": "semantics/sections/m/margin-inline",
+              "name": "components/button-group/sm/gap",
               "type": "number",
               "isAlias": true,
               "value": {
                 "collection": "Themes",
-                "name": "primitives/space/32"
+                "name": "primitives/space/6"
               }
             },
             {
-              "name": "semantics/sections/m/margin-block",
-              "type": "number",
-              "isAlias": true,
-              "value": {
-                "collection": "Themes",
-                "name": "primitives/space/24"
-              }
-            },
-            {
-              "name": "semantics/sections/m/gap",
-              "type": "number",
-              "isAlias": true,
-              "value": {
-                "collection": "Themes",
-                "name": "primitives/space/24"
-              }
-            },
-            {
-              "name": "semantics/sections/l/margin-inline",
-              "type": "number",
-              "isAlias": true,
-              "value": {
-                "collection": "Themes",
-                "name": "primitives/space/48"
-              }
-            },
-            {
-              "name": "semantics/sections/l/margin-block",
-              "type": "number",
-              "isAlias": true,
-              "value": {
-                "collection": "Themes",
-                "name": "primitives/space/32"
-              }
-            },
-            {
-              "name": "semantics/sections/l/gap",
-              "type": "number",
-              "isAlias": true,
-              "value": {
-                "collection": "Themes",
-                "name": "primitives/space/24"
-              }
-            },
-            {
-              "name": "components/segmented-control/content/color",
-              "type": "color",
-              "isAlias": true,
-              "value": {
-                "collection": "Themes",
-                "name": "semantics/buttons/neutral-tinted/color"
-              }
-            },
-            {
-              "name": "components/segmented-control/is-hovered/background-color",
-              "type": "color",
-              "isAlias": true,
-              "value": {
-                "collection": "Themes",
-                "name": "primitives/color/neutral/300"
-              }
-            },
-            {
-              "name": "components/segmented-control/is-hovered/content/color",
-              "type": "color",
-              "isAlias": true,
-              "value": {
-                "collection": "Themes",
-                "name": "primitives/color/neutral/900"
-              }
-            },
-            {
-              "name": "components/segmented-control/is-selected/background-color",
-              "type": "color",
-              "isAlias": true,
-              "value": {
-                "collection": "Themes",
-                "name": "primitives/color/accent/100"
-              }
-            },
-            {
-              "name": "components/segmented-control/is-selected/content/color",
-              "type": "color",
-              "isAlias": true,
-              "value": {
-                "collection": "Themes",
-                "name": "semantics/content/white/color"
-              }
-            },
-            {
-              "name": "components/segmented-control/background-color",
-              "type": "color",
-              "isAlias": true,
-              "value": {
-                "collection": "Themes",
-                "name": "semantics/buttons/neutral-tinted/background-color"
-              }
-            },
-            {
-              "name": "components/control-group/gap",
+              "name": "components/button-group/md/gap",
               "type": "number",
               "isAlias": true,
               "value": {
@@ -2433,7 +2643,2889 @@
               }
             },
             {
-              "name": "components/toggle-button-group/gap",
+              "name": "components/toggle-button-group/sm/gap",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/space/6"
+              }
+            },
+            {
+              "name": "components/toggle-button-group/md/gap",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/space/8"
+              }
+            },
+            {
+              "name": "components/page/fixed-area/background-gradient/color-1",
+              "type": "color",
+              "isAlias": false,
+              "value": "#FFFFFFF2"
+            },
+            {
+              "name": "components/page/fixed-area/background-gradient/color-2",
+              "type": "color",
+              "isAlias": false,
+              "value": "#FFFFFF99"
+            },
+            {
+              "name": "components/page/fixed-area/background-gradient/color-3",
+              "type": "color",
+              "isAlias": false,
+              "value": "#FFFFFF00"
+            },
+            {
+              "name": "components/page/fixed-area/tinted/background-gradient/color-1",
+              "type": "color",
+              "isAlias": false,
+              "value": "#F5F6F9F2"
+            },
+            {
+              "name": "components/page/fixed-area/tinted/background-gradient/color-2",
+              "type": "color",
+              "isAlias": false,
+              "value": "#F5F6F999"
+            },
+            {
+              "name": "components/page/fixed-area/tinted/background-gradient/color-3",
+              "type": "color",
+              "isAlias": false,
+              "value": "#F5F6F900"
+            },
+            {
+              "name": "primitives/color/accent/750 (reference)",
+              "type": "color",
+              "isAlias": false,
+              "value": "#194476"
+            },
+            {
+              "name": "primitives/color/accent/800",
+              "type": "color",
+              "isAlias": false,
+              "value": "#053B6B"
+            },
+            {
+              "name": "primitives/color/accent/850",
+              "type": "color",
+              "isAlias": false,
+              "value": "#00305B"
+            },
+            {
+              "name": "primitives/color/accent/900",
+              "type": "color",
+              "isAlias": false,
+              "value": "#002547"
+            },
+            {
+              "name": "primitives/color/accent/950",
+              "type": "color",
+              "isAlias": false,
+              "value": "#001730"
+            },
+            {
+              "name": "primitives/color/accent/1000",
+              "type": "color",
+              "isAlias": false,
+              "value": "#000000"
+            },
+            {
+              "name": "semantics/controls/lg/min-size",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/space/56"
+              }
+            },
+            {
+              "name": "semantics/controls/lg/corner-radius",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/corner-radius/md"
+              }
+            },
+            {
+              "name": "semantics/focus-rings/outer/color",
+              "type": "color",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "semantics/surfaces/background-color"
+              }
+            },
+            {
+              "name": "semantics/focus-rings/outer/thickness",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/space/6"
+              }
+            }
+          ]
+        },
+        {
+          "name": "Rijksoverheid (Dark)",
+          "variables": [
+            {
+              "name": "components/list/item/sm/padding-block",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/space/8"
+              }
+            },
+            {
+              "name": "components/list/item/md/padding-block",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/space/12"
+              }
+            },
+            {
+              "name": "components/list/item/is-selected/corner-radius",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/corner-radius/md"
+              }
+            },
+            {
+              "name": "components/list/item/is-selected/background-color",
+              "type": "color",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/color/accent/700"
+              }
+            },
+            {
+              "name": "components/list/item/is-selected/content/color",
+              "type": "color",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/color/neutral/0"
+              }
+            },
+            {
+              "name": "components/menu-bar/menu-item/color",
+              "type": "color",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/color/accent/750 (reference)"
+              }
+            },
+            {
+              "name": "components/menu-bar/menu-item/is-selected/color",
+              "type": "color",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/color/accent/750 (reference)"
+              }
+            },
+            {
+              "name": "components/menu-bar/menu-item/is-selected/indicator/color",
+              "type": "color",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/color/accent/750 (reference)"
+              }
+            },
+            {
+              "name": "components/menu-bar/menu-item/is-selected/indicator/height",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/space/4"
+              }
+            },
+            {
+              "name": "components/menu-bar/menu-item/is-hovered/indicator/color",
+              "type": "color",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/color/neutral/200"
+              }
+            },
+            {
+              "name": "components/menu-bar/menu-item/is-hovered/indicator/height",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/space/32"
+              }
+            },
+            {
+              "name": "components/checkbox/border-thickness",
+              "type": "number",
+              "isAlias": false,
+              "value": 2
+            },
+            {
+              "name": "components/checkbox/border-color",
+              "type": "color",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/color/neutral/600"
+              }
+            },
+            {
+              "name": "components/checkbox/background-color",
+              "type": "color",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "semantics/surfaces/background-color"
+              }
+            },
+            {
+              "name": "components/checkbox/is-selected/background-color",
+              "type": "color",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/color/accent/700"
+              }
+            },
+            {
+              "name": "components/checkbox/is-selected/icon/color",
+              "type": "color",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/color/neutral/0"
+              }
+            },
+            {
+              "name": "components/radio-button/border-thickness",
+              "type": "number",
+              "isAlias": false,
+              "value": 2
+            },
+            {
+              "name": "components/radio-button/border-color",
+              "type": "color",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/color/neutral/600"
+              }
+            },
+            {
+              "name": "components/radio-button/background-color",
+              "type": "color",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "semantics/surfaces/background-color"
+              }
+            },
+            {
+              "name": "components/radio-button/is-selected/background-color",
+              "type": "color",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/color/accent/700"
+              }
+            },
+            {
+              "name": "components/radio-button/is-selected/inner-shape/border-thickness",
+              "type": "number",
+              "isAlias": false,
+              "value": 2
+            },
+            {
+              "name": "components/radio-button/is-selected/inner-shape/border-color",
+              "type": "color",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/color/neutral/0"
+              }
+            },
+            {
+              "name": "components/switch/border-thickness",
+              "type": "number",
+              "isAlias": false,
+              "value": 2
+            },
+            {
+              "name": "components/switch/border-color",
+              "type": "color",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/color/neutral/600"
+              }
+            },
+            {
+              "name": "components/switch/background-color",
+              "type": "color",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "semantics/surfaces/background-color"
+              }
+            },
+            {
+              "name": "components/switch/thumb/border-thickness",
+              "type": "number",
+              "isAlias": false,
+              "value": 2
+            },
+            {
+              "name": "components/switch/thumb/border-color",
+              "type": "color",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/color/neutral/600"
+              }
+            },
+            {
+              "name": "components/switch/thumb/background-color",
+              "type": "color",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "semantics/surfaces/background-color"
+              }
+            },
+            {
+              "name": "components/switch/icon/color",
+              "type": "color",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/color/neutral/600"
+              }
+            },
+            {
+              "name": "components/switch/is-selected/background-color",
+              "type": "color",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/color/accent/700"
+              }
+            },
+            {
+              "name": "components/switch/is-selected/thumb/background-color",
+              "type": "color",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/color/neutral/100"
+              }
+            },
+            {
+              "name": "components/switch/is-selected/icon/color",
+              "type": "color",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/color/accent/700"
+              }
+            },
+            {
+              "name": "components/box/background-color",
+              "type": "color",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "semantics/surfaces/tinted/background-color"
+              }
+            },
+            {
+              "name": "components/box/is-on-tinted/background-color",
+              "type": "color",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "semantics/surfaces/background-color"
+              }
+            },
+            {
+              "name": "components/box/corner-radius",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/corner-radius/xl"
+              }
+            },
+            {
+              "name": "components/box/padding",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/space/16"
+              }
+            },
+            {
+              "name": "components/top-title-bar/button-bar-divider/color",
+              "type": "color",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/color/neutral/350"
+              }
+            },
+            {
+              "name": "components/toolbar/sm/gap",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/space/6"
+              }
+            },
+            {
+              "name": "components/grab-handle/background-color",
+              "type": "color",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/color/neutral/200"
+              }
+            },
+            {
+              "name": "components/form/gap",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/space/16"
+              }
+            },
+            {
+              "name": "components/toolbar/md/gap",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/space/8"
+              }
+            },
+            {
+              "name": "components/grab-handle/color",
+              "type": "color",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/color/neutral/600"
+              }
+            },
+            {
+              "name": "semantics/surfaces/background-color",
+              "type": "color",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/color/neutral/100"
+              }
+            },
+            {
+              "name": "semantics/surfaces/tinted/background-color",
+              "type": "color",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/color/neutral/75"
+              }
+            },
+            {
+              "name": "semantics/content/color",
+              "type": "color",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/color/neutral/800"
+              }
+            },
+            {
+              "name": "semantics/content/secondary/color",
+              "type": "color",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/color/neutral/600"
+              }
+            },
+            {
+              "name": "semantics/links/color",
+              "type": "color",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/color/accent/800"
+              }
+            },
+            {
+              "name": "semantics/controls/xs/min-size",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/space/24"
+              }
+            },
+            {
+              "name": "semantics/controls/xs/corner-radius",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/corner-radius/xs"
+              }
+            },
+            {
+              "name": "semantics/controls/sm/min-size",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/space/32"
+              }
+            },
+            {
+              "name": "semantics/controls/sm/corner-radius",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/corner-radius/sm"
+              }
+            },
+            {
+              "name": "semantics/controls/md/min-size",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/space/44"
+              }
+            },
+            {
+              "name": "semantics/controls/md/corner-radius",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/corner-radius/md"
+              }
+            },
+            {
+              "name": "semantics/buttons/neutral-tinted/divider/color",
+              "type": "color",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/color/neutral/400"
+              }
+            },
+            {
+              "name": "semantics/buttons/neutral-tinted/end-fade/start-color",
+              "type": "color",
+              "isAlias": false,
+              "value": "#3A445300"
+            },
+            {
+              "name": "semantics/buttons/neutral-tinted/end-fade/end-color",
+              "type": "color",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "semantics/buttons/neutral-tinted/background-color"
+              }
+            },
+            {
+              "name": "semantics/buttons/sm/divider/length",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/space/20"
+              }
+            },
+            {
+              "name": "semantics/buttons/md/divider/length",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/space/28"
+              }
+            },
+            {
+              "name": "semantics/buttons/neutral-tinted/background-color",
+              "type": "color",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/color/neutral/250"
+              }
+            },
+            {
+              "name": "semantics/buttons/neutral-tinted/content/color",
+              "type": "color",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/color/neutral/900"
+              }
+            },
+            {
+              "name": "semantics/buttons/neutral-tinted/is-hovered/background-color",
+              "type": "color",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/color/neutral/300"
+              }
+            },
+            {
+              "name": "semantics/buttons/neutral-tinted/is-hovered/content/color",
+              "type": "color",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/color/neutral/1000"
+              }
+            },
+            {
+              "name": "semantics/buttons/neutral-tinted/is-active/content/color",
+              "type": "color",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/color/neutral/1000"
+              }
+            },
+            {
+              "name": "semantics/buttons/neutral-tinted/is-active/background-color",
+              "type": "color",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/color/neutral/350"
+              }
+            },
+            {
+              "name": "semantics/buttons/neutral-tinted/is-selected/backround-color",
+              "type": "color",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/color/accent/700"
+              }
+            },
+            {
+              "name": "semantics/buttons/neutral-tinted/is-selected/content/color",
+              "type": "color",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/color/neutral/0"
+              }
+            },
+            {
+              "name": "semantics/buttons/neutral-transparent/content/color",
+              "type": "color",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/color/neutral/900"
+              }
+            },
+            {
+              "name": "semantics/buttons/neutral-transparent/is-active/content/color",
+              "type": "color",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/color/neutral/1000"
+              }
+            },
+            {
+              "name": "semantics/buttons/neutral-transparent/is-hovered/background-color",
+              "type": "color",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/color/neutral/300"
+              }
+            },
+            {
+              "name": "semantics/buttons/neutral-transparent/is-hovered/content/color",
+              "type": "color",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/color/neutral/1000"
+              }
+            },
+            {
+              "name": "semantics/buttons/neutral-transparent/is-active/background-color",
+              "type": "color",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/color/neutral/350"
+              }
+            },
+            {
+              "name": "semantics/buttons/neutral-transparent/is-selected/backround-color",
+              "type": "color",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/color/accent/700"
+              }
+            },
+            {
+              "name": "semantics/buttons/neutral-transparent/is-selected/content/color",
+              "type": "color",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/color/neutral/0"
+              }
+            },
+            {
+              "name": "semantics/buttons/accent-filled/content/color",
+              "type": "color",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/color/neutral/0"
+              }
+            },
+            {
+              "name": "semantics/buttons/accent-filled/background-color",
+              "type": "color",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/color/accent/700"
+              }
+            },
+            {
+              "name": "semantics/buttons/accent-filled/is-hovered/content/color",
+              "type": "color",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/color/neutral/0"
+              }
+            },
+            {
+              "name": "semantics/buttons/accent-filled/is-hovered/background-color",
+              "type": "color",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/color/accent/750 (reference)"
+              }
+            },
+            {
+              "name": "semantics/buttons/accent-tinted/content/color",
+              "type": "color",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/color/accent/700"
+              }
+            },
+            {
+              "name": "semantics/buttons/accent-tinted/background-color",
+              "type": "color",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/color/accent/100"
+              }
+            },
+            {
+              "name": "semantics/buttons/accent-tinted/is-hovered/content/color",
+              "type": "color",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/color/accent/700"
+              }
+            },
+            {
+              "name": "semantics/buttons/accent-tinted/is-hovered/background-color",
+              "type": "color",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/color/accent/150"
+              }
+            },
+            {
+              "name": "semantics/buttons/accent-outlined/content/color",
+              "type": "color",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/color/accent/700"
+              }
+            },
+            {
+              "name": "semantics/buttons/accent-outlined/border-color",
+              "type": "color",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/color/accent/700"
+              }
+            },
+            {
+              "name": "semantics/buttons/accent-outlined/border-thickness",
+              "type": "number",
+              "isAlias": false,
+              "value": 2
+            },
+            {
+              "name": "semantics/buttons/accent-transparent/content/color",
+              "type": "color",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/color/accent/700"
+              }
+            },
+            {
+              "name": "semantics/buttons/danger-tinted/content/color",
+              "type": "color",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/color/danger/750"
+              }
+            },
+            {
+              "name": "semantics/buttons/danger-tinted/background-color",
+              "type": "color",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/color/danger/200"
+              }
+            },
+            {
+              "name": "semantics/input-fields/border-thickness",
+              "type": "number",
+              "isAlias": false,
+              "value": 2
+            },
+            {
+              "name": "semantics/dividers/color",
+              "type": "color",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/color/neutral/250"
+              }
+            },
+            {
+              "name": "semantics/dividers/thickness",
+              "type": "number",
+              "isAlias": false,
+              "value": 1
+            },
+            {
+              "name": "semantics/input-fields/placeholder/color",
+              "type": "color",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/color/neutral/600"
+              }
+            },
+            {
+              "name": "semantics/input-fields/end-fade/start-color",
+              "type": "color",
+              "isAlias": false,
+              "value": "#20252B00"
+            },
+            {
+              "name": "semantics/input-fields/background-color",
+              "type": "color",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "semantics/surfaces/background-color"
+              }
+            },
+            {
+              "name": "semantics/input-fields/border-color",
+              "type": "color",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/color/neutral/600"
+              }
+            },
+            {
+              "name": "semantics/input-fields/end-fade/end-color",
+              "type": "color",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "semantics/input-fields/background-color"
+              }
+            },
+            {
+              "name": "semantics/input-fields/is-valid/border-color",
+              "type": "color",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/color/success/600"
+              }
+            },
+            {
+              "name": "semantics/input-fields/is-valid/icon/color",
+              "type": "color",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/color/success/600"
+              }
+            },
+            {
+              "name": "semantics/input-fields/is-invalid/border-color",
+              "type": "color",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/color/danger/600"
+              }
+            },
+            {
+              "name": "semantics/input-fields/is-read-only/background-color",
+              "type": "color",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/color/neutral/150"
+              }
+            },
+            {
+              "name": "semantics/input-fields/is-read-only/border-color",
+              "type": "color",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/color/neutral/150"
+              }
+            },
+            {
+              "name": "semantics/input-fields/is-invalid/icon/color",
+              "type": "color",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/color/danger/600"
+              }
+            },
+            {
+              "name": "semantics/page-sections/body/max-width",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/area/1280"
+              }
+            },
+            {
+              "name": "semantics/page-sections/sm/margin-inline",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/space/16"
+              }
+            },
+            {
+              "name": "semantics/page-sections/sm/margin-block",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/space/16"
+              }
+            },
+            {
+              "name": "semantics/page-sections/sm/gap",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/space/16"
+              }
+            },
+            {
+              "name": "semantics/page-sections/md/margin-inline",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/space/32"
+              }
+            },
+            {
+              "name": "semantics/page-sections/md/margin-block",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/space/24"
+              }
+            },
+            {
+              "name": "semantics/page-sections/md/gap",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/space/24"
+              }
+            },
+            {
+              "name": "semantics/page-sections/lg/margin-inline",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/space/48"
+              }
+            },
+            {
+              "name": "semantics/page-sections/lg/margin-block",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/space/32"
+              }
+            },
+            {
+              "name": "semantics/page-sections/lg/gap",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/space/24"
+              }
+            },
+            {
+              "name": "semantics/overlays/corner-radius",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/corner-radius/none"
+              }
+            },
+            {
+              "name": "semantics/focus-rings/inner/color",
+              "type": "color",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "semantics/surfaces/background-color"
+              }
+            },
+            {
+              "name": "semantics/focus-rings/inner/thickness",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/space/2"
+              }
+            },
+            {
+              "name": "semantics/focus-rings/center/color",
+              "type": "color",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/color/accent/650"
+              }
+            },
+            {
+              "name": "semantics/focus-rings/center/thickness",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/space/4"
+              }
+            },
+            {
+              "name": "primitives/color/neutral/0",
+              "type": "color",
+              "isAlias": false,
+              "value": "#000000"
+            },
+            {
+              "name": "primitives/color/neutral/25",
+              "type": "color",
+              "isAlias": false,
+              "value": "#0B0D10"
+            },
+            {
+              "name": "primitives/color/neutral/50",
+              "type": "color",
+              "isAlias": false,
+              "value": "#14171A"
+            },
+            {
+              "name": "primitives/color/neutral/75",
+              "type": "color",
+              "isAlias": false,
+              "value": "#1B1E23"
+            },
+            {
+              "name": "primitives/color/neutral/100",
+              "type": "color",
+              "isAlias": false,
+              "value": "#20252B"
+            },
+            {
+              "name": "primitives/font-family/body",
+              "type": "string",
+              "isAlias": false,
+              "value": "RijksSansVF"
+            },
+            {
+              "name": "primitives/color/neutral/150",
+              "type": "color",
+              "isAlias": false,
+              "value": "#2A3039"
+            },
+            {
+              "name": "primitives/font-family/body-fallback",
+              "type": "string",
+              "isAlias": false,
+              "value": "system-ui"
+            },
+            {
+              "name": "primitives/font-family/display",
+              "type": "string",
+              "isAlias": false,
+              "value": "RijksSansVF"
+            },
+            {
+              "name": "primitives/font-family/display-fallback",
+              "type": "string",
+              "isAlias": false,
+              "value": "system-ui"
+            },
+            {
+              "name": "primitives/font-family/sans-serif",
+              "type": "string",
+              "isAlias": false,
+              "value": "RijksSansVF"
+            },
+            {
+              "name": "primitives/font-family/sans-serif-fallback",
+              "type": "string",
+              "isAlias": false,
+              "value": "system-ui"
+            },
+            {
+              "name": "primitives/font-family/serif",
+              "type": "string",
+              "isAlias": false,
+              "value": "RijksoverheidSerif"
+            },
+            {
+              "name": "primitives/font-family/serif-fallback",
+              "type": "string",
+              "isAlias": false,
+              "value": "serif"
+            },
+            {
+              "name": "primitives/color/neutral/200",
+              "type": "color",
+              "isAlias": false,
+              "value": "#333A45"
+            },
+            {
+              "name": "primitives/color/neutral/250",
+              "type": "color",
+              "isAlias": false,
+              "value": "#3B4451"
+            },
+            {
+              "name": "primitives/color/neutral/300",
+              "type": "color",
+              "isAlias": false,
+              "value": "#444E5D"
+            },
+            {
+              "name": "primitives/color/neutral/350",
+              "type": "color",
+              "isAlias": false,
+              "value": "#4C5869"
+            },
+            {
+              "name": "primitives/color/neutral/400",
+              "type": "color",
+              "isAlias": false,
+              "value": "#556275"
+            },
+            {
+              "name": "primitives/color/neutral/450",
+              "type": "color",
+              "isAlias": false,
+              "value": "#5D6C81"
+            },
+            {
+              "name": "primitives/color/neutral/500",
+              "type": "color",
+              "isAlias": false,
+              "value": "#67778D"
+            },
+            {
+              "name": "primitives/color/neutral/550",
+              "type": "color",
+              "isAlias": false,
+              "value": "#738197"
+            },
+            {
+              "name": "primitives/color/neutral/600",
+              "type": "color",
+              "isAlias": false,
+              "value": "#808DA0"
+            },
+            {
+              "name": "primitives/color/neutral/650",
+              "type": "color",
+              "isAlias": false,
+              "value": "#8D98AA"
+            },
+            {
+              "name": "primitives/color/neutral/700",
+              "type": "color",
+              "isAlias": false,
+              "value": "#9BA5B5"
+            },
+            {
+              "name": "primitives/color/neutral/750",
+              "type": "color",
+              "isAlias": false,
+              "value": "#A9B2C0"
+            },
+            {
+              "name": "primitives/color/neutral/800",
+              "type": "color",
+              "isAlias": false,
+              "value": "#B8C0CB"
+            },
+            {
+              "name": "primitives/color/neutral/850",
+              "type": "color",
+              "isAlias": false,
+              "value": "#C9CED8"
+            },
+            {
+              "name": "primitives/color/neutral/900",
+              "type": "color",
+              "isAlias": false,
+              "value": "#D9DEE4"
+            },
+            {
+              "name": "primitives/color/neutral/950",
+              "type": "color",
+              "isAlias": false,
+              "value": "#EBEEF2"
+            },
+            {
+              "name": "primitives/color/neutral/1000",
+              "type": "color",
+              "isAlias": false,
+              "value": "#FFFFFF"
+            },
+            {
+              "name": "primitives/color/accent/0",
+              "type": "color",
+              "isAlias": false,
+              "value": "#000000"
+            },
+            {
+              "name": "primitives/color/accent/25",
+              "type": "color",
+              "isAlias": false,
+              "value": "#000D21"
+            },
+            {
+              "name": "primitives/color/accent/50",
+              "type": "color",
+              "isAlias": false,
+              "value": "#08192B"
+            },
+            {
+              "name": "primitives/color/accent/75",
+              "type": "color",
+              "isAlias": false,
+              "value": "#001E3D"
+            },
+            {
+              "name": "primitives/color/accent/100",
+              "type": "color",
+              "isAlias": false,
+              "value": "#08192B"
+            },
+            {
+              "name": "primitives/color/accent/150",
+              "type": "color",
+              "isAlias": false,
+              "value": "#0C2541"
+            },
+            {
+              "name": "primitives/color/accent/200",
+              "type": "color",
+              "isAlias": false,
+              "value": "#103257"
+            },
+            {
+              "name": "primitives/color/accent/250",
+              "type": "color",
+              "isAlias": false,
+              "value": "#133D6A"
+            },
+            {
+              "name": "primitives/color/accent/300",
+              "type": "color",
+              "isAlias": false,
+              "value": "#184B81"
+            },
+            {
+              "name": "primitives/color/accent/350",
+              "type": "color",
+              "isAlias": false,
+              "value": "#1C5897"
+            },
+            {
+              "name": "primitives/color/accent/400",
+              "type": "color",
+              "isAlias": false,
+              "value": "#2064AC"
+            },
+            {
+              "name": "primitives/color/accent/450",
+              "type": "color",
+              "isAlias": false,
+              "value": "#2471C2"
+            },
+            {
+              "name": "primitives/color/accent/500",
+              "type": "color",
+              "isAlias": false,
+              "value": "#2677CD"
+            },
+            {
+              "name": "primitives/color/success/0",
+              "type": "color",
+              "isAlias": false,
+              "value": "#000000"
+            },
+            {
+              "name": "primitives/color/success/25",
+              "type": "color",
+              "isAlias": false,
+              "value": "#070F00"
+            },
+            {
+              "name": "primitives/color/success/50",
+              "type": "color",
+              "isAlias": false,
+              "value": "#0E1A00"
+            },
+            {
+              "name": "primitives/color/success/75",
+              "type": "color",
+              "isAlias": false,
+              "value": "#122200"
+            },
+            {
+              "name": "primitives/color/success/100",
+              "type": "color",
+              "isAlias": false,
+              "value": "#132A00"
+            },
+            {
+              "name": "primitives/color/success/150",
+              "type": "color",
+              "isAlias": false,
+              "value": "#153700"
+            },
+            {
+              "name": "primitives/color/success/200",
+              "type": "color",
+              "isAlias": false,
+              "value": "#174300"
+            },
+            {
+              "name": "primitives/color/accent/550",
+              "type": "color",
+              "isAlias": false,
+              "value": "#3D8BDB"
+            },
+            {
+              "name": "primitives/color/accent/600",
+              "type": "color",
+              "isAlias": false,
+              "value": "#5397DF"
+            },
+            {
+              "name": "primitives/color/success/250",
+              "type": "color",
+              "isAlias": false,
+              "value": "#1B4E00"
+            },
+            {
+              "name": "primitives/color/success/300",
+              "type": "color",
+              "isAlias": false,
+              "value": "#205900"
+            },
+            {
+              "name": "primitives/color/success/350",
+              "type": "color",
+              "isAlias": false,
+              "value": "#256400"
+            },
+            {
+              "name": "primitives/color/accent/650",
+              "type": "color",
+              "isAlias": false,
+              "value": "#68A4E3"
+            },
+            {
+              "name": "primitives/color/success/400",
+              "type": "color",
+              "isAlias": false,
+              "value": "#296F00"
+            },
+            {
+              "name": "primitives/color/success/450",
+              "type": "color",
+              "isAlias": false,
+              "value": "#2F7B00"
+            },
+            {
+              "name": "primitives/color/accent/700",
+              "type": "color",
+              "isAlias": false,
+              "value": "#7EB1E7"
+            },
+            {
+              "name": "primitives/color/success/500",
+              "type": "color",
+              "isAlias": false,
+              "value": "#38860A"
+            },
+            {
+              "name": "primitives/color/success/550",
+              "type": "color",
+              "isAlias": false,
+              "value": "#44911A"
+            },
+            {
+              "name": "primitives/color/success/600",
+              "type": "color",
+              "isAlias": false,
+              "value": "#519D28"
+            },
+            {
+              "name": "primitives/color/success/650",
+              "type": "color",
+              "isAlias": false,
+              "value": "#5EAA34"
+            },
+            {
+              "name": "primitives/color/warning/0",
+              "type": "color",
+              "isAlias": false,
+              "value": "#000000"
+            },
+            {
+              "name": "primitives/color/warning/25",
+              "type": "color",
+              "isAlias": false,
+              "value": "#170A00"
+            },
+            {
+              "name": "primitives/color/success/700",
+              "type": "color",
+              "isAlias": false,
+              "value": "#6BB641"
+            },
+            {
+              "name": "primitives/color/warning/50",
+              "type": "color",
+              "isAlias": false,
+              "value": "#241300"
+            },
+            {
+              "name": "primitives/color/warning/75",
+              "type": "color",
+              "isAlias": false,
+              "value": "#301800"
+            },
+            {
+              "name": "primitives/color/warning/100",
+              "type": "color",
+              "isAlias": false,
+              "value": "#3B1D00"
+            },
+            {
+              "name": "primitives/color/warning/150",
+              "type": "color",
+              "isAlias": false,
+              "value": "#4D2500"
+            },
+            {
+              "name": "primitives/color/success/750",
+              "type": "color",
+              "isAlias": false,
+              "value": "#78C44E"
+            },
+            {
+              "name": "primitives/color/warning/200",
+              "type": "color",
+              "isAlias": false,
+              "value": "#5E2C00"
+            },
+            {
+              "name": "primitives/color/warning/250",
+              "type": "color",
+              "isAlias": false,
+              "value": "#6E3400"
+            },
+            {
+              "name": "primitives/color/success/800",
+              "type": "color",
+              "isAlias": false,
+              "value": "#87D25B"
+            },
+            {
+              "name": "primitives/color/success/850",
+              "type": "color",
+              "isAlias": false,
+              "value": "#95E169"
+            },
+            {
+              "name": "primitives/color/success/900",
+              "type": "color",
+              "isAlias": false,
+              "value": "#A5F178"
+            },
+            {
+              "name": "primitives/color/warning/300",
+              "type": "color",
+              "isAlias": false,
+              "value": "#7D3B00"
+            },
+            {
+              "name": "primitives/color/warning/350",
+              "type": "color",
+              "isAlias": false,
+              "value": "#8B4300"
+            },
+            {
+              "name": "primitives/color/success/950",
+              "type": "color",
+              "isAlias": false,
+              "value": "#C1FF99"
+            },
+            {
+              "name": "primitives/color/warning/400",
+              "type": "color",
+              "isAlias": false,
+              "value": "#9A4B00"
+            },
+            {
+              "name": "primitives/color/success/1000",
+              "type": "color",
+              "isAlias": false,
+              "value": "#FFFFFF"
+            },
+            {
+              "name": "primitives/color/warning/450",
+              "type": "color",
+              "isAlias": false,
+              "value": "#AA5300"
+            },
+            {
+              "name": "primitives/color/warning/500",
+              "type": "color",
+              "isAlias": false,
+              "value": "#BA5B00"
+            },
+            {
+              "name": "primitives/color/warning/550",
+              "type": "color",
+              "isAlias": false,
+              "value": "#CA6400"
+            },
+            {
+              "name": "primitives/color/warning/600",
+              "type": "color",
+              "isAlias": false,
+              "value": "#DB6D00"
+            },
+            {
+              "name": "primitives/color/warning/650",
+              "type": "color",
+              "isAlias": false,
+              "value": "#EB7810"
+            },
+            {
+              "name": "primitives/color/warning/700",
+              "type": "color",
+              "isAlias": false,
+              "value": "#FA8521"
+            },
+            {
+              "name": "primitives/color/warning/750",
+              "type": "color",
+              "isAlias": false,
+              "value": "#FF9849"
+            },
+            {
+              "name": "primitives/color/warning/800",
+              "type": "color",
+              "isAlias": false,
+              "value": "#FFAC72"
+            },
+            {
+              "name": "primitives/color/warning/850",
+              "type": "color",
+              "isAlias": false,
+              "value": "#FFC197"
+            },
+            {
+              "name": "primitives/color/warning/900",
+              "type": "color",
+              "isAlias": false,
+              "value": "#FFD5BA"
+            },
+            {
+              "name": "primitives/color/warning/950",
+              "type": "color",
+              "isAlias": false,
+              "value": "#FFEADD"
+            },
+            {
+              "name": "primitives/color/warning/1000",
+              "type": "color",
+              "isAlias": false,
+              "value": "#FFFFFF"
+            },
+            {
+              "name": "primitives/color/danger/0",
+              "type": "color",
+              "isAlias": false,
+              "value": "#000000"
+            },
+            {
+              "name": "primitives/color/danger/25",
+              "type": "color",
+              "isAlias": false,
+              "value": "#1C0700"
+            },
+            {
+              "name": "primitives/color/highlight/0",
+              "type": "color",
+              "isAlias": false,
+              "value": "#000000"
+            },
+            {
+              "name": "primitives/color/highlight/25",
+              "type": "color",
+              "isAlias": false,
+              "value": "#130C00"
+            },
+            {
+              "name": "primitives/color/highlight/50",
+              "type": "color",
+              "isAlias": false,
+              "value": "#1F1500"
+            },
+            {
+              "name": "primitives/color/highlight/75",
+              "type": "color",
+              "isAlias": false,
+              "value": "#291C00"
+            },
+            {
+              "name": "primitives/color/highlight/100",
+              "type": "color",
+              "isAlias": false,
+              "value": "#322100"
+            },
+            {
+              "name": "primitives/color/highlight/150",
+              "type": "color",
+              "isAlias": false,
+              "value": "#412C00"
+            },
+            {
+              "name": "primitives/color/highlight/200",
+              "type": "color",
+              "isAlias": false,
+              "value": "#4E3500"
+            },
+            {
+              "name": "primitives/color/highlight/250",
+              "type": "color",
+              "isAlias": false,
+              "value": "#5B3E00"
+            },
+            {
+              "name": "primitives/color/highlight/300",
+              "type": "color",
+              "isAlias": false,
+              "value": "#684700"
+            },
+            {
+              "name": "primitives/color/highlight/350",
+              "type": "color",
+              "isAlias": false,
+              "value": "#745000"
+            },
+            {
+              "name": "primitives/color/highlight/400",
+              "type": "color",
+              "isAlias": false,
+              "value": "#815A00"
+            },
+            {
+              "name": "primitives/color/highlight/450",
+              "type": "color",
+              "isAlias": false,
+              "value": "#8E6300"
+            },
+            {
+              "name": "primitives/color/highlight/500",
+              "type": "color",
+              "isAlias": false,
+              "value": "#9B6D00"
+            },
+            {
+              "name": "primitives/color/highlight/550",
+              "type": "color",
+              "isAlias": false,
+              "value": "#A97700"
+            },
+            {
+              "name": "primitives/color/highlight/600",
+              "type": "color",
+              "isAlias": false,
+              "value": "#B88200"
+            },
+            {
+              "name": "primitives/color/highlight/650",
+              "type": "color",
+              "isAlias": false,
+              "value": "#C78D00"
+            },
+            {
+              "name": "primitives/color/highlight/700",
+              "type": "color",
+              "isAlias": false,
+              "value": "#D89800"
+            },
+            {
+              "name": "primitives/color/highlight/750",
+              "type": "color",
+              "isAlias": false,
+              "value": "#E9A500"
+            },
+            {
+              "name": "primitives/color/highlight/800",
+              "type": "color",
+              "isAlias": false,
+              "value": "#FAB207"
+            },
+            {
+              "name": "primitives/color/highlight/850",
+              "type": "color",
+              "isAlias": false,
+              "value": "#FFC460"
+            },
+            {
+              "name": "primitives/color/highlight/900",
+              "type": "color",
+              "isAlias": false,
+              "value": "#FFD79F"
+            },
+            {
+              "name": "primitives/color/highlight/950",
+              "type": "color",
+              "isAlias": false,
+              "value": "#FFEBD1"
+            },
+            {
+              "name": "primitives/color/highlight/1000",
+              "type": "color",
+              "isAlias": false,
+              "value": "#FFFFFF"
+            },
+            {
+              "name": "primitives/color/reference/coolgray",
+              "type": "color",
+              "isAlias": false,
+              "value": "#64748B"
+            },
+            {
+              "name": "primitives/color/danger/50",
+              "type": "color",
+              "isAlias": false,
+              "value": "#2C0D00"
+            },
+            {
+              "name": "primitives/color/danger/75",
+              "type": "color",
+              "isAlias": false,
+              "value": "#3D0E00"
+            },
+            {
+              "name": "primitives/color/danger/100",
+              "type": "color",
+              "isAlias": false,
+              "value": "#4B0D00"
+            },
+            {
+              "name": "primitives/color/danger/150",
+              "type": "color",
+              "isAlias": false,
+              "value": "#640800"
+            },
+            {
+              "name": "primitives/color/danger/200",
+              "type": "color",
+              "isAlias": false,
+              "value": "#7B0000"
+            },
+            {
+              "name": "primitives/color/danger/250",
+              "type": "color",
+              "isAlias": false,
+              "value": "#8D0004"
+            },
+            {
+              "name": "primitives/color/danger/300",
+              "type": "color",
+              "isAlias": false,
+              "value": "#A00007"
+            },
+            {
+              "name": "primitives/color/danger/350",
+              "type": "color",
+              "isAlias": false,
+              "value": "#B20009"
+            },
+            {
+              "name": "primitives/color/danger/400",
+              "type": "color",
+              "isAlias": false,
+              "value": "#C21110"
+            },
+            {
+              "name": "primitives/color/danger/450",
+              "type": "color",
+              "isAlias": false,
+              "value": "#CF241A"
+            },
+            {
+              "name": "primitives/color/danger/500",
+              "type": "color",
+              "isAlias": false,
+              "value": "#DD3424"
+            },
+            {
+              "name": "primitives/color/danger/550",
+              "type": "color",
+              "isAlias": false,
+              "value": "#EB412E"
+            },
+            {
+              "name": "primitives/color/danger/600",
+              "type": "color",
+              "isAlias": false,
+              "value": "#F94F38"
+            },
+            {
+              "name": "primitives/color/danger/650",
+              "type": "color",
+              "isAlias": false,
+              "value": "#FF654C"
+            },
+            {
+              "name": "primitives/color/danger/700",
+              "type": "color",
+              "isAlias": false,
+              "value": "#FF7E65"
+            },
+            {
+              "name": "primitives/color/danger/750",
+              "type": "color",
+              "isAlias": false,
+              "value": "#FF947E"
+            },
+            {
+              "name": "primitives/color/danger/800",
+              "type": "color",
+              "isAlias": false,
+              "value": "#FFAA97"
+            },
+            {
+              "name": "primitives/color/danger/850",
+              "type": "color",
+              "isAlias": false,
+              "value": "#FFBFB0"
+            },
+            {
+              "name": "primitives/color/danger/900",
+              "type": "color",
+              "isAlias": false,
+              "value": "#FFD4CA"
+            },
+            {
+              "name": "primitives/color/danger/950",
+              "type": "color",
+              "isAlias": false,
+              "value": "#FFE9E4"
+            },
+            {
+              "name": "primitives/color/danger/1000",
+              "type": "color",
+              "isAlias": false,
+              "value": "#FFFFFF"
+            },
+            {
+              "name": "primitives/color/reference/lintblauw",
+              "type": "color",
+              "isAlias": false,
+              "value": "#154273"
+            },
+            {
+              "name": "primitives/color/reference/paars",
+              "type": "color",
+              "isAlias": false,
+              "value": "#42145F"
+            },
+            {
+              "name": "primitives/color/reference/violet",
+              "type": "color",
+              "isAlias": false,
+              "value": "#A90061"
+            },
+            {
+              "name": "primitives/color/reference/robijnrood",
+              "type": "color",
+              "isAlias": false,
+              "value": "#CA005D"
+            },
+            {
+              "name": "primitives/color/reference/roze",
+              "type": "color",
+              "isAlias": false,
+              "value": "#F092CD"
+            },
+            {
+              "name": "primitives/color/reference/rood",
+              "type": "color",
+              "isAlias": false,
+              "value": "#D52B1E"
+            },
+            {
+              "name": "primitives/font-size/1000",
+              "type": "number",
+              "isAlias": false,
+              "value": 52
+            },
+            {
+              "name": "primitives/font-size/900",
+              "type": "number",
+              "isAlias": false,
+              "value": 46
+            },
+            {
+              "name": "primitives/font-size/800",
+              "type": "number",
+              "isAlias": false,
+              "value": 41
+            },
+            {
+              "name": "primitives/font-size/700",
+              "type": "number",
+              "isAlias": false,
+              "value": 36
+            },
+            {
+              "name": "primitives/font-size/600",
+              "type": "number",
+              "isAlias": false,
+              "value": 32
+            },
+            {
+              "name": "primitives/font-size/500",
+              "type": "number",
+              "isAlias": false,
+              "value": 29
+            },
+            {
+              "name": "primitives/font-size/400",
+              "type": "number",
+              "isAlias": false,
+              "value": 26
+            },
+            {
+              "name": "primitives/font-size/300",
+              "type": "number",
+              "isAlias": false,
+              "value": 23
+            },
+            {
+              "name": "primitives/font-size/200",
+              "type": "number",
+              "isAlias": false,
+              "value": 20
+            },
+            {
+              "name": "primitives/font-size/100",
+              "type": "number",
+              "isAlias": false,
+              "value": 18
+            },
+            {
+              "name": "primitives/font-size/90",
+              "type": "number",
+              "isAlias": false,
+              "value": 16
+            },
+            {
+              "name": "primitives/font-size/80",
+              "type": "number",
+              "isAlias": false,
+              "value": 14
+            },
+            {
+              "name": "primitives/font-size/70",
+              "type": "number",
+              "isAlias": false,
+              "value": 12
+            },
+            {
+              "name": "primitives/line-height/loose",
+              "type": "number",
+              "isAlias": false,
+              "value": 1.75
+            },
+            {
+              "name": "primitives/line-height/snug",
+              "type": "number",
+              "isAlias": false,
+              "value": 1.5
+            },
+            {
+              "name": "primitives/line-height/tight",
+              "type": "number",
+              "isAlias": false,
+              "value": 1.25
+            },
+            {
+              "name": "primitives/line-height/flat",
+              "type": "number",
+              "isAlias": false,
+              "value": 1.1299999952316284
+            },
+            {
+              "name": "primitives/space/0",
+              "type": "number",
+              "isAlias": false,
+              "value": 0
+            },
+            {
+              "name": "primitives/space/2",
+              "type": "number",
+              "isAlias": false,
+              "value": 2
+            },
+            {
+              "name": "primitives/space/4",
+              "type": "number",
+              "isAlias": false,
+              "value": 4
+            },
+            {
+              "name": "primitives/space/6",
+              "type": "number",
+              "isAlias": false,
+              "value": 6
+            },
+            {
+              "name": "primitives/space/8",
+              "type": "number",
+              "isAlias": false,
+              "value": 8
+            },
+            {
+              "name": "primitives/space/10",
+              "type": "number",
+              "isAlias": false,
+              "value": 10
+            },
+            {
+              "name": "primitives/space/12",
+              "type": "number",
+              "isAlias": false,
+              "value": 12
+            },
+            {
+              "name": "primitives/space/14",
+              "type": "number",
+              "isAlias": false,
+              "value": 14
+            },
+            {
+              "name": "primitives/space/16",
+              "type": "number",
+              "isAlias": false,
+              "value": 16
+            },
+            {
+              "name": "primitives/space/18",
+              "type": "number",
+              "isAlias": false,
+              "value": 18
+            },
+            {
+              "name": "primitives/space/20",
+              "type": "number",
+              "isAlias": false,
+              "value": 20
+            },
+            {
+              "name": "primitives/space/24",
+              "type": "number",
+              "isAlias": false,
+              "value": 24
+            },
+            {
+              "name": "primitives/space/28",
+              "type": "number",
+              "isAlias": false,
+              "value": 28
+            },
+            {
+              "name": "primitives/space/32",
+              "type": "number",
+              "isAlias": false,
+              "value": 32
+            },
+            {
+              "name": "primitives/space/40",
+              "type": "number",
+              "isAlias": false,
+              "value": 40
+            },
+            {
+              "name": "primitives/space/44",
+              "type": "number",
+              "isAlias": false,
+              "value": 44
+            },
+            {
+              "name": "primitives/space/48",
+              "type": "number",
+              "isAlias": false,
+              "value": 48
+            },
+            {
+              "name": "primitives/space/56",
+              "type": "number",
+              "isAlias": false,
+              "value": 56
+            },
+            {
+              "name": "primitives/space/64",
+              "type": "number",
+              "isAlias": false,
+              "value": 64
+            },
+            {
+              "name": "primitives/space/80",
+              "type": "number",
+              "isAlias": false,
+              "value": 80
+            },
+            {
+              "name": "primitives/space/96",
+              "type": "number",
+              "isAlias": false,
+              "value": 96
+            },
+            {
+              "name": "primitives/font-weight/body/hairline",
+              "type": "string",
+              "isAlias": false,
+              "value": "Thin"
+            },
+            {
+              "name": "primitives/font-weight/body/thin",
+              "type": "string",
+              "isAlias": false,
+              "value": "Thin"
+            },
+            {
+              "name": "primitives/font-weight/body/light",
+              "type": "string",
+              "isAlias": false,
+              "value": "Light"
+            },
+            {
+              "name": "primitives/font-weight/body/regular",
+              "type": "string",
+              "isAlias": false,
+              "value": "Regular"
+            },
+            {
+              "name": "primitives/font-weight/body/medium",
+              "type": "string",
+              "isAlias": false,
+              "value": "SemiBold"
+            },
+            {
+              "name": "primitives/font-weight/body/semi-bold",
+              "type": "string",
+              "isAlias": false,
+              "value": "SemiBold"
+            },
+            {
+              "name": "primitives/font-weight/body/bold",
+              "type": "string",
+              "isAlias": false,
+              "value": "SemiBold"
+            },
+            {
+              "name": "primitives/font-weight/body/extra-bold",
+              "type": "string",
+              "isAlias": false,
+              "value": "Bold"
+            },
+            {
+              "name": "primitives/font-weight/body/black",
+              "type": "string",
+              "isAlias": false,
+              "value": "ExtraBold"
+            },
+            {
+              "name": "primitives/area/120",
+              "type": "number",
+              "isAlias": false,
+              "value": 120
+            },
+            {
+              "name": "primitives/area/160",
+              "type": "number",
+              "isAlias": false,
+              "value": 160
+            },
+            {
+              "name": "primitives/area/200",
+              "type": "number",
+              "isAlias": false,
+              "value": 200
+            },
+            {
+              "name": "primitives/area/240",
+              "type": "number",
+              "isAlias": false,
+              "value": 240
+            },
+            {
+              "name": "primitives/area/280",
+              "type": "number",
+              "isAlias": false,
+              "value": 280
+            },
+            {
+              "name": "primitives/area/320",
+              "type": "number",
+              "isAlias": false,
+              "value": 320
+            },
+            {
+              "name": "primitives/area/360",
+              "type": "number",
+              "isAlias": false,
+              "value": 360
+            },
+            {
+              "name": "primitives/area/400",
+              "type": "number",
+              "isAlias": false,
+              "value": 400
+            },
+            {
+              "name": "primitives/area/480",
+              "type": "number",
+              "isAlias": false,
+              "value": 480
+            },
+            {
+              "name": "primitives/area/640",
+              "type": "number",
+              "isAlias": false,
+              "value": 640
+            },
+            {
+              "name": "primitives/area/720",
+              "type": "number",
+              "isAlias": false,
+              "value": 720
+            },
+            {
+              "name": "primitives/area/800",
+              "type": "number",
+              "isAlias": false,
+              "value": 800
+            },
+            {
+              "name": "primitives/area/960",
+              "type": "number",
+              "isAlias": false,
+              "value": 960
+            },
+            {
+              "name": "primitives/area/1280",
+              "type": "number",
+              "isAlias": false,
+              "value": 1280
+            },
+            {
+              "name": "primitives/area/1440",
+              "type": "number",
+              "isAlias": false,
+              "value": 1440
+            },
+            {
+              "name": "primitives/breakpoint/sm-min",
+              "type": "number",
+              "isAlias": false,
+              "value": 320
+            },
+            {
+              "name": "primitives/breakpoint/sm-max",
+              "type": "number",
+              "isAlias": false,
+              "value": 640
+            },
+            {
+              "name": "primitives/breakpoint/md-min",
+              "type": "number",
+              "isAlias": false,
+              "value": 641
+            },
+            {
+              "name": "primitives/breakpoint/md-max",
+              "type": "number",
+              "isAlias": false,
+              "value": 1007
+            },
+            {
+              "name": "primitives/breakpoint/lg-min",
+              "type": "number",
+              "isAlias": false,
+              "value": 1008
+            },
+            {
+              "name": "primitives/corner-radius/none",
+              "type": "number",
+              "isAlias": false,
+              "value": 0
+            },
+            {
+              "name": "primitives/corner-radius/xxs",
+              "type": "number",
+              "isAlias": false,
+              "value": 2
+            },
+            {
+              "name": "primitives/corner-radius/xs",
+              "type": "number",
+              "isAlias": false,
+              "value": 4
+            },
+            {
+              "name": "primitives/corner-radius/sm",
+              "type": "number",
+              "isAlias": false,
+              "value": 6
+            },
+            {
+              "name": "primitives/corner-radius/md",
+              "type": "number",
+              "isAlias": false,
+              "value": 9
+            },
+            {
+              "name": "primitives/corner-radius/lg",
+              "type": "number",
+              "isAlias": false,
+              "value": 12
+            },
+            {
+              "name": "primitives/corner-radius/xl",
+              "type": "number",
+              "isAlias": false,
+              "value": 16
+            },
+            {
+              "name": "primitives/corner-radius/xxl",
+              "type": "number",
+              "isAlias": false,
+              "value": 20
+            },
+            {
+              "name": "primitives/corner-radius/xxxl",
+              "type": "number",
+              "isAlias": false,
+              "value": 24
+            },
+            {
+              "name": "primitives/corner-radius/full",
+              "type": "number",
+              "isAlias": false,
+              "value": 9999
+            },
+            {
+              "name": "primitives/opacity/disabled",
+              "type": "number",
+              "isAlias": false,
+              "value": 38
+            },
+            {
+              "name": "primitives/opacity/0",
+              "type": "number",
+              "isAlias": false,
+              "value": 0
+            },
+            {
+              "name": "primitives/opacity/5",
+              "type": "number",
+              "isAlias": false,
+              "value": 5
+            },
+            {
+              "name": "primitives/opacity/10",
+              "type": "number",
+              "isAlias": false,
+              "value": 10
+            },
+            {
+              "name": "primitives/opacity/15",
+              "type": "number",
+              "isAlias": false,
+              "value": 15
+            },
+            {
+              "name": "primitives/opacity/20",
+              "type": "number",
+              "isAlias": false,
+              "value": 20
+            },
+            {
+              "name": "primitives/opacity/25",
+              "type": "number",
+              "isAlias": false,
+              "value": 25
+            },
+            {
+              "name": "primitives/opacity/30",
+              "type": "number",
+              "isAlias": false,
+              "value": 30
+            },
+            {
+              "name": "primitives/opacity/35",
+              "type": "number",
+              "isAlias": false,
+              "value": 35
+            },
+            {
+              "name": "primitives/opacity/40",
+              "type": "number",
+              "isAlias": false,
+              "value": 40
+            },
+            {
+              "name": "primitives/opacity/45",
+              "type": "number",
+              "isAlias": false,
+              "value": 45
+            },
+            {
+              "name": "primitives/opacity/50",
+              "type": "number",
+              "isAlias": false,
+              "value": 50
+            },
+            {
+              "name": "primitives/opacity/55",
+              "type": "number",
+              "isAlias": false,
+              "value": 55
+            },
+            {
+              "name": "primitives/opacity/60",
+              "type": "number",
+              "isAlias": false,
+              "value": 60
+            },
+            {
+              "name": "primitives/opacity/65",
+              "type": "number",
+              "isAlias": false,
+              "value": 65
+            },
+            {
+              "name": "primitives/opacity/70",
+              "type": "number",
+              "isAlias": false,
+              "value": 70
+            },
+            {
+              "name": "primitives/opacity/75",
+              "type": "number",
+              "isAlias": false,
+              "value": 75
+            },
+            {
+              "name": "primitives/opacity/80",
+              "type": "number",
+              "isAlias": false,
+              "value": 80
+            },
+            {
+              "name": "primitives/opacity/85",
+              "type": "number",
+              "isAlias": false,
+              "value": 85
+            },
+            {
+              "name": "primitives/opacity/90",
+              "type": "number",
+              "isAlias": false,
+              "value": 90
+            },
+            {
+              "name": "primitives/opacity/95",
+              "type": "number",
+              "isAlias": false,
+              "value": 95
+            },
+            {
+              "name": "primitives/opacity/100",
+              "type": "number",
+              "isAlias": false,
+              "value": 100
+            },
+            {
+              "name": "primitives/font-weight/display/hairline",
+              "type": "string",
+              "isAlias": false,
+              "value": "Thin"
+            },
+            {
+              "name": "primitives/font-weight/display/thin",
+              "type": "string",
+              "isAlias": false,
+              "value": "Thin"
+            },
+            {
+              "name": "primitives/font-weight/display/light",
+              "type": "string",
+              "isAlias": false,
+              "value": "Light"
+            },
+            {
+              "name": "primitives/font-weight/display/regular",
+              "type": "string",
+              "isAlias": false,
+              "value": "Regular"
+            },
+            {
+              "name": "primitives/font-weight/display/medium",
+              "type": "string",
+              "isAlias": false,
+              "value": "SemiBold"
+            },
+            {
+              "name": "primitives/font-weight/display/semi-bold",
+              "type": "string",
+              "isAlias": false,
+              "value": "SemiBold"
+            },
+            {
+              "name": "primitives/font-weight/display/bold",
+              "type": "string",
+              "isAlias": false,
+              "value": "SemiBold"
+            },
+            {
+              "name": "primitives/font-weight/display/extra-bold",
+              "type": "string",
+              "isAlias": false,
+              "value": "Bold"
+            },
+            {
+              "name": "primitives/font-weight/display/black",
+              "type": "string",
+              "isAlias": false,
+              "value": "ExtraBold"
+            },
+            {
+              "name": "primitives/color/reference/oranje",
+              "type": "color",
+              "isAlias": false,
+              "value": "#E17000"
+            },
+            {
+              "name": "primitives/color/reference/donkergeel",
+              "type": "color",
+              "isAlias": false,
+              "value": "#FFB612"
+            },
+            {
+              "name": "primitives/color/reference/geel",
+              "type": "color",
+              "isAlias": false,
+              "value": "#F9E11E"
+            },
+            {
+              "name": "primitives/color/reference/donkerbruin",
+              "type": "color",
+              "isAlias": false,
+              "value": "#673327"
+            },
+            {
+              "name": "primitives/color/reference/bruin",
+              "type": "color",
+              "isAlias": false,
+              "value": "#94710A"
+            },
+            {
+              "name": "primitives/color/reference/donkergroen",
+              "type": "color",
+              "isAlias": false,
+              "value": "#275937"
+            },
+            {
+              "name": "primitives/color/reference/groen",
+              "type": "color",
+              "isAlias": false,
+              "value": "#39870C"
+            },
+            {
+              "name": "primitives/color/reference/mosgroen",
+              "type": "color",
+              "isAlias": false,
+              "value": "#777B00"
+            },
+            {
+              "name": "primitives/color/reference/mintgroen",
+              "type": "color",
+              "isAlias": false,
+              "value": "#76D2B6"
+            },
+            {
+              "name": "primitives/color/reference/donkerblauw",
+              "type": "color",
+              "isAlias": false,
+              "value": "#01689B"
+            },
+            {
+              "name": "primitives/color/reference/hemelblauw",
+              "type": "color",
+              "isAlias": false,
+              "value": "#007BC7"
+            },
+            {
+              "name": "primitives/color/reference/lichtblauw",
+              "type": "color",
+              "isAlias": false,
+              "value": "#8FCAE7"
+            },
+            {
+              "name": "components/button-group/sm/gap",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/space/6"
+              }
+            },
+            {
+              "name": "components/button-group/md/gap",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/space/8"
+              }
+            },
+            {
+              "name": "components/toggle-button-group/sm/gap",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/space/6"
+              }
+            },
+            {
+              "name": "components/toggle-button-group/md/gap",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/space/8"
+              }
+            },
+            {
+              "name": "components/page/fixed-area/background-gradient/color-1",
+              "type": "color",
+              "isAlias": false,
+              "value": "#20252BF2"
+            },
+            {
+              "name": "components/page/fixed-area/background-gradient/color-2",
+              "type": "color",
+              "isAlias": false,
+              "value": "#20252B99"
+            },
+            {
+              "name": "components/page/fixed-area/background-gradient/color-3",
+              "type": "color",
+              "isAlias": false,
+              "value": "#1E252E00"
+            },
+            {
+              "name": "components/page/fixed-area/tinted/background-gradient/color-1",
+              "type": "color",
+              "isAlias": false,
+              "value": "#1B1E23F2"
+            },
+            {
+              "name": "components/page/fixed-area/tinted/background-gradient/color-2",
+              "type": "color",
+              "isAlias": false,
+              "value": "#1B1E2399"
+            },
+            {
+              "name": "components/page/fixed-area/tinted/background-gradient/color-3",
+              "type": "color",
+              "isAlias": false,
+              "value": "#1B1E2300"
+            },
+            {
+              "name": "primitives/color/accent/750 (reference)",
+              "type": "color",
+              "isAlias": false,
+              "value": "#93BEEB"
+            },
+            {
+              "name": "primitives/color/accent/800",
+              "type": "color",
+              "isAlias": false,
+              "value": "#A9CBEF"
+            },
+            {
+              "name": "primitives/color/accent/850",
+              "type": "color",
+              "isAlias": false,
+              "value": "#BED8F3"
+            },
+            {
+              "name": "primitives/color/accent/900",
+              "type": "color",
+              "isAlias": false,
+              "value": "#D4E5F7"
+            },
+            {
+              "name": "primitives/color/accent/950",
+              "type": "color",
+              "isAlias": false,
+              "value": "#E9F2FB"
+            },
+            {
+              "name": "primitives/color/accent/1000",
+              "type": "color",
+              "isAlias": false,
+              "value": "#FFFFFF"
+            },
+            {
+              "name": "semantics/controls/lg/min-size",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/space/56"
+              }
+            },
+            {
+              "name": "semantics/controls/lg/corner-radius",
+              "type": "number",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "primitives/corner-radius/md"
+              }
+            },
+            {
+              "name": "semantics/focus-rings/outer/color",
+              "type": "color",
+              "isAlias": true,
+              "value": {
+                "collection": "Themes",
+                "name": "semantics/surfaces/background-color"
+              }
+            },
+            {
+              "name": "semantics/focus-rings/outer/thickness",
               "type": "number",
               "isAlias": true,
               "value": {
@@ -2452,14 +5544,14 @@
           "name": "Style",
           "variables": [
             {
-              "name": "components/button/m/font",
+              "name": "components/title-bar/sm/overline",
               "type": "typography",
               "isAlias": false,
               "value": {
-                "fontSize": 18,
+                "fontSize": 14,
                 "fontFamily": "RijksSansVF",
-                "fontWeight": 550,
-                "lineHeight": 112.5,
+                "fontWeight": "Regular",
+                "lineHeight": 125,
                 "lineHeightUnit": "PERCENT",
                 "letterSpacing": 0,
                 "letterSpacingUnit": "PERCENT",
@@ -2468,14 +5560,14 @@
               }
             },
             {
-              "name": "components/button/s/font",
+              "name": "components/title-bar/sm/subtitle",
               "type": "typography",
               "isAlias": false,
               "value": {
                 "fontSize": 16,
                 "fontFamily": "RijksSansVF",
-                "fontWeight": 550,
-                "lineHeight": 112.5,
+                "fontWeight": "Regular",
+                "lineHeight": 125,
                 "lineHeightUnit": "PERCENT",
                 "letterSpacing": 0,
                 "letterSpacingUnit": "PERCENT",
@@ -2484,14 +5576,14 @@
               }
             },
             {
-              "name": "components/button/xs/font",
+              "name": "components/title-bar/md/overline",
               "type": "typography",
               "isAlias": false,
               "value": {
                 "fontSize": 14,
                 "fontFamily": "RijksSansVF",
-                "fontWeight": 550,
-                "lineHeight": 112.5,
+                "fontWeight": "Regular",
+                "lineHeight": 125,
                 "lineHeightUnit": "PERCENT",
                 "letterSpacing": 0,
                 "letterSpacingUnit": "PERCENT",
@@ -2500,14 +5592,62 @@
               }
             },
             {
-              "name": "components/icon-button/font",
+              "name": "components/title-bar/md/subtitle",
               "type": "typography",
               "isAlias": false,
               "value": {
-                "fontSize": 14,
+                "fontSize": 16,
                 "fontFamily": "RijksSansVF",
-                "fontWeight": 550,
-                "lineHeight": 112.5,
+                "fontWeight": "Regular",
+                "lineHeight": 125,
+                "lineHeightUnit": "PERCENT",
+                "letterSpacing": 0,
+                "letterSpacingUnit": "PERCENT",
+                "textCase": "ORIGINAL",
+                "textDecoration": "NONE"
+              }
+            },
+            {
+              "name": "components/title-bar/lg/overline",
+              "type": "typography",
+              "isAlias": false,
+              "value": {
+                "fontSize": 16,
+                "fontFamily": "RijksSansVF",
+                "fontWeight": "Regular",
+                "lineHeight": 125,
+                "lineHeightUnit": "PERCENT",
+                "letterSpacing": 0,
+                "letterSpacingUnit": "PERCENT",
+                "textCase": "ORIGINAL",
+                "textDecoration": "NONE"
+              }
+            },
+            {
+              "name": "components/title-bar/lg/subtitle",
+              "type": "typography",
+              "isAlias": false,
+              "value": {
+                "fontSize": 16,
+                "fontFamily": "RijksSansVF",
+                "fontWeight": "Regular",
+                "lineHeight": 125,
+                "lineHeightUnit": "PERCENT",
+                "letterSpacing": 0,
+                "letterSpacingUnit": "PERCENT",
+                "textCase": "ORIGINAL",
+                "textDecoration": "NONE"
+              }
+            },
+            {
+              "name": "components/document-tab-bar/tab-title/font",
+              "type": "typography",
+              "isAlias": false,
+              "value": {
+                "fontSize": 16,
+                "fontFamily": "RijksSansVF",
+                "fontWeight": "SemiBold",
+                "lineHeight": 100,
                 "lineHeightUnit": "PERCENT",
                 "letterSpacing": 0,
                 "letterSpacingUnit": "PERCENT",
@@ -2522,7 +5662,7 @@
               "value": {
                 "fontSize": 18,
                 "fontFamily": "RijksSansVF",
-                "fontWeight": 550,
+                "fontWeight": "SemiBold",
                 "lineHeight": 112.5,
                 "lineHeightUnit": "PERCENT",
                 "letterSpacing": 0,
@@ -2538,7 +5678,7 @@
               "value": {
                 "fontSize": 20,
                 "fontFamily": "RijksSansVF",
-                "fontWeight": 550,
+                "fontWeight": "SemiBold",
                 "lineHeight": 112.5,
                 "lineHeightUnit": "PERCENT",
                 "letterSpacing": 0,
@@ -2554,7 +5694,7 @@
               "value": {
                 "fontSize": 23,
                 "fontFamily": "RijksSansVF",
-                "fontWeight": 550,
+                "fontWeight": "SemiBold",
                 "lineHeight": 112.5,
                 "lineHeightUnit": "PERCENT",
                 "letterSpacing": 0,
@@ -2570,7 +5710,7 @@
               "value": {
                 "fontSize": 18,
                 "fontFamily": "RijksSansVF",
-                "fontWeight": 550,
+                "fontWeight": "SemiBold",
                 "lineHeight": 112.5,
                 "lineHeightUnit": "PERCENT",
                 "letterSpacing": 0,
@@ -2580,14 +5720,14 @@
               }
             },
             {
-              "name": "semantics/document-tab-bar/tab-title/font",
+              "name": "semantics/content/body/lg/regular-loose",
               "type": "typography",
               "isAlias": false,
               "value": {
-                "fontSize": 16,
+                "fontSize": 20,
                 "fontFamily": "RijksSansVF",
-                "fontWeight": 550,
-                "lineHeight": 100,
+                "fontWeight": "Regular",
+                "lineHeight": 175,
                 "lineHeightUnit": "PERCENT",
                 "letterSpacing": 0,
                 "letterSpacingUnit": "PERCENT",
@@ -2596,14 +5736,126 @@
               }
             },
             {
-              "name": "semantics/input-fields/text",
+              "name": "semantics/content/body/lg/regular-snug",
+              "type": "typography",
+              "isAlias": false,
+              "value": {
+                "fontSize": 20,
+                "fontFamily": "RijksSansVF",
+                "fontWeight": "Regular",
+                "lineHeight": 150,
+                "lineHeightUnit": "PERCENT",
+                "letterSpacing": 0,
+                "letterSpacingUnit": "PERCENT",
+                "textCase": "ORIGINAL",
+                "textDecoration": "NONE"
+              }
+            },
+            {
+              "name": "semantics/content/body/lg/regular-tight",
+              "type": "typography",
+              "isAlias": false,
+              "value": {
+                "fontSize": 20,
+                "fontFamily": "RijksSansVF",
+                "fontWeight": "Regular",
+                "lineHeight": 125,
+                "lineHeightUnit": "PERCENT",
+                "letterSpacing": 0,
+                "letterSpacingUnit": "PERCENT",
+                "textCase": "ORIGINAL",
+                "textDecoration": "NONE"
+              }
+            },
+            {
+              "name": "semantics/content/body/lg/regular-flat",
+              "type": "typography",
+              "isAlias": false,
+              "value": {
+                "fontSize": 20,
+                "fontFamily": "RijksSansVF",
+                "fontWeight": "Regular",
+                "lineHeight": 112.5,
+                "lineHeightUnit": "PERCENT",
+                "letterSpacing": 0,
+                "letterSpacingUnit": "PERCENT",
+                "textCase": "ORIGINAL",
+                "textDecoration": "NONE"
+              }
+            },
+            {
+              "name": "semantics/content/body/lg/bold-loose",
+              "type": "typography",
+              "isAlias": false,
+              "value": {
+                "fontSize": 20,
+                "fontFamily": "RijksSansVF",
+                "fontWeight": "SemiBold",
+                "lineHeight": 175,
+                "lineHeightUnit": "PERCENT",
+                "letterSpacing": 0,
+                "letterSpacingUnit": "PERCENT",
+                "textCase": "ORIGINAL",
+                "textDecoration": "NONE"
+              }
+            },
+            {
+              "name": "semantics/content/body/lg/bold-snug",
+              "type": "typography",
+              "isAlias": false,
+              "value": {
+                "fontSize": 20,
+                "fontFamily": "RijksSansVF",
+                "fontWeight": "SemiBold",
+                "lineHeight": 150,
+                "lineHeightUnit": "PERCENT",
+                "letterSpacing": 0,
+                "letterSpacingUnit": "PERCENT",
+                "textCase": "ORIGINAL",
+                "textDecoration": "NONE"
+              }
+            },
+            {
+              "name": "semantics/content/body/lg/bold-tight",
+              "type": "typography",
+              "isAlias": false,
+              "value": {
+                "fontSize": 20,
+                "fontFamily": "RijksSansVF",
+                "fontWeight": "SemiBold",
+                "lineHeight": 125,
+                "lineHeightUnit": "PERCENT",
+                "letterSpacing": 0,
+                "letterSpacingUnit": "PERCENT",
+                "textCase": "ORIGINAL",
+                "textDecoration": "NONE"
+              }
+            },
+            {
+              "name": "semantics/content/body/lg/bold-flat",
+              "type": "typography",
+              "isAlias": false,
+              "value": {
+                "fontSize": 20,
+                "fontFamily": "RijksSansVF",
+                "fontWeight": "SemiBold",
+                "lineHeight": 112.5,
+                "lineHeightUnit": "PERCENT",
+                "letterSpacing": 0,
+                "letterSpacingUnit": "PERCENT",
+                "textCase": "ORIGINAL",
+                "textDecoration": "NONE"
+              }
+            },
+            {
+              "name": "semantics/content/body/md/regular-loose",
               "type": "typography",
               "isAlias": false,
               "value": {
                 "fontSize": 18,
                 "fontFamily": "RijksSansVF",
                 "fontWeight": "Regular",
-                "lineHeight": 100,
+                "lineHeight": 175,
                 "lineHeightUnit": "PERCENT",
                 "letterSpacing": 0,
                 "letterSpacingUnit": "PERCENT",
@@ -2612,13 +5864,45 @@
               }
             },
             {
-              "name": "primitives/display/a",
+              "name": "semantics/content/body/md/regular-snug",
               "type": "typography",
               "isAlias": false,
               "value": {
-                "fontSize": 52,
+                "fontSize": 18,
                 "fontFamily": "RijksSansVF",
-                "fontWeight": 550,
+                "fontWeight": "Regular",
+                "lineHeight": 150,
+                "lineHeightUnit": "PERCENT",
+                "letterSpacing": 0,
+                "letterSpacingUnit": "PERCENT",
+                "textCase": "ORIGINAL",
+                "textDecoration": "NONE"
+              }
+            },
+            {
+              "name": "semantics/content/body/md/regular-tight",
+              "type": "typography",
+              "isAlias": false,
+              "value": {
+                "fontSize": 18,
+                "fontFamily": "RijksSansVF",
+                "fontWeight": "Regular",
+                "lineHeight": 125,
+                "lineHeightUnit": "PERCENT",
+                "letterSpacing": 0,
+                "letterSpacingUnit": "PERCENT",
+                "textCase": "ORIGINAL",
+                "textDecoration": "NONE"
+              }
+            },
+            {
+              "name": "semantics/content/body/md/regular-flat",
+              "type": "typography",
+              "isAlias": false,
+              "value": {
+                "fontSize": 18,
+                "fontFamily": "RijksSansVF",
+                "fontWeight": "Regular",
                 "lineHeight": 112.5,
                 "lineHeightUnit": "PERCENT",
                 "letterSpacing": 0,
@@ -2628,13 +5912,61 @@
               }
             },
             {
-              "name": "primitives/display/b",
+              "name": "semantics/content/body/md/bold-loose",
               "type": "typography",
               "isAlias": false,
               "value": {
-                "fontSize": 46,
+                "fontSize": 18,
                 "fontFamily": "RijksSansVF",
-                "fontWeight": 550,
+                "fontWeight": "SemiBold",
+                "lineHeight": 175,
+                "lineHeightUnit": "PERCENT",
+                "letterSpacing": 0,
+                "letterSpacingUnit": "PERCENT",
+                "textCase": "ORIGINAL",
+                "textDecoration": "NONE"
+              }
+            },
+            {
+              "name": "semantics/content/body/md/bold-snug",
+              "type": "typography",
+              "isAlias": false,
+              "value": {
+                "fontSize": 18,
+                "fontFamily": "RijksSansVF",
+                "fontWeight": "SemiBold",
+                "lineHeight": 150,
+                "lineHeightUnit": "PERCENT",
+                "letterSpacing": 0,
+                "letterSpacingUnit": "PERCENT",
+                "textCase": "ORIGINAL",
+                "textDecoration": "NONE"
+              }
+            },
+            {
+              "name": "semantics/content/body/md/bold-tight",
+              "type": "typography",
+              "isAlias": false,
+              "value": {
+                "fontSize": 18,
+                "fontFamily": "RijksSansVF",
+                "fontWeight": "SemiBold",
+                "lineHeight": 125,
+                "lineHeightUnit": "PERCENT",
+                "letterSpacing": 0,
+                "letterSpacingUnit": "PERCENT",
+                "textCase": "ORIGINAL",
+                "textDecoration": "NONE"
+              }
+            },
+            {
+              "name": "semantics/content/body/md/bold-flat",
+              "type": "typography",
+              "isAlias": false,
+              "value": {
+                "fontSize": 18,
+                "fontFamily": "RijksSansVF",
+                "fontWeight": "SemiBold",
                 "lineHeight": 112.5,
                 "lineHeightUnit": "PERCENT",
                 "letterSpacing": 0,
@@ -2644,13 +5976,61 @@
               }
             },
             {
-              "name": "primitives/display/c",
+              "name": "semantics/content/body/sm/regular-loose",
               "type": "typography",
               "isAlias": false,
               "value": {
-                "fontSize": 41,
+                "fontSize": 16,
                 "fontFamily": "RijksSansVF",
-                "fontWeight": 550,
+                "fontWeight": "Regular",
+                "lineHeight": 175,
+                "lineHeightUnit": "PERCENT",
+                "letterSpacing": 0,
+                "letterSpacingUnit": "PERCENT",
+                "textCase": "ORIGINAL",
+                "textDecoration": "NONE"
+              }
+            },
+            {
+              "name": "semantics/content/body/sm/regular-snug",
+              "type": "typography",
+              "isAlias": false,
+              "value": {
+                "fontSize": 16,
+                "fontFamily": "RijksSansVF",
+                "fontWeight": "Regular",
+                "lineHeight": 150,
+                "lineHeightUnit": "PERCENT",
+                "letterSpacing": 0,
+                "letterSpacingUnit": "PERCENT",
+                "textCase": "ORIGINAL",
+                "textDecoration": "NONE"
+              }
+            },
+            {
+              "name": "semantics/content/body/sm/regular-tight",
+              "type": "typography",
+              "isAlias": false,
+              "value": {
+                "fontSize": 16,
+                "fontFamily": "RijksSansVF",
+                "fontWeight": "Regular",
+                "lineHeight": 125,
+                "lineHeightUnit": "PERCENT",
+                "letterSpacing": 0,
+                "letterSpacingUnit": "PERCENT",
+                "textCase": "ORIGINAL",
+                "textDecoration": "NONE"
+              }
+            },
+            {
+              "name": "semantics/content/body/sm/regular-flat",
+              "type": "typography",
+              "isAlias": false,
+              "value": {
+                "fontSize": 16,
+                "fontFamily": "RijksSansVF",
+                "fontWeight": "Regular",
                 "lineHeight": 112.5,
                 "lineHeightUnit": "PERCENT",
                 "letterSpacing": 0,
@@ -2660,13 +6040,333 @@
               }
             },
             {
-              "name": "primitives/display/d",
+              "name": "semantics/content/body/sm/bold-loose",
+              "type": "typography",
+              "isAlias": false,
+              "value": {
+                "fontSize": 16,
+                "fontFamily": "RijksSansVF",
+                "fontWeight": "SemiBold",
+                "lineHeight": 175,
+                "lineHeightUnit": "PERCENT",
+                "letterSpacing": 0,
+                "letterSpacingUnit": "PERCENT",
+                "textCase": "ORIGINAL",
+                "textDecoration": "NONE"
+              }
+            },
+            {
+              "name": "semantics/content/body/sm/bold-snug",
+              "type": "typography",
+              "isAlias": false,
+              "value": {
+                "fontSize": 16,
+                "fontFamily": "RijksSansVF",
+                "fontWeight": "SemiBold",
+                "lineHeight": 150,
+                "lineHeightUnit": "PERCENT",
+                "letterSpacing": 0,
+                "letterSpacingUnit": "PERCENT",
+                "textCase": "ORIGINAL",
+                "textDecoration": "NONE"
+              }
+            },
+            {
+              "name": "semantics/content/body/sm/bold-tight",
+              "type": "typography",
+              "isAlias": false,
+              "value": {
+                "fontSize": 16,
+                "fontFamily": "RijksSansVF",
+                "fontWeight": "SemiBold",
+                "lineHeight": 125,
+                "lineHeightUnit": "PERCENT",
+                "letterSpacing": 0,
+                "letterSpacingUnit": "PERCENT",
+                "textCase": "ORIGINAL",
+                "textDecoration": "NONE"
+              }
+            },
+            {
+              "name": "semantics/content/body/sm/bold-flat",
+              "type": "typography",
+              "isAlias": false,
+              "value": {
+                "fontSize": 16,
+                "fontFamily": "RijksSansVF",
+                "fontWeight": "SemiBold",
+                "lineHeight": 112.5,
+                "lineHeightUnit": "PERCENT",
+                "letterSpacing": 0,
+                "letterSpacingUnit": "PERCENT",
+                "textCase": "ORIGINAL",
+                "textDecoration": "NONE"
+              }
+            },
+            {
+              "name": "semantics/content/body/xs/regular-loose",
+              "type": "typography",
+              "isAlias": false,
+              "value": {
+                "fontSize": 14,
+                "fontFamily": "RijksSansVF",
+                "fontWeight": "Regular",
+                "lineHeight": 175,
+                "lineHeightUnit": "PERCENT",
+                "letterSpacing": 0,
+                "letterSpacingUnit": "PERCENT",
+                "textCase": "ORIGINAL",
+                "textDecoration": "NONE"
+              }
+            },
+            {
+              "name": "semantics/content/body/xs/regular-snug",
+              "type": "typography",
+              "isAlias": false,
+              "value": {
+                "fontSize": 14,
+                "fontFamily": "RijksSansVF",
+                "fontWeight": "Regular",
+                "lineHeight": 150,
+                "lineHeightUnit": "PERCENT",
+                "letterSpacing": 0,
+                "letterSpacingUnit": "PERCENT",
+                "textCase": "ORIGINAL",
+                "textDecoration": "NONE"
+              }
+            },
+            {
+              "name": "semantics/content/body/xs/regular-tight",
+              "type": "typography",
+              "isAlias": false,
+              "value": {
+                "fontSize": 14,
+                "fontFamily": "RijksSansVF",
+                "fontWeight": "Regular",
+                "lineHeight": 125,
+                "lineHeightUnit": "PERCENT",
+                "letterSpacing": 0,
+                "letterSpacingUnit": "PERCENT",
+                "textCase": "ORIGINAL",
+                "textDecoration": "NONE"
+              }
+            },
+            {
+              "name": "semantics/content/body/xs/regular-flat",
+              "type": "typography",
+              "isAlias": false,
+              "value": {
+                "fontSize": 14,
+                "fontFamily": "RijksSansVF",
+                "fontWeight": "Regular",
+                "lineHeight": 112.5,
+                "lineHeightUnit": "PERCENT",
+                "letterSpacing": 0,
+                "letterSpacingUnit": "PERCENT",
+                "textCase": "ORIGINAL",
+                "textDecoration": "NONE"
+              }
+            },
+            {
+              "name": "semantics/content/body/xs/bold-loose",
+              "type": "typography",
+              "isAlias": false,
+              "value": {
+                "fontSize": 14,
+                "fontFamily": "RijksSansVF",
+                "fontWeight": "SemiBold",
+                "lineHeight": 175,
+                "lineHeightUnit": "PERCENT",
+                "letterSpacing": 0,
+                "letterSpacingUnit": "PERCENT",
+                "textCase": "ORIGINAL",
+                "textDecoration": "NONE"
+              }
+            },
+            {
+              "name": "semantics/content/body/xs/bold-snug",
+              "type": "typography",
+              "isAlias": false,
+              "value": {
+                "fontSize": 14,
+                "fontFamily": "RijksSansVF",
+                "fontWeight": "SemiBold",
+                "lineHeight": 150,
+                "lineHeightUnit": "PERCENT",
+                "letterSpacing": 0,
+                "letterSpacingUnit": "PERCENT",
+                "textCase": "ORIGINAL",
+                "textDecoration": "NONE"
+              }
+            },
+            {
+              "name": "semantics/content/body/xs/bold-tight",
+              "type": "typography",
+              "isAlias": false,
+              "value": {
+                "fontSize": 14,
+                "fontFamily": "RijksSansVF",
+                "fontWeight": "SemiBold",
+                "lineHeight": 125,
+                "lineHeightUnit": "PERCENT",
+                "letterSpacing": 0,
+                "letterSpacingUnit": "PERCENT",
+                "textCase": "ORIGINAL",
+                "textDecoration": "NONE"
+              }
+            },
+            {
+              "name": "semantics/content/body/xs/bold-flat",
+              "type": "typography",
+              "isAlias": false,
+              "value": {
+                "fontSize": 14,
+                "fontFamily": "RijksSansVF",
+                "fontWeight": "SemiBold",
+                "lineHeight": 112.5,
+                "lineHeightUnit": "PERCENT",
+                "letterSpacing": 0,
+                "letterSpacingUnit": "PERCENT",
+                "textCase": "ORIGINAL",
+                "textDecoration": "NONE"
+              }
+            },
+            {
+              "name": "semantics/content/body/xxs/bold-flat",
+              "type": "typography",
+              "isAlias": false,
+              "value": {
+                "fontSize": 12,
+                "fontFamily": "RijksSansVF",
+                "fontWeight": "SemiBold",
+                "lineHeight": 112.5,
+                "lineHeightUnit": "PERCENT",
+                "letterSpacing": 0,
+                "letterSpacingUnit": "PERCENT",
+                "textCase": "ORIGINAL",
+                "textDecoration": "NONE"
+              }
+            },
+            {
+              "name": "semantics/content/body/xxs/regular-loose",
+              "type": "typography",
+              "isAlias": false,
+              "value": {
+                "fontSize": 12,
+                "fontFamily": "RijksSansVF",
+                "fontWeight": "Regular",
+                "lineHeight": 175,
+                "lineHeightUnit": "PERCENT",
+                "letterSpacing": 0,
+                "letterSpacingUnit": "PERCENT",
+                "textCase": "ORIGINAL",
+                "textDecoration": "NONE"
+              }
+            },
+            {
+              "name": "semantics/content/body/xxs/regular-snug",
+              "type": "typography",
+              "isAlias": false,
+              "value": {
+                "fontSize": 12,
+                "fontFamily": "RijksSansVF",
+                "fontWeight": "Regular",
+                "lineHeight": 150,
+                "lineHeightUnit": "PERCENT",
+                "letterSpacing": 0,
+                "letterSpacingUnit": "PERCENT",
+                "textCase": "ORIGINAL",
+                "textDecoration": "NONE"
+              }
+            },
+            {
+              "name": "semantics/content/body/xxs/regular-tight",
+              "type": "typography",
+              "isAlias": false,
+              "value": {
+                "fontSize": 12,
+                "fontFamily": "RijksSansVF",
+                "fontWeight": "Regular",
+                "lineHeight": 125,
+                "lineHeightUnit": "PERCENT",
+                "letterSpacing": 0,
+                "letterSpacingUnit": "PERCENT",
+                "textCase": "ORIGINAL",
+                "textDecoration": "NONE"
+              }
+            },
+            {
+              "name": "semantics/content/body/xxs/regular-flat",
+              "type": "typography",
+              "isAlias": false,
+              "value": {
+                "fontSize": 12,
+                "fontFamily": "RijksSansVF",
+                "fontWeight": "Regular",
+                "lineHeight": 112.5,
+                "lineHeightUnit": "PERCENT",
+                "letterSpacing": 0,
+                "letterSpacingUnit": "PERCENT",
+                "textCase": "ORIGINAL",
+                "textDecoration": "NONE"
+              }
+            },
+            {
+              "name": "semantics/content/body/xxs/bold-loose",
+              "type": "typography",
+              "isAlias": false,
+              "value": {
+                "fontSize": 12,
+                "fontFamily": "RijksSansVF",
+                "fontWeight": "SemiBold",
+                "lineHeight": 175,
+                "lineHeightUnit": "PERCENT",
+                "letterSpacing": 0,
+                "letterSpacingUnit": "PERCENT",
+                "textCase": "ORIGINAL",
+                "textDecoration": "NONE"
+              }
+            },
+            {
+              "name": "semantics/content/body/xxs/bold-snug",
+              "type": "typography",
+              "isAlias": false,
+              "value": {
+                "fontSize": 12,
+                "fontFamily": "RijksSansVF",
+                "fontWeight": "SemiBold",
+                "lineHeight": 150,
+                "lineHeightUnit": "PERCENT",
+                "letterSpacing": 0,
+                "letterSpacingUnit": "PERCENT",
+                "textCase": "ORIGINAL",
+                "textDecoration": "NONE"
+              }
+            },
+            {
+              "name": "semantics/content/body/xxs/bold-tight",
+              "type": "typography",
+              "isAlias": false,
+              "value": {
+                "fontSize": 12,
+                "fontFamily": "RijksSansVF",
+                "fontWeight": "SemiBold",
+                "lineHeight": 125,
+                "lineHeightUnit": "PERCENT",
+                "letterSpacing": 0,
+                "letterSpacingUnit": "PERCENT",
+                "textCase": "ORIGINAL",
+                "textDecoration": "NONE"
+              }
+            },
+            {
+              "name": "semantics/content/sm/title-1",
               "type": "typography",
               "isAlias": false,
               "value": {
                 "fontSize": 36,
                 "fontFamily": "RijksSansVF",
-                "fontWeight": 550,
+                "fontWeight": "SemiBold",
                 "lineHeight": 112.5,
                 "lineHeightUnit": "PERCENT",
                 "letterSpacing": 0,
@@ -2676,29 +6376,13 @@
               }
             },
             {
-              "name": "primitives/display/e",
-              "type": "typography",
-              "isAlias": false,
-              "value": {
-                "fontSize": 32,
-                "fontFamily": "RijksSansVF",
-                "fontWeight": 550,
-                "lineHeight": 112.5,
-                "lineHeightUnit": "PERCENT",
-                "letterSpacing": 0,
-                "letterSpacingUnit": "PERCENT",
-                "textCase": "ORIGINAL",
-                "textDecoration": "NONE"
-              }
-            },
-            {
-              "name": "primitives/display/f",
+              "name": "semantics/content/sm/title-2",
               "type": "typography",
               "isAlias": false,
               "value": {
                 "fontSize": 29,
                 "fontFamily": "RijksSansVF",
-                "fontWeight": 550,
+                "fontWeight": "SemiBold",
                 "lineHeight": 112.5,
                 "lineHeightUnit": "PERCENT",
                 "letterSpacing": 0,
@@ -2708,13 +6392,13 @@
               }
             },
             {
-              "name": "primitives/display/g",
+              "name": "semantics/content/sm/title-3",
               "type": "typography",
               "isAlias": false,
               "value": {
                 "fontSize": 26,
                 "fontFamily": "RijksSansVF",
-                "fontWeight": 550,
+                "fontWeight": "SemiBold",
                 "lineHeight": 112.5,
                 "lineHeightUnit": "PERCENT",
                 "letterSpacing": 0,
@@ -2724,13 +6408,13 @@
               }
             },
             {
-              "name": "primitives/display/h",
+              "name": "semantics/content/sm/title-4",
               "type": "typography",
               "isAlias": false,
               "value": {
                 "fontSize": 23,
                 "fontFamily": "RijksSansVF",
-                "fontWeight": 550,
+                "fontWeight": "SemiBold",
                 "lineHeight": 112.5,
                 "lineHeightUnit": "PERCENT",
                 "letterSpacing": 0,
@@ -2740,93 +6424,13 @@
               }
             },
             {
-              "name": "primitives/display/i",
+              "name": "semantics/content/sm/title-5",
               "type": "typography",
               "isAlias": false,
               "value": {
                 "fontSize": 20,
                 "fontFamily": "RijksSansVF",
-                "fontWeight": 550,
-                "lineHeight": 125,
-                "lineHeightUnit": "PERCENT",
-                "letterSpacing": 0,
-                "letterSpacingUnit": "PERCENT",
-                "textCase": "ORIGINAL",
-                "textDecoration": "NONE"
-              }
-            },
-            {
-              "name": "primitives/display/j",
-              "type": "typography",
-              "isAlias": false,
-              "value": {
-                "fontSize": 18,
-                "fontFamily": "RijksSansVF",
-                "fontWeight": 550,
-                "lineHeight": 125,
-                "lineHeightUnit": "PERCENT",
-                "letterSpacing": 0,
-                "letterSpacingUnit": "PERCENT",
-                "textCase": "ORIGINAL",
-                "textDecoration": "NONE"
-              }
-            },
-            {
-              "name": "primitives/body/l/regular-loose",
-              "type": "typography",
-              "isAlias": false,
-              "value": {
-                "fontSize": 20,
-                "fontFamily": "RijksSansVF",
-                "fontWeight": "Regular",
-                "lineHeight": 175,
-                "lineHeightUnit": "PERCENT",
-                "letterSpacing": 0,
-                "letterSpacingUnit": "PERCENT",
-                "textCase": "ORIGINAL",
-                "textDecoration": "NONE"
-              }
-            },
-            {
-              "name": "primitives/body/l/regular-snug",
-              "type": "typography",
-              "isAlias": false,
-              "value": {
-                "fontSize": 20,
-                "fontFamily": "RijksSansVF",
-                "fontWeight": "Regular",
-                "lineHeight": 150,
-                "lineHeightUnit": "PERCENT",
-                "letterSpacing": 0,
-                "letterSpacingUnit": "PERCENT",
-                "textCase": "ORIGINAL",
-                "textDecoration": "NONE"
-              }
-            },
-            {
-              "name": "primitives/body/l/regular-tight",
-              "type": "typography",
-              "isAlias": false,
-              "value": {
-                "fontSize": 20,
-                "fontFamily": "RijksSansVF",
-                "fontWeight": "Regular",
-                "lineHeight": 125,
-                "lineHeightUnit": "PERCENT",
-                "letterSpacing": 0,
-                "letterSpacingUnit": "PERCENT",
-                "textCase": "ORIGINAL",
-                "textDecoration": "NONE"
-              }
-            },
-            {
-              "name": "primitives/body/l/regular-flat",
-              "type": "typography",
-              "isAlias": false,
-              "value": {
-                "fontSize": 20,
-                "fontFamily": "RijksSansVF",
-                "fontWeight": "Regular",
+                "fontWeight": "SemiBold",
                 "lineHeight": 112.5,
                 "lineHeightUnit": "PERCENT",
                 "letterSpacing": 0,
@@ -2836,61 +6440,13 @@
               }
             },
             {
-              "name": "primitives/body/l/bold-loose",
+              "name": "semantics/content/sm/title-6",
               "type": "typography",
               "isAlias": false,
               "value": {
-                "fontSize": 20,
+                "fontSize": 18,
                 "fontFamily": "RijksSansVF",
-                "fontWeight": "Bold",
-                "lineHeight": 175,
-                "lineHeightUnit": "PERCENT",
-                "letterSpacing": 0,
-                "letterSpacingUnit": "PERCENT",
-                "textCase": "ORIGINAL",
-                "textDecoration": "NONE"
-              }
-            },
-            {
-              "name": "primitives/body/l/bold-snug",
-              "type": "typography",
-              "isAlias": false,
-              "value": {
-                "fontSize": 20,
-                "fontFamily": "RijksSansVF",
-                "fontWeight": "Bold",
-                "lineHeight": 150,
-                "lineHeightUnit": "PERCENT",
-                "letterSpacing": 0,
-                "letterSpacingUnit": "PERCENT",
-                "textCase": "ORIGINAL",
-                "textDecoration": "NONE"
-              }
-            },
-            {
-              "name": "primitives/body/l/bold-tight",
-              "type": "typography",
-              "isAlias": false,
-              "value": {
-                "fontSize": 20,
-                "fontFamily": "RijksSansVF",
-                "fontWeight": "Bold",
-                "lineHeight": 125,
-                "lineHeightUnit": "PERCENT",
-                "letterSpacing": 0,
-                "letterSpacingUnit": "PERCENT",
-                "textCase": "ORIGINAL",
-                "textDecoration": "NONE"
-              }
-            },
-            {
-              "name": "primitives/body/l/bold-flat",
-              "type": "typography",
-              "isAlias": false,
-              "value": {
-                "fontSize": 20,
-                "fontFamily": "RijksSansVF",
-                "fontWeight": "Bold",
+                "fontWeight": "SemiBold",
                 "lineHeight": 112.5,
                 "lineHeightUnit": "PERCENT",
                 "letterSpacing": 0,
@@ -2900,61 +6456,13 @@
               }
             },
             {
-              "name": "primitives/body/m/regular-loose",
+              "name": "semantics/content/md/title-1",
               "type": "typography",
               "isAlias": false,
               "value": {
-                "fontSize": 18,
+                "fontSize": 41,
                 "fontFamily": "RijksSansVF",
-                "fontWeight": "Regular",
-                "lineHeight": 175,
-                "lineHeightUnit": "PERCENT",
-                "letterSpacing": 0,
-                "letterSpacingUnit": "PERCENT",
-                "textCase": "ORIGINAL",
-                "textDecoration": "NONE"
-              }
-            },
-            {
-              "name": "primitives/body/m/regular-snug",
-              "type": "typography",
-              "isAlias": false,
-              "value": {
-                "fontSize": 18,
-                "fontFamily": "RijksSansVF",
-                "fontWeight": "Regular",
-                "lineHeight": 150,
-                "lineHeightUnit": "PERCENT",
-                "letterSpacing": 0,
-                "letterSpacingUnit": "PERCENT",
-                "textCase": "ORIGINAL",
-                "textDecoration": "NONE"
-              }
-            },
-            {
-              "name": "primitives/body/m/regular-tight",
-              "type": "typography",
-              "isAlias": false,
-              "value": {
-                "fontSize": 18,
-                "fontFamily": "RijksSansVF",
-                "fontWeight": "Regular",
-                "lineHeight": 125,
-                "lineHeightUnit": "PERCENT",
-                "letterSpacing": 0,
-                "letterSpacingUnit": "PERCENT",
-                "textCase": "ORIGINAL",
-                "textDecoration": "NONE"
-              }
-            },
-            {
-              "name": "primitives/body/m/regular-flat",
-              "type": "typography",
-              "isAlias": false,
-              "value": {
-                "fontSize": 18,
-                "fontFamily": "RijksSansVF",
-                "fontWeight": "Regular",
+                "fontWeight": "SemiBold",
                 "lineHeight": 112.5,
                 "lineHeightUnit": "PERCENT",
                 "letterSpacing": 0,
@@ -2964,61 +6472,13 @@
               }
             },
             {
-              "name": "primitives/body/m/bold-loose",
+              "name": "semantics/content/md/title-2",
               "type": "typography",
               "isAlias": false,
               "value": {
-                "fontSize": 18,
+                "fontSize": 32,
                 "fontFamily": "RijksSansVF",
-                "fontWeight": "Bold",
-                "lineHeight": 175,
-                "lineHeightUnit": "PERCENT",
-                "letterSpacing": 0,
-                "letterSpacingUnit": "PERCENT",
-                "textCase": "ORIGINAL",
-                "textDecoration": "NONE"
-              }
-            },
-            {
-              "name": "primitives/body/m/bold-snug",
-              "type": "typography",
-              "isAlias": false,
-              "value": {
-                "fontSize": 18,
-                "fontFamily": "RijksSansVF",
-                "fontWeight": "Bold",
-                "lineHeight": 150,
-                "lineHeightUnit": "PERCENT",
-                "letterSpacing": 0,
-                "letterSpacingUnit": "PERCENT",
-                "textCase": "ORIGINAL",
-                "textDecoration": "NONE"
-              }
-            },
-            {
-              "name": "primitives/body/m/bold-tight",
-              "type": "typography",
-              "isAlias": false,
-              "value": {
-                "fontSize": 18,
-                "fontFamily": "RijksSansVF",
-                "fontWeight": "Bold",
-                "lineHeight": 125,
-                "lineHeightUnit": "PERCENT",
-                "letterSpacing": 0,
-                "letterSpacingUnit": "PERCENT",
-                "textCase": "ORIGINAL",
-                "textDecoration": "NONE"
-              }
-            },
-            {
-              "name": "primitives/body/m/bold-flat",
-              "type": "typography",
-              "isAlias": false,
-              "value": {
-                "fontSize": 18,
-                "fontFamily": "RijksSansVF",
-                "fontWeight": "Bold",
+                "fontWeight": "SemiBold",
                 "lineHeight": 112.5,
                 "lineHeightUnit": "PERCENT",
                 "letterSpacing": 0,
@@ -3028,14 +6488,222 @@
               }
             },
             {
-              "name": "primitives/body/s/regular-loose",
+              "name": "semantics/content/md/title-3",
+              "type": "typography",
+              "isAlias": false,
+              "value": {
+                "fontSize": 26,
+                "fontFamily": "RijksSansVF",
+                "fontWeight": "SemiBold",
+                "lineHeight": 112.5,
+                "lineHeightUnit": "PERCENT",
+                "letterSpacing": 0,
+                "letterSpacingUnit": "PERCENT",
+                "textCase": "ORIGINAL",
+                "textDecoration": "NONE"
+              }
+            },
+            {
+              "name": "semantics/content/md/title-4",
+              "type": "typography",
+              "isAlias": false,
+              "value": {
+                "fontSize": 23,
+                "fontFamily": "RijksSansVF",
+                "fontWeight": "SemiBold",
+                "lineHeight": 112.5,
+                "lineHeightUnit": "PERCENT",
+                "letterSpacing": 0,
+                "letterSpacingUnit": "PERCENT",
+                "textCase": "ORIGINAL",
+                "textDecoration": "NONE"
+              }
+            },
+            {
+              "name": "semantics/content/md/title-5",
+              "type": "typography",
+              "isAlias": false,
+              "value": {
+                "fontSize": 20,
+                "fontFamily": "RijksSansVF",
+                "fontWeight": "SemiBold",
+                "lineHeight": 112.5,
+                "lineHeightUnit": "PERCENT",
+                "letterSpacing": 0,
+                "letterSpacingUnit": "PERCENT",
+                "textCase": "ORIGINAL",
+                "textDecoration": "NONE"
+              }
+            },
+            {
+              "name": "semantics/content/md/title-6",
+              "type": "typography",
+              "isAlias": false,
+              "value": {
+                "fontSize": 18,
+                "fontFamily": "RijksSansVF",
+                "fontWeight": "SemiBold",
+                "lineHeight": 112.5,
+                "lineHeightUnit": "PERCENT",
+                "letterSpacing": 0,
+                "letterSpacingUnit": "PERCENT",
+                "textCase": "ORIGINAL",
+                "textDecoration": "NONE"
+              }
+            },
+            {
+              "name": "semantics/content/lg/title-1",
+              "type": "typography",
+              "isAlias": false,
+              "value": {
+                "fontSize": 52,
+                "fontFamily": "RijksSansVF",
+                "fontWeight": "SemiBold",
+                "lineHeight": 112.5,
+                "lineHeightUnit": "PERCENT",
+                "letterSpacing": 0,
+                "letterSpacingUnit": "PERCENT",
+                "textCase": "ORIGINAL",
+                "textDecoration": "NONE"
+              }
+            },
+            {
+              "name": "semantics/content/lg/title-2",
+              "type": "typography",
+              "isAlias": false,
+              "value": {
+                "fontSize": 41,
+                "fontFamily": "RijksSansVF",
+                "fontWeight": "SemiBold",
+                "lineHeight": 112.5,
+                "lineHeightUnit": "PERCENT",
+                "letterSpacing": 0,
+                "letterSpacingUnit": "PERCENT",
+                "textCase": "ORIGINAL",
+                "textDecoration": "NONE"
+              }
+            },
+            {
+              "name": "semantics/content/lg/title-3",
+              "type": "typography",
+              "isAlias": false,
+              "value": {
+                "fontSize": 32,
+                "fontFamily": "RijksSansVF",
+                "fontWeight": "SemiBold",
+                "lineHeight": 112.5,
+                "lineHeightUnit": "PERCENT",
+                "letterSpacing": 0,
+                "letterSpacingUnit": "PERCENT",
+                "textCase": "ORIGINAL",
+                "textDecoration": "NONE"
+              }
+            },
+            {
+              "name": "semantics/content/lg/title-4",
+              "type": "typography",
+              "isAlias": false,
+              "value": {
+                "fontSize": 26,
+                "fontFamily": "RijksSansVF",
+                "fontWeight": "SemiBold",
+                "lineHeight": 112.5,
+                "lineHeightUnit": "PERCENT",
+                "letterSpacing": 0,
+                "letterSpacingUnit": "PERCENT",
+                "textCase": "ORIGINAL",
+                "textDecoration": "NONE"
+              }
+            },
+            {
+              "name": "semantics/content/lg/title-5",
+              "type": "typography",
+              "isAlias": false,
+              "value": {
+                "fontSize": 20,
+                "fontFamily": "RijksSansVF",
+                "fontWeight": "SemiBold",
+                "lineHeight": 112.5,
+                "lineHeightUnit": "PERCENT",
+                "letterSpacing": 0,
+                "letterSpacingUnit": "PERCENT",
+                "textCase": "ORIGINAL",
+                "textDecoration": "NONE"
+              }
+            },
+            {
+              "name": "semantics/content/lg/title-6",
+              "type": "typography",
+              "isAlias": false,
+              "value": {
+                "fontSize": 18,
+                "fontFamily": "RijksSansVF",
+                "fontWeight": "SemiBold",
+                "lineHeight": 112.5,
+                "lineHeightUnit": "PERCENT",
+                "letterSpacing": 0,
+                "letterSpacingUnit": "PERCENT",
+                "textCase": "ORIGINAL",
+                "textDecoration": "NONE"
+              }
+            },
+            {
+              "name": "semantics/buttons/xs/font",
+              "type": "typography",
+              "isAlias": false,
+              "value": {
+                "fontSize": 14,
+                "fontFamily": "RijksSansVF",
+                "fontWeight": "SemiBold",
+                "lineHeight": 112.5,
+                "lineHeightUnit": "PERCENT",
+                "letterSpacing": 0,
+                "letterSpacingUnit": "PERCENT",
+                "textCase": "ORIGINAL",
+                "textDecoration": "NONE"
+              }
+            },
+            {
+              "name": "semantics/buttons/sm/font",
+              "type": "typography",
+              "isAlias": false,
+              "value": {
+                "fontSize": 16,
+                "fontFamily": "RijksSansVF",
+                "fontWeight": "SemiBold",
+                "lineHeight": 112.5,
+                "lineHeightUnit": "PERCENT",
+                "letterSpacing": 0,
+                "letterSpacingUnit": "PERCENT",
+                "textCase": "ORIGINAL",
+                "textDecoration": "NONE"
+              }
+            },
+            {
+              "name": "semantics/buttons/md/font",
+              "type": "typography",
+              "isAlias": false,
+              "value": {
+                "fontSize": 18,
+                "fontFamily": "RijksSansVF",
+                "fontWeight": "SemiBold",
+                "lineHeight": 112.5,
+                "lineHeightUnit": "PERCENT",
+                "letterSpacing": 0,
+                "letterSpacingUnit": "PERCENT",
+                "textCase": "ORIGINAL",
+                "textDecoration": "NONE"
+              }
+            },
+            {
+              "name": "semantics/input-fields/sm/text",
               "type": "typography",
               "isAlias": false,
               "value": {
                 "fontSize": 16,
                 "fontFamily": "RijksSansVF",
                 "fontWeight": "Regular",
-                "lineHeight": 175,
+                "lineHeight": 100,
                 "lineHeightUnit": "PERCENT",
                 "letterSpacing": 0,
                 "letterSpacingUnit": "PERCENT",
@@ -3044,14 +6712,30 @@
               }
             },
             {
-              "name": "primitives/body/s/regular-snug",
+              "name": "semantics/input-fields/sm/mask",
               "type": "typography",
               "isAlias": false,
               "value": {
                 "fontSize": 16,
+                "fontFamily": "Verdana",
+                "fontWeight": "Regular",
+                "lineHeight": 100,
+                "lineHeightUnit": "PERCENT",
+                "letterSpacing": 0,
+                "letterSpacingUnit": "PERCENT",
+                "textCase": "ORIGINAL",
+                "textDecoration": "NONE"
+              }
+            },
+            {
+              "name": "semantics/input-fields/md/text",
+              "type": "typography",
+              "isAlias": false,
+              "value": {
+                "fontSize": 18,
                 "fontFamily": "RijksSansVF",
                 "fontWeight": "Regular",
-                "lineHeight": 150,
+                "lineHeight": 100,
                 "lineHeightUnit": "PERCENT",
                 "letterSpacing": 0,
                 "letterSpacingUnit": "PERCENT",
@@ -3060,222 +6744,14 @@
               }
             },
             {
-              "name": "primitives/body/s/regular-tight",
+              "name": "semantics/input-fields/md/mask",
               "type": "typography",
               "isAlias": false,
               "value": {
-                "fontSize": 16,
-                "fontFamily": "RijksSansVF",
+                "fontSize": 18,
+                "fontFamily": "Verdana",
                 "fontWeight": "Regular",
-                "lineHeight": 125,
-                "lineHeightUnit": "PERCENT",
-                "letterSpacing": 0,
-                "letterSpacingUnit": "PERCENT",
-                "textCase": "ORIGINAL",
-                "textDecoration": "NONE"
-              }
-            },
-            {
-              "name": "primitives/body/s/regular-flat",
-              "type": "typography",
-              "isAlias": false,
-              "value": {
-                "fontSize": 16,
-                "fontFamily": "RijksSansVF",
-                "fontWeight": "Regular",
-                "lineHeight": 112.5,
-                "lineHeightUnit": "PERCENT",
-                "letterSpacing": 0,
-                "letterSpacingUnit": "PERCENT",
-                "textCase": "ORIGINAL",
-                "textDecoration": "NONE"
-              }
-            },
-            {
-              "name": "primitives/body/s/bold-loose",
-              "type": "typography",
-              "isAlias": false,
-              "value": {
-                "fontSize": 16,
-                "fontFamily": "RijksSansVF",
-                "fontWeight": "Bold",
-                "lineHeight": 175,
-                "lineHeightUnit": "PERCENT",
-                "letterSpacing": 0,
-                "letterSpacingUnit": "PERCENT",
-                "textCase": "ORIGINAL",
-                "textDecoration": "NONE"
-              }
-            },
-            {
-              "name": "primitives/body/s/bold-snug",
-              "type": "typography",
-              "isAlias": false,
-              "value": {
-                "fontSize": 16,
-                "fontFamily": "RijksSansVF",
-                "fontWeight": "Bold",
-                "lineHeight": 150,
-                "lineHeightUnit": "PERCENT",
-                "letterSpacing": 0,
-                "letterSpacingUnit": "PERCENT",
-                "textCase": "ORIGINAL",
-                "textDecoration": "NONE"
-              }
-            },
-            {
-              "name": "primitives/body/s/bold-tight",
-              "type": "typography",
-              "isAlias": false,
-              "value": {
-                "fontSize": 16,
-                "fontFamily": "RijksSansVF",
-                "fontWeight": "Bold",
-                "lineHeight": 125,
-                "lineHeightUnit": "PERCENT",
-                "letterSpacing": 0,
-                "letterSpacingUnit": "PERCENT",
-                "textCase": "ORIGINAL",
-                "textDecoration": "NONE"
-              }
-            },
-            {
-              "name": "primitives/body/s/bold-flat",
-              "type": "typography",
-              "isAlias": false,
-              "value": {
-                "fontSize": 16,
-                "fontFamily": "RijksSansVF",
-                "fontWeight": "Bold",
-                "lineHeight": 112.5,
-                "lineHeightUnit": "PERCENT",
-                "letterSpacing": 0,
-                "letterSpacingUnit": "PERCENT",
-                "textCase": "ORIGINAL",
-                "textDecoration": "NONE"
-              }
-            },
-            {
-              "name": "primitives/body/xs/regular-loose",
-              "type": "typography",
-              "isAlias": false,
-              "value": {
-                "fontSize": 14,
-                "fontFamily": "RijksSansVF",
-                "fontWeight": "Regular",
-                "lineHeight": 175,
-                "lineHeightUnit": "PERCENT",
-                "letterSpacing": 0,
-                "letterSpacingUnit": "PERCENT",
-                "textCase": "ORIGINAL",
-                "textDecoration": "NONE"
-              }
-            },
-            {
-              "name": "primitives/body/xs/regular-snug",
-              "type": "typography",
-              "isAlias": false,
-              "value": {
-                "fontSize": 14,
-                "fontFamily": "RijksSansVF",
-                "fontWeight": "Regular",
-                "lineHeight": 150,
-                "lineHeightUnit": "PERCENT",
-                "letterSpacing": 0,
-                "letterSpacingUnit": "PERCENT",
-                "textCase": "ORIGINAL",
-                "textDecoration": "NONE"
-              }
-            },
-            {
-              "name": "primitives/body/xs/regular-tight",
-              "type": "typography",
-              "isAlias": false,
-              "value": {
-                "fontSize": 14,
-                "fontFamily": "RijksSansVF",
-                "fontWeight": "Regular",
-                "lineHeight": 125,
-                "lineHeightUnit": "PERCENT",
-                "letterSpacing": 0,
-                "letterSpacingUnit": "PERCENT",
-                "textCase": "ORIGINAL",
-                "textDecoration": "NONE"
-              }
-            },
-            {
-              "name": "primitives/body/xs/regular-flat",
-              "type": "typography",
-              "isAlias": false,
-              "value": {
-                "fontSize": 14,
-                "fontFamily": "RijksSansVF",
-                "fontWeight": "Regular",
-                "lineHeight": 112.5,
-                "lineHeightUnit": "PERCENT",
-                "letterSpacing": 0,
-                "letterSpacingUnit": "PERCENT",
-                "textCase": "ORIGINAL",
-                "textDecoration": "NONE"
-              }
-            },
-            {
-              "name": "primitives/body/xs/bold-loose",
-              "type": "typography",
-              "isAlias": false,
-              "value": {
-                "fontSize": 14,
-                "fontFamily": "RijksSansVF",
-                "fontWeight": "Bold",
-                "lineHeight": 175,
-                "lineHeightUnit": "PERCENT",
-                "letterSpacing": 0,
-                "letterSpacingUnit": "PERCENT",
-                "textCase": "ORIGINAL",
-                "textDecoration": "NONE"
-              }
-            },
-            {
-              "name": "primitives/body/xs/bold-snug",
-              "type": "typography",
-              "isAlias": false,
-              "value": {
-                "fontSize": 14,
-                "fontFamily": "RijksSansVF",
-                "fontWeight": "Bold",
-                "lineHeight": 150,
-                "lineHeightUnit": "PERCENT",
-                "letterSpacing": 0,
-                "letterSpacingUnit": "PERCENT",
-                "textCase": "ORIGINAL",
-                "textDecoration": "NONE"
-              }
-            },
-            {
-              "name": "primitives/body/xs/bold-tight",
-              "type": "typography",
-              "isAlias": false,
-              "value": {
-                "fontSize": 14,
-                "fontFamily": "RijksSansVF",
-                "fontWeight": "Bold",
-                "lineHeight": 125,
-                "lineHeightUnit": "PERCENT",
-                "letterSpacing": 0,
-                "letterSpacingUnit": "PERCENT",
-                "textCase": "ORIGINAL",
-                "textDecoration": "NONE"
-              }
-            },
-            {
-              "name": "primitives/body/xs/bold-flat",
-              "type": "typography",
-              "isAlias": false,
-              "value": {
-                "fontSize": 14,
-                "fontFamily": "RijksSansVF",
-                "fontWeight": "Bold",
-                "lineHeight": 112.5,
+                "lineHeight": 100,
                 "lineHeightUnit": "PERCENT",
                 "letterSpacing": 0,
                 "letterSpacingUnit": "PERCENT",


### PR DESCRIPTION
## Summary

- Migrate design tokens to new Figma naming convention (s→sm, m→md, l→lg)
- Update focus ring tokens (focus-ring → focus-rings-center)
- Update divider tokens (divider → dividers)
- Update button font tokens (components/button → semantics/buttons)
- Fix toggle button horizontal padding to match Figma spacer gaps
- Remove non-existent accent-tinted variant from button FigmaComparison

## Screenshots

### Button

| Side-by-Side | Overlay |
|--------------|---------|
| ![side-by-side](https://0x0.st/PbTO.png) | ![overlay](https://0x0.st/PbTV.png) |

---

### Toggle Button

| Side-by-Side | Overlay |
|--------------|---------|
| ![side-by-side](https://0x0.st/PbTU.png) | ![overlay](https://0x0.st/PbT0.png) |

---

### Checkbox

| Side-by-Side | Overlay |
|--------------|---------|
| ![side-by-side](https://0x0.st/PbTG.png) | ![overlay](https://0x0.st/PbTD.png) |

---

### Icon Button

| Side-by-Side | Overlay |
|--------------|---------|
| ![side-by-side](https://0x0.st/PbTk.png) | ![overlay](https://0x0.st/PbTd.png) |

---

### Switch

| Side-by-Side | Overlay |
|--------------|---------|
| ![side-by-side](https://0x0.st/PbTn.png) | ![overlay](https://0x0.st/PbT5.png) |

---

### Radio

| Side-by-Side | Overlay |
|--------------|---------|
| ![side-by-side](https://0x0.st/PbTR.png) | ![overlay](https://0x0.st/PbT7.png) |

---

### Menu Bar

| Side-by-Side | Overlay |
|--------------|---------|
| ![side-by-side](https://0x0.st/PbTh.png) | ![overlay](https://0x0.st/Pbc6.png) |

---

## How to Verify

1. Check the Side-by-Side screenshots to see Code (bottom) vs Figma (top)
2. Check the Overlay screenshots (at 50% opacity) to see any pixel differences
3. Minor differences in anti-aliasing are expected

## Test plan

- [x] Token build succeeds (`npm run build:tokens`)
- [x] Token validation passes (`npm run validate:tokens`)
- [x] Storybook loads all components
- [x] FigmaComparison screenshots match design