### PR TITLE
fix: simplify font-family variable and fix checkbox BEM naming

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -224,7 +224,6 @@ min-height: var(--semantics-controls-m-min-size);
 
 **Uitzonderingen (behoud fallbacks):**
 - Override hooks: `var(--rr-button-background-color, var(--_bg-color))`
-- Font-family: `var(--rr-font-family-sans, 'RijksSansVF', system-ui, sans-serif)`
 
 CI faalt als tokens ontbreken. Dit dwingt af dat alle tokens gedefinieerd zijn in `dist/css/tokens.css`.
 

--- a/src/components/box/rr-box.js
+++ b/src/components/box/rr-box.js
@@ -55,7 +55,7 @@ export class RRBox extends RRBaseComponent {
     return `
       :host {
         display: block;
-        font-family: var(--rr-font-family-sans, 'RijksoverheidSans', system-ui, sans-serif);
+        font-family: var(--rr-font-family-sans);
       }
 
       :host([hidden]) {

--- a/src/components/box/rr-box.ts
+++ b/src/components/box/rr-box.ts
@@ -23,7 +23,7 @@ export class RRBox extends LitElement {
   static override styles = css`
     :host {
       display: block;
-      font-family: var(--rr-font-family-sans, 'RijksSansVF', system-ui, sans-serif);
+      font-family: var(--rr-font-family-sans);
     }
 
     :host([hidden]) {

--- a/src/components/button/rr-button.ts
+++ b/src/components/button/rr-button.ts
@@ -36,7 +36,7 @@ export class RRButton extends LitElement {
   static override styles = css`
     :host {
       display: inline-block;
-      font-family: var(--rr-font-family-sans, 'RijksSansVF', system-ui, sans-serif);
+      font-family: var(--rr-font-family-sans);
     }
 
     :host([hidden]) {

--- a/src/components/checkbox/rr-checkbox.ts
+++ b/src/components/checkbox/rr-checkbox.ts
@@ -25,7 +25,7 @@ export class RRCheckbox extends LitElement {
   static override styles = css`
     :host {
       display: inline-block;
-      font-family: var(--rr-font-family-sans, 'RijksSansVF', system-ui, sans-serif);
+      font-family: var(--rr-font-family-sans);
       cursor: pointer;
       user-select: none;
       -webkit-user-select: none;
@@ -46,7 +46,7 @@ export class RRCheckbox extends LitElement {
       justify-content: center;
     }
 
-    .box {
+    .checkbox__box {
       position: relative;
       display: inline-flex;
       align-items: center;
@@ -68,7 +68,7 @@ export class RRCheckbox extends LitElement {
     }
 
     /* Checkmark icon */
-    .icon {
+    .checkbox__icon {
       display: none;
       width: 14px;
       height: 14px;
@@ -76,43 +76,43 @@ export class RRCheckbox extends LitElement {
     }
 
     /* Checkbox is always 24x24px per Figma specs */
-    .box {
+    .checkbox__box {
       width: var(--semantics-controls-xs-min-size);
       height: var(--semantics-controls-xs-min-size);
       border-radius: var(--semantics-controls-xs-corner-radius);
     }
 
     /* Checked state */
-    :host([checked]) .box {
+    :host([checked]) .checkbox__box {
       --_bg-color: var(--components-checkbox-is-selected-background-color);
       --_border-color: var(--components-checkbox-is-selected-background-color);
     }
 
-    :host([checked]) .icon--check {
+    :host([checked]) .checkbox__icon--check {
       display: block;
     }
 
     /* Indeterminate state - takes precedence over checked */
-    :host([indeterminate]) .box {
+    :host([indeterminate]) .checkbox__box {
       --_bg-color: var(--components-checkbox-is-selected-background-color);
       --_border-color: var(--components-checkbox-is-selected-background-color);
     }
 
-    :host([indeterminate]) .icon--indeterminate {
+    :host([indeterminate]) .checkbox__icon--indeterminate {
       display: block;
     }
 
-    :host([indeterminate]) .icon--check {
+    :host([indeterminate]) .checkbox__icon--check {
       display: none;
     }
 
     /* Hover state */
-    :host(:hover:not([disabled])) .box {
+    :host(:hover:not([disabled])) .checkbox__box {
       --_border-color: var(--primitives-color-accent-75);
     }
 
-    :host([checked]:hover:not([disabled])) .box,
-    :host([indeterminate]:hover:not([disabled])) .box {
+    :host([checked]:hover:not([disabled])) .checkbox__box,
+    :host([indeterminate]:hover:not([disabled])) .checkbox__box {
       --_bg-color: var(--primitives-color-accent-75);
       --_border-color: var(--primitives-color-accent-75);
     }
@@ -122,7 +122,7 @@ export class RRCheckbox extends LitElement {
       outline: none;
     }
 
-    :host(:focus-visible) .box {
+    :host(:focus-visible) .checkbox__box {
       outline: var(--semantics-focus-rings-center-thickness) solid var(--semantics-focus-rings-center-color);
       outline-offset: 2px;
     }
@@ -135,23 +135,23 @@ export class RRCheckbox extends LitElement {
 
     /* Accessibility: Reduced motion */
     @media (prefers-reduced-motion: reduce) {
-      .box {
+      .checkbox__box {
         transition: none;
       }
     }
 
     /* Accessibility: High Contrast Mode */
     @media (forced-colors: active) {
-      .box {
+      .checkbox__box {
         outline: 2px solid CanvasText !important;
       }
 
-      :host([checked]) .box,
-      :host([indeterminate]) .box {
+      :host([checked]) .checkbox__box,
+      :host([indeterminate]) .checkbox__box {
         background-color: Highlight !important;
       }
 
-      :host(:focus-visible) .box {
+      :host(:focus-visible) .checkbox__box {
         outline: 2px solid CanvasText !important;
         outline-offset: 2px !important;
       }
@@ -251,7 +251,7 @@ export class RRCheckbox extends LitElement {
 
   private _renderCheckIcon() {
     return svg`
-      <svg class="icon icon--check" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+      <svg class="checkbox__icon checkbox__icon--check" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
         <polyline points="20 6 9 17 4 12"></polyline>
       </svg>
     `;
@@ -259,7 +259,7 @@ export class RRCheckbox extends LitElement {
 
   private _renderIndeterminateIcon() {
     return svg`
-      <svg class="icon icon--indeterminate" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round">
+      <svg class="checkbox__icon checkbox__icon--indeterminate" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round">
         <line x1="6" y1="12" x2="18" y2="12"></line>
       </svg>
     `;
@@ -268,7 +268,7 @@ export class RRCheckbox extends LitElement {
   override render() {
     return html`
       <div class="checkbox" part="checkbox">
-        <div class="box" part="box">${this._renderCheckIcon()} ${this._renderIndeterminateIcon()}</div>
+        <div class="checkbox__box" part="box">${this._renderCheckIcon()} ${this._renderIndeterminateIcon()}</div>
       </div>
     `;
   }

--- a/src/components/icon-button/rr-icon-button.js
+++ b/src/components/icon-button/rr-icon-button.js
@@ -106,7 +106,7 @@ export class RRIconButton extends RRBaseComponent {
     return `
       :host {
         display: inline-block;
-        font-family: var(--rr-font-family-sans, 'RijksoverheidSans', system-ui, sans-serif);
+        font-family: var(--rr-font-family-sans);
       }
 
       :host([hidden]) {

--- a/src/components/icon-button/rr-icon-button.ts
+++ b/src/components/icon-button/rr-icon-button.ts
@@ -31,7 +31,7 @@ export class RRIconButton extends LitElement {
   static override styles = css`
     :host {
       display: inline-block;
-      font-family: var(--rr-font-family-sans, 'RijksSansVF', system-ui, sans-serif);
+      font-family: var(--rr-font-family-sans);
     }
 
     :host([hidden]) {

--- a/src/components/label-cell/rr-label-cell.ts
+++ b/src/components/label-cell/rr-label-cell.ts
@@ -26,7 +26,7 @@ export class RRLabelCell extends LitElement {
       flex-direction: column;
       justify-content: center; /* Match Figma's label-cell__inner justifyContent: center */
       height: 100%; /* Fill container height so centering works */
-      font-family: var(--rr-font-family-sans, 'RijksoverheidSans', system-ui, sans-serif);
+      font-family: var(--rr-font-family-sans);
     }
 
     :host([hidden]) {

--- a/src/components/menu-bar/rr-menu-bar.js
+++ b/src/components/menu-bar/rr-menu-bar.js
@@ -410,7 +410,7 @@ export class RRMenuBar extends RRBaseComponent {
     return `
       :host {
         display: block;
-        font-family: var(--rr-font-family-sans, 'RijksoverheidSans', system-ui, sans-serif);
+        font-family: var(--rr-font-family-sans);
         width: 100%;
         min-width: 0; /* Allow shrinking */
       }

--- a/src/components/menu-bar/rr-menu-bar.ts
+++ b/src/components/menu-bar/rr-menu-bar.ts
@@ -36,7 +36,7 @@ export class RRMenuBar extends LitElement {
   static override styles = css`
     :host {
       display: block;
-      font-family: var(--rr-font-family-sans, 'RijksSansVF', system-ui, sans-serif);
+      font-family: var(--rr-font-family-sans);
       width: 100%;
       min-width: 0; /* Allow shrinking */
     }

--- a/src/components/menu-bar/rr-menu-item.js
+++ b/src/components/menu-bar/rr-menu-item.js
@@ -118,7 +118,7 @@ export class RRMenuItem extends RRBaseComponent {
       :host {
         display: block;
         position: relative;
-        font-family: var(--rr-font-family-sans, 'RijksoverheidSans', system-ui, sans-serif);
+        font-family: var(--rr-font-family-sans);
       }
 
       :host([hidden]) {

--- a/src/components/menu-bar/rr-menu-item.ts
+++ b/src/components/menu-bar/rr-menu-item.ts
@@ -26,7 +26,7 @@ export class RRMenuItem extends LitElement {
       display: inline-block;
       position: relative;
       width: fit-content;
-      font-family: var(--rr-font-family-sans, 'RijksSansVF', system-ui, sans-serif);
+      font-family: var(--rr-font-family-sans);
     }
 
     :host([hidden]) {

--- a/src/components/radio/rr-radio.js
+++ b/src/components/radio/rr-radio.js
@@ -235,7 +235,7 @@ export class RRRadio extends RRBaseComponent {
         display: inline-flex;
         align-items: center;
         cursor: pointer;
-        font-family: var(--rr-font-family-sans, 'RijksoverheidSans', system-ui, sans-serif);
+        font-family: var(--rr-font-family-sans);
       }
 
       :host([hidden]) {

--- a/src/components/radio/rr-radio.stories.js
+++ b/src/components/radio/rr-radio.stories.js
@@ -101,7 +101,7 @@ const Template = ({ checked, disabled, size, name, value, label }) => html`
       aria-label=${label}
     ></rr-radio>
     <span
-      style="font-family: var(--rr-font-family-sans, 'RijksoverheidSans', system-ui); font-size: 16px;"
+      style="font-family: var(--rr-font-family-sans); font-size: 16px;"
     >
       ${label}
     </span>
@@ -158,7 +158,7 @@ export const RadioGroup = () => html`
   <div role="radiogroup" aria-labelledby="group-label-1" style="padding: 0; margin: 0;">
     <div
       id="group-label-1"
-      style="font-family: var(--rr-font-family-sans, 'RijksoverheidSans', system-ui); font-size: 18px; font-weight: 550; margin-bottom: 16px;"
+      style="font-family: var(--rr-font-family-sans); font-size: 18px; font-weight: 550; margin-bottom: 16px;"
     >
       Kies een optie
     </div>
@@ -166,7 +166,7 @@ export const RadioGroup = () => html`
       <label style="display: flex; align-items: center; gap: 12px; cursor: pointer;">
         <rr-radio name="group1" value="option1" checked aria-label="Optie 1"></rr-radio>
         <span
-          style="font-family: var(--rr-font-family-sans, 'RijksoverheidSans', system-ui); font-size: 16px;"
+          style="font-family: var(--rr-font-family-sans); font-size: 16px;"
         >
           Optie 1
         </span>
@@ -174,7 +174,7 @@ export const RadioGroup = () => html`
       <label style="display: flex; align-items: center; gap: 12px; cursor: pointer;">
         <rr-radio name="group1" value="option2" aria-label="Optie 2"></rr-radio>
         <span
-          style="font-family: var(--rr-font-family-sans, 'RijksoverheidSans', system-ui); font-size: 16px;"
+          style="font-family: var(--rr-font-family-sans); font-size: 16px;"
         >
           Optie 2
         </span>
@@ -182,7 +182,7 @@ export const RadioGroup = () => html`
       <label style="display: flex; align-items: center; gap: 12px; cursor: pointer;">
         <rr-radio name="group1" value="option3" aria-label="Optie 3"></rr-radio>
         <span
-          style="font-family: var(--rr-font-family-sans, 'RijksoverheidSans', system-ui); font-size: 16px;"
+          style="font-family: var(--rr-font-family-sans); font-size: 16px;"
         >
           Optie 3
         </span>
@@ -197,7 +197,7 @@ export const RadioGroup = () => html`
           aria-label="Optie 4 (uitgeschakeld)"
         ></rr-radio>
         <span
-          style="font-family: var(--rr-font-family-sans, 'RijksoverheidSans', system-ui); font-size: 16px;"
+          style="font-family: var(--rr-font-family-sans); font-size: 16px;"
         >
           Optie 4 (uitgeschakeld)
         </span>
@@ -221,7 +221,7 @@ export const AllSizes = () => html`
     <label style="display: flex; align-items: center; gap: 12px; cursor: pointer;">
       <rr-radio name="sizes" value="xs" size="xs" checked aria-label="Extra Small (XS)"></rr-radio>
       <span
-        style="font-family: var(--rr-font-family-sans, 'RijksoverheidSans', system-ui); font-size: 14px;"
+        style="font-family: var(--rr-font-family-sans); font-size: 14px;"
       >
         Extra Small (XS)
       </span>
@@ -229,7 +229,7 @@ export const AllSizes = () => html`
     <label style="display: flex; align-items: center; gap: 12px; cursor: pointer;">
       <rr-radio name="sizes" value="s" size="s" aria-label="Small (S)"></rr-radio>
       <span
-        style="font-family: var(--rr-font-family-sans, 'RijksoverheidSans', system-ui); font-size: 16px;"
+        style="font-family: var(--rr-font-family-sans); font-size: 16px;"
       >
         Small (S)
       </span>
@@ -237,7 +237,7 @@ export const AllSizes = () => html`
     <label style="display: flex; align-items: center; gap: 12px; cursor: pointer;">
       <rr-radio name="sizes" value="m" size="m" aria-label="Medium (M)"></rr-radio>
       <span
-        style="font-family: var(--rr-font-family-sans, 'RijksoverheidSans', system-ui); font-size: 18px;"
+        style="font-family: var(--rr-font-family-sans); font-size: 18px;"
       >
         Medium (M)
       </span>
@@ -353,7 +353,7 @@ export const MultipleGroups = () => html`
   <div style="display: flex; gap: 3rem;">
     <fieldset style="border: none; padding: 0; margin: 0;">
       <legend
-        style="font-family: var(--rr-font-family-sans, 'RijksoverheidSans', system-ui); font-size: 16px; font-weight: 550; margin-bottom: 12px;"
+        style="font-family: var(--rr-font-family-sans); font-size: 16px; font-weight: 550; margin-bottom: 12px;"
       >
         Groep 1: Voorkeur
       </legend>
@@ -361,7 +361,7 @@ export const MultipleGroups = () => html`
         <label style="display: flex; align-items: center; gap: 10px; cursor: pointer;">
           <rr-radio name="preference" value="yes" checked aria-label="Ja"></rr-radio>
           <span
-            style="font-family: var(--rr-font-family-sans, 'RijksoverheidSans', system-ui); font-size: 16px;"
+            style="font-family: var(--rr-font-family-sans); font-size: 16px;"
           >
             Ja
           </span>
@@ -369,7 +369,7 @@ export const MultipleGroups = () => html`
         <label style="display: flex; align-items: center; gap: 10px; cursor: pointer;">
           <rr-radio name="preference" value="no" aria-label="Nee"></rr-radio>
           <span
-            style="font-family: var(--rr-font-family-sans, 'RijksoverheidSans', system-ui); font-size: 16px;"
+            style="font-family: var(--rr-font-family-sans); font-size: 16px;"
           >
             Nee
           </span>
@@ -379,7 +379,7 @@ export const MultipleGroups = () => html`
 
     <fieldset style="border: none; padding: 0; margin: 0;">
       <legend
-        style="font-family: var(--rr-font-family-sans, 'RijksoverheidSans', system-ui); font-size: 16px; font-weight: 550; margin-bottom: 12px;"
+        style="font-family: var(--rr-font-family-sans); font-size: 16px; font-weight: 550; margin-bottom: 12px;"
       >
         Groep 2: Prioriteit
       </legend>
@@ -387,7 +387,7 @@ export const MultipleGroups = () => html`
         <label style="display: flex; align-items: center; gap: 10px; cursor: pointer;">
           <rr-radio name="priority" value="high" aria-label="Hoog"></rr-radio>
           <span
-            style="font-family: var(--rr-font-family-sans, 'RijksoverheidSans', system-ui); font-size: 16px;"
+            style="font-family: var(--rr-font-family-sans); font-size: 16px;"
           >
             Hoog
           </span>
@@ -395,7 +395,7 @@ export const MultipleGroups = () => html`
         <label style="display: flex; align-items: center; gap: 10px; cursor: pointer;">
           <rr-radio name="priority" value="medium" checked aria-label="Gemiddeld"></rr-radio>
           <span
-            style="font-family: var(--rr-font-family-sans, 'RijksoverheidSans', system-ui); font-size: 16px;"
+            style="font-family: var(--rr-font-family-sans); font-size: 16px;"
           >
             Gemiddeld
           </span>
@@ -403,7 +403,7 @@ export const MultipleGroups = () => html`
         <label style="display: flex; align-items: center; gap: 10px; cursor: pointer;">
           <rr-radio name="priority" value="low" aria-label="Laag"></rr-radio>
           <span
-            style="font-family: var(--rr-font-family-sans, 'RijksoverheidSans', system-ui); font-size: 16px;"
+            style="font-family: var(--rr-font-family-sans); font-size: 16px;"
           >
             Laag
           </span>
@@ -435,14 +435,14 @@ export const FormIntegration = () => {
     <form @submit=${handleSubmit} style="max-width: 400px;">
       <fieldset style="border: 1px solid #e2e8f0; border-radius: 8px; padding: 20px; margin: 0;">
         <legend
-          style="font-family: var(--rr-font-family-sans, 'RijksoverheidSans', system-ui); font-size: 18px; font-weight: 550; padding: 0 8px;"
+          style="font-family: var(--rr-font-family-sans); font-size: 18px; font-weight: 550; padding: 0 8px;"
         >
           Vragenlijst
         </legend>
 
         <div style="margin-bottom: 20px;">
           <div
-            style="font-family: var(--rr-font-family-sans, 'RijksoverheidSans', system-ui); font-size: 16px; font-weight: 550; margin-bottom: 12px;"
+            style="font-family: var(--rr-font-family-sans); font-size: 16px; font-weight: 550; margin-bottom: 12px;"
           >
             1. Hoe tevreden bent u?
           </div>
@@ -454,7 +454,7 @@ export const FormIntegration = () => {
                 aria-label="Zeer tevreden"
               ></rr-radio>
               <span
-                style="font-family: var(--rr-font-family-sans, 'RijksoverheidSans', system-ui); font-size: 16px;"
+                style="font-family: var(--rr-font-family-sans); font-size: 16px;"
               >
                 Zeer tevreden
               </span>
@@ -467,7 +467,7 @@ export const FormIntegration = () => {
                 aria-label="Tevreden"
               ></rr-radio>
               <span
-                style="font-family: var(--rr-font-family-sans, 'RijksoverheidSans', system-ui); font-size: 16px;"
+                style="font-family: var(--rr-font-family-sans); font-size: 16px;"
               >
                 Tevreden
               </span>
@@ -475,7 +475,7 @@ export const FormIntegration = () => {
             <label style="display: flex; align-items: center; gap: 10px; cursor: pointer;">
               <rr-radio name="satisfaction" value="neutral" aria-label="Neutraal"></rr-radio>
               <span
-                style="font-family: var(--rr-font-family-sans, 'RijksoverheidSans', system-ui); font-size: 16px;"
+                style="font-family: var(--rr-font-family-sans); font-size: 16px;"
               >
                 Neutraal
               </span>
@@ -483,7 +483,7 @@ export const FormIntegration = () => {
             <label style="display: flex; align-items: center; gap: 10px; cursor: pointer;">
               <rr-radio name="satisfaction" value="unsatisfied" aria-label="Ontevreden"></rr-radio>
               <span
-                style="font-family: var(--rr-font-family-sans, 'RijksoverheidSans', system-ui); font-size: 16px;"
+                style="font-family: var(--rr-font-family-sans); font-size: 16px;"
               >
                 Ontevreden
               </span>
@@ -493,7 +493,7 @@ export const FormIntegration = () => {
 
         <div style="margin-bottom: 20px;">
           <div
-            style="font-family: var(--rr-font-family-sans, 'RijksoverheidSans', system-ui); font-size: 16px; font-weight: 550; margin-bottom: 12px;"
+            style="font-family: var(--rr-font-family-sans); font-size: 16px; font-weight: 550; margin-bottom: 12px;"
           >
             2. Zou u dit aanbevelen?
           </div>
@@ -501,7 +501,7 @@ export const FormIntegration = () => {
             <label style="display: flex; align-items: center; gap: 10px; cursor: pointer;">
               <rr-radio name="recommend" value="yes" aria-label="Ja"></rr-radio>
               <span
-                style="font-family: var(--rr-font-family-sans, 'RijksoverheidSans', system-ui); font-size: 16px;"
+                style="font-family: var(--rr-font-family-sans); font-size: 16px;"
               >
                 Ja
               </span>
@@ -509,7 +509,7 @@ export const FormIntegration = () => {
             <label style="display: flex; align-items: center; gap: 10px; cursor: pointer;">
               <rr-radio name="recommend" value="no" aria-label="Nee"></rr-radio>
               <span
-                style="font-family: var(--rr-font-family-sans, 'RijksoverheidSans', system-ui); font-size: 16px;"
+                style="font-family: var(--rr-font-family-sans); font-size: 16px;"
               >
                 Nee
               </span>
@@ -517,7 +517,7 @@ export const FormIntegration = () => {
             <label style="display: flex; align-items: center; gap: 10px; cursor: pointer;">
               <rr-radio name="recommend" value="maybe" checked aria-label="Misschien"></rr-radio>
               <span
-                style="font-family: var(--rr-font-family-sans, 'RijksoverheidSans', system-ui); font-size: 16px;"
+                style="font-family: var(--rr-font-family-sans); font-size: 16px;"
               >
                 Misschien
               </span>
@@ -528,7 +528,7 @@ export const FormIntegration = () => {
         <button
           type="submit"
           style="
-          font-family: var(--rr-font-family-sans, 'RijksoverheidSans', system-ui);
+          font-family: var(--rr-font-family-sans);
           font-size: 16px;
           font-weight: 550;
           padding: 10px 20px;

--- a/src/components/radio/rr-radio.ts
+++ b/src/components/radio/rr-radio.ts
@@ -37,7 +37,7 @@ export class RRRadio extends LitElement {
     :host {
       display: inline-flex;
       align-items: center;
-      font-family: var(--rr-font-family-sans, 'RijksSansVF', system-ui, sans-serif);
+      font-family: var(--rr-font-family-sans);
       cursor: pointer;
       user-select: none;
       -webkit-user-select: none;

--- a/src/components/segmented-control/rr-segmented-control-item.ts
+++ b/src/components/segmented-control/rr-segmented-control-item.ts
@@ -30,7 +30,7 @@ export class RRSegmentedControlItem extends LitElement {
   static override styles = css`
     :host {
       display: inline-flex;
-      font-family: var(--rr-font-family-sans, 'RijksSansVF', system-ui, sans-serif);
+      font-family: var(--rr-font-family-sans);
       flex: 1;
     }
 

--- a/src/components/segmented-control/rr-segmented-control.ts
+++ b/src/components/segmented-control/rr-segmented-control.ts
@@ -27,7 +27,7 @@ export class RRSegmentedControl extends LitElement {
   static override styles = css`
     :host {
       display: inline-block;
-      font-family: var(--rr-font-family-sans, 'RijksSansVF', system-ui, sans-serif);
+      font-family: var(--rr-font-family-sans);
     }
 
     :host([hidden]) {

--- a/src/components/stepper/rr-stepper.ts
+++ b/src/components/stepper/rr-stepper.ts
@@ -28,7 +28,7 @@ export class RRStepper extends LitElement {
   static override styles = css`
     :host {
       display: inline-block;
-      font-family: var(--rr-font-family-sans, 'RijksSansVF', system-ui, sans-serif);
+      font-family: var(--rr-font-family-sans);
     }
 
     :host([hidden]) {

--- a/src/components/switch/rr-switch.js
+++ b/src/components/switch/rr-switch.js
@@ -137,7 +137,7 @@ export class RRSwitch extends RRBaseComponent {
     return `
       :host {
         display: inline-block;
-        font-family: var(--rr-font-family-sans, 'RijksoverheidSans', system-ui, sans-serif);
+        font-family: var(--rr-font-family-sans);
         outline: none;
         cursor: pointer;
       }

--- a/src/components/switch/rr-switch.ts
+++ b/src/components/switch/rr-switch.ts
@@ -25,7 +25,7 @@ export class RRSwitch extends LitElement {
   static override styles = css`
     :host {
       display: inline-block;
-      font-family: var(--rr-font-family-sans, 'RijksSansVF', system-ui, sans-serif);
+      font-family: var(--rr-font-family-sans);
       outline: none;
       cursor: pointer;
       user-select: none;

--- a/src/components/title-cell/rr-title-cell.ts
+++ b/src/components/title-cell/rr-title-cell.ts
@@ -28,7 +28,7 @@ export class RRTitleCell extends LitElement {
     :host {
       display: flex;
       flex-direction: column;
-      font-family: var(--rr-font-family-sans, 'RijksoverheidSans', system-ui, sans-serif);
+      font-family: var(--rr-font-family-sans);
     }
 
     :host([hidden]) {

--- a/src/components/toggle-button/rr-toggle-button.ts
+++ b/src/components/toggle-button/rr-toggle-button.ts
@@ -28,7 +28,7 @@ export class RRToggleButton extends LitElement {
   static override styles = css`
     :host {
       display: inline-block;
-      font-family: var(--rr-font-family-sans, 'RijksoverheidSans', system-ui, sans-serif);
+      font-family: var(--rr-font-family-sans);
     }
 
     :host([hidden]) {

--- a/src/components/token/rr-token.ts
+++ b/src/components/token/rr-token.ts
@@ -28,7 +28,7 @@ export class RRToken extends LitElement {
   static override styles = css`
     :host {
       display: inline-block;
-      font-family: var(--rr-font-family-sans, 'RijksSansVF', system-ui, sans-serif);
+      font-family: var(--rr-font-family-sans);
     }
 
     :host([hidden]) {

--- a/src/components/top-navigation-bar/rr-nav-logo.ts
+++ b/src/components/top-navigation-bar/rr-nav-logo.ts
@@ -99,7 +99,7 @@ export class RRNavLogo extends LitElement {
     }
 
     .subtitle {
-      font: 400 16px/1.25 var(--rr-font-family-sans, RijksSansVF, system-ui);
+      font: 400 16px/1.25 var(--rr-font-family-sans);
       color: var(--primitives-color-neutral-700);
       margin: 0;
     }
@@ -113,7 +113,7 @@ export class RRNavLogo extends LitElement {
     }
 
     .supporting-text {
-      font: 400 14px/1.25 var(--rr-font-family-sans, RijksSansVF, system-ui);
+      font: 400 14px/1.25 var(--rr-font-family-sans);
       color: var(--primitives-color-accent-100);
       margin: 0;
     }

--- a/src/components/top-navigation-bar/rr-top-navigation-bar.ts
+++ b/src/components/top-navigation-bar/rr-top-navigation-bar.ts
@@ -74,7 +74,7 @@ export class RRTopNavigationBar extends LitElement {
   static override styles = css`
     :host {
       display: block;
-      font-family: var(--rr-font-family-sans, 'RijksSansVF', system-ui, sans-serif);
+      font-family: var(--rr-font-family-sans);
       width: 100%;
     }
 


### PR DESCRIPTION
## Summary

- **Font-family simplified**: Removed verbose inline fallbacks from 24 component files, replacing `var(--rr-font-family-sans, 'RijksSansVF', system-ui, sans-serif)` with `var(--rr-font-family-sans)`. The variable is already defined in `:root` in `fonts.css`, so fallbacks are unnecessary.
- **Checkbox BEM naming**: Renamed `.box`/`.icon` classes in `rr-checkbox.ts` to proper BEM naming (`.checkbox__box`, `.checkbox__icon`).
- **CLAUDE.md updated**: Removed the font-family fallback exception since it no longer applies.

Addresses PR #20 review feedback from @bartvandebiezen.

## Test plan

- [x] Storybook loads without errors on port 6007
- [x] Checkbox component renders correctly in all states (checked, unchecked, indeterminate, disabled) and sizes (XS, S, M)
- [x] Font-family still applies correctly (text renders in RijksSansVF)
- [ ] Visual regression check on other components