### PR TITLE
ci: add token validation to all PRs

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,28 @@
+name: Validate
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  validate:
+    name: Validate CSS Variables
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Validate CSS variables
+        run: npm run validate:tokens


### PR DESCRIPTION
## Summary
- Adds `validate.yml` workflow that runs `npm run validate:tokens` on all PRs
- Previously validation only ran when token files changed, not when components changed
- This will catch components referencing non-existent tokens

## Expected Result
This PR should **fail CI** - there are 132 token references in components using the old naming convention (e.g., `sm` instead of `s`, `md` instead of `m`).

This proves the validation is working. A follow-up PR will fix all the token references.