### PR TITLE
ci: add build and component-map validation to PR checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  build-and-check:
+    name: Build & Validate
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build tokens
+        run: npm run build:tokens
+
+      - name: Build components
+        run: npm run build:components
+
+      - name: Validate component map
+        run: npm run validate:map

--- a/docs/component-map.json
+++ b/docs/component-map.json
@@ -41,7 +41,7 @@
       },
       "implementation": {
         "tagName": "rr-button",
-        "file": "src/components/button/rr-button.js",
+        "file": "src/components/button/rr-button.ts",
         "className": "RRButton"
       },
       "tokens": {
@@ -121,7 +121,7 @@
       },
       "implementation": {
         "tagName": "rr-checkbox",
-        "file": "src/components/checkbox/rr-checkbox.js",
+        "file": "src/components/checkbox/rr-checkbox.ts",
         "className": "RRCheckbox"
       },
       "tokens": {
@@ -281,7 +281,7 @@
       },
       "implementation": {
         "tagName": "rr-toggle-button",
-        "file": "src/components/toggle-button/rr-toggle-button.js",
+        "file": "src/components/toggle-button/rr-toggle-button.ts",
         "className": "RRToggleButton"
       },
       "tokens": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "build": "npm run build:tokens && npm run validate:tokens && npm run build:components",
     "build:tokens": "node style-dictionary.config.js",
     "validate:tokens": "node scripts/validate-css-variables.js",
+    "validate:map": "node scripts/validate-component-map.js",
     "build:components": "node scripts/build-components.js",
     "dev": "npm run build && npm run serve",
     "serve": "npx http-server . -p 3000 -c-1",

--- a/scripts/validate-component-map.js
+++ b/scripts/validate-component-map.js
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+
+/**
+ * Component Map Validation Script
+ *
+ * Validates that all file paths referenced in docs/component-map.json
+ * actually exist on disk. Catches stale paths after file moves/renames.
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT_DIR = path.resolve(__dirname, '..');
+const MAP_FILE = path.join(ROOT_DIR, 'docs/component-map.json');
+
+const map = JSON.parse(fs.readFileSync(MAP_FILE, 'utf8'));
+const errors = [];
+
+for (const component of map.components) {
+  const impl = component.implementation;
+  if (!impl) continue;
+
+  // Check main component file
+  if (impl.file) {
+    const fullPath = path.join(ROOT_DIR, impl.file);
+    if (!fs.existsSync(fullPath)) {
+      errors.push(`${impl.tagName}: ${impl.file}`);
+    }
+  }
+
+  // Check additional component files
+  if (impl.additionalComponents) {
+    for (const sub of impl.additionalComponents) {
+      if (sub.file) {
+        const fullPath = path.join(ROOT_DIR, sub.file);
+        if (!fs.existsSync(fullPath)) {
+          errors.push(`${sub.tagName}: ${sub.file}`);
+        }
+      }
+    }
+  }
+}
+
+if (errors.length > 0) {
+  console.error(`\n❌ ${errors.length} broken path(s) in component-map.json:\n`);
+  for (const error of errors) {
+    console.error(`   ${error}`);
+  }
+  console.error('');
+  process.exit(1);
+} else {
+  console.log('✅ All component-map.json paths are valid.');
+}


### PR DESCRIPTION
## Summary

- Adds a CI workflow (`.github/workflows/ci.yml`) that runs on every PR and push to main
- Adds a `validate:map` script that checks all file paths in `component-map.json` exist on disk
- Fixes 3 stale `.js` references in `component-map.json` (button, checkbox, toggle-button → `.ts`)

## What it catches

These two checks would have blocked PR #27 which has 7 broken imports and 11 broken component-map paths:

| Check | What it catches |
|-------|----------------|
| `build:components` | Broken imports in `index.ts` — esbuild resolves all paths and fails on missing files |
| `validate:map` | Stale or mistyped file paths in `docs/component-map.json` |

## Not included (yet)

`validate:tokens` and `typecheck` both have pre-existing failures on main and need separate fixes before they can be added to CI.

## Test plan

- [ ] CI workflow runs and passes on this PR
- [ ] Verify `npm run validate:map` fails when a component-map path is wrong
- [ ] Verify `npm run build:components` fails when an index.ts import path is wrong