### PR TITLE
feat(tokens): add multi-theme support with dark mode

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -8,7 +8,8 @@ const config = {
   addons: [
     '@storybook/addon-a11y',
     '@storybook/addon-docs',
-    '@storybook/addon-designs'
+    '@storybook/addon-designs',
+    '@storybook/addon-themes'
   ],
   framework: '@storybook/web-components-vite',
   staticDirs: ['../dist', '../public'],

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,5 +1,7 @@
 import '../src/fonts/fonts.css';
 import '../dist/css/tokens.css';
+import '../dist/css/theme-dark.css';
+import { withThemeByDataAttribute } from '@storybook/addon-themes';
 
 // Figma Testing Library for pixel-perfect comparison
 import { defineCustomElements } from '@cianfrani/figma-testing-library/loader';
@@ -11,6 +13,16 @@ if (typeof window !== 'undefined') {
 
 /** @type { import('@storybook/web-components-vite').Preview } */
 const preview = {
+  decorators: [
+    withThemeByDataAttribute({
+      themes: {
+        light: '',
+        dark: 'dark',
+      },
+      defaultTheme: 'light',
+      attributeName: 'data-theme',
+    }),
+  ],
   parameters: {
     controls: {
       matchers: {

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,6 +1,6 @@
 import '../src/fonts/fonts.css';
 import '../dist/css/tokens.css';
-import '../dist/css/theme-dark.css';
+import '../dist/css/scheme-dark.css';
 import { withThemeByDataAttribute } from '@storybook/addon-themes';
 
 // Figma Testing Library for pixel-perfect comparison
@@ -20,7 +20,7 @@ const preview = {
         dark: 'dark',
       },
       defaultTheme: 'light',
-      attributeName: 'data-theme',
+      attributeName: 'data-scheme',
     }),
   ],
   parameters: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "@storybook/addon-a11y": "^10.1.10",
         "@storybook/addon-designs": "^11.1.0",
         "@storybook/addon-docs": "^10.1.10",
+        "@storybook/addon-themes": "^10.2.8",
         "@storybook/addon-vitest": "^10.1.10",
         "@storybook/web-components-vite": "^10.1.10",
         "@vitest/browser-playwright": "^4.0.16",
@@ -3194,6 +3195,23 @@
       },
       "peerDependencies": {
         "storybook": "^10.1.10"
+      }
+    },
+    "node_modules/@storybook/addon-themes": {
+      "version": "10.2.8",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-themes/-/addon-themes-10.2.8.tgz",
+      "integrity": "sha512-nM5Po7led1YVPJQpemRe9cICIwoPKxerVf2DCxD2kliIDSowv7IZcZgOEPF+pzCjqpLwLG3nkiYt/BbNy+n0ig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ts-dedent": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "storybook": "^10.2.8"
       }
     },
     "node_modules/@storybook/addon-vitest": {
@@ -14690,14 +14708,14 @@
       "license": "MIT"
     },
     "node_modules/storybook": {
-      "version": "10.1.10",
-      "resolved": "https://registry.npmjs.org/storybook/-/storybook-10.1.10.tgz",
-      "integrity": "sha512-oK0t0jEogiKKfv5Z1ao4Of99+xWw1TMUGuGRYDQS4kp2yyBsJQEgu7NI7OLYsCDI6gzt5p3RPtl1lqdeVLUi8A==",
+      "version": "10.2.8",
+      "resolved": "https://registry.npmjs.org/storybook/-/storybook-10.2.8.tgz",
+      "integrity": "sha512-885uSIn8NQw2ZG7vy84K45lHCOSyz1DVsDV8pHiHQj3J0riCuWLNeO50lK9z98zE8kjhgTtxAAkMTy5nkmNRKQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@storybook/global": "^5.0.0",
-        "@storybook/icons": "^2.0.0",
+        "@storybook/icons": "^2.0.1",
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/user-event": "^14.6.1",
         "@vitest/expect": "3.2.4",
@@ -14705,7 +14723,7 @@
         "esbuild": "^0.18.0 || ^0.19.0 || ^0.20.0 || ^0.21.0 || ^0.22.0 || ^0.23.0 || ^0.24.0 || ^0.25.0 || ^0.26.0 || ^0.27.0",
         "open": "^10.2.0",
         "recast": "^0.23.5",
-        "semver": "^7.6.2",
+        "semver": "^7.7.3",
         "use-sync-external-store": "^1.5.0",
         "ws": "^8.18.0"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@storybook/addon-a11y": "^10.1.10",
         "@storybook/addon-designs": "^11.1.0",
         "@storybook/addon-docs": "^10.1.10",
-        "@storybook/addon-themes": "^10.2.8",
+        "@storybook/addon-themes": "^10.1.10",
         "@storybook/addon-vitest": "^10.1.10",
         "@storybook/web-components-vite": "^10.1.10",
         "@vitest/browser-playwright": "^4.0.16",
@@ -3198,9 +3198,9 @@
       }
     },
     "node_modules/@storybook/addon-themes": {
-      "version": "10.2.8",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-themes/-/addon-themes-10.2.8.tgz",
-      "integrity": "sha512-nM5Po7led1YVPJQpemRe9cICIwoPKxerVf2DCxD2kliIDSowv7IZcZgOEPF+pzCjqpLwLG3nkiYt/BbNy+n0ig==",
+      "version": "10.1.10",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-themes/-/addon-themes-10.1.10.tgz",
+      "integrity": "sha512-YlTzREQnUFZ6wepo4MppiobkFrsF1EuObh+vaEhjEj5Cs1oH+kqP5Db+rXi8rbrxnVXaWKmDgqZMtB7kVN4Dnw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3211,7 +3211,7 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^10.2.8"
+        "storybook": "^10.1.10"
       }
     },
     "node_modules/@storybook/addon-vitest": {
@@ -14708,14 +14708,14 @@
       "license": "MIT"
     },
     "node_modules/storybook": {
-      "version": "10.2.8",
-      "resolved": "https://registry.npmjs.org/storybook/-/storybook-10.2.8.tgz",
-      "integrity": "sha512-885uSIn8NQw2ZG7vy84K45lHCOSyz1DVsDV8pHiHQj3J0riCuWLNeO50lK9z98zE8kjhgTtxAAkMTy5nkmNRKQ==",
+      "version": "10.1.10",
+      "resolved": "https://registry.npmjs.org/storybook/-/storybook-10.1.10.tgz",
+      "integrity": "sha512-oK0t0jEogiKKfv5Z1ao4Of99+xWw1TMUGuGRYDQS4kp2yyBsJQEgu7NI7OLYsCDI6gzt5p3RPtl1lqdeVLUi8A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@storybook/global": "^5.0.0",
-        "@storybook/icons": "^2.0.1",
+        "@storybook/icons": "^2.0.0",
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/user-event": "^14.6.1",
         "@vitest/expect": "3.2.4",
@@ -14723,7 +14723,7 @@
         "esbuild": "^0.18.0 || ^0.19.0 || ^0.20.0 || ^0.21.0 || ^0.22.0 || ^0.23.0 || ^0.24.0 || ^0.25.0 || ^0.26.0 || ^0.27.0",
         "open": "^10.2.0",
         "recast": "^0.23.5",
-        "semver": "^7.7.3",
+        "semver": "^7.6.2",
         "use-sync-external-store": "^1.5.0",
         "ws": "^8.18.0"
       },

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "./css": "./dist/css/tokens.css",
     "./css/primitives": "./dist/css/primitives.css",
     "./css/semantics": "./dist/css/semantics.css",
-    "./css/components": "./dist/css/components.css"
+    "./css/components": "./dist/css/components.css",
+    "./css/theme-dark": "./dist/css/theme-dark.css"
   },
   "files": [
     "dist",
@@ -63,6 +64,7 @@
     "@storybook/addon-a11y": "^10.1.10",
     "@storybook/addon-designs": "^11.1.0",
     "@storybook/addon-docs": "^10.1.10",
+    "@storybook/addon-themes": "^10.2.8",
     "@storybook/addon-vitest": "^10.1.10",
     "@storybook/web-components-vite": "^10.1.10",
     "@vitest/browser-playwright": "^4.0.16",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "./css/primitives": "./dist/css/primitives.css",
     "./css/semantics": "./dist/css/semantics.css",
     "./css/components": "./dist/css/components.css",
-    "./css/theme-dark": "./dist/css/theme-dark.css"
+    "./css/scheme-dark": "./dist/css/scheme-dark.css"
   },
   "files": [
     "dist",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "@storybook/addon-a11y": "^10.1.10",
     "@storybook/addon-designs": "^11.1.0",
     "@storybook/addon-docs": "^10.1.10",
-    "@storybook/addon-themes": "^10.2.8",
+    "@storybook/addon-themes": "^10.1.10",
     "@storybook/addon-vitest": "^10.1.10",
     "@storybook/web-components-vite": "^10.1.10",
     "@vitest/browser-playwright": "^4.0.16",

--- a/scripts/validate-css-variables.js
+++ b/scripts/validate-css-variables.js
@@ -20,7 +20,7 @@ const ROOT_DIR = path.resolve(__dirname, '..');
 
 // Configuration
 const TOKENS_FILE = path.join(ROOT_DIR, 'dist/css/tokens.css');
-const DARK_TOKENS_FILE = path.join(ROOT_DIR, 'dist/css/theme-dark.css');
+const DARK_TOKENS_FILE = path.join(ROOT_DIR, 'dist/css/scheme-dark.css');
 const COMPONENTS_DIR = path.join(ROOT_DIR, 'src/components');
 
 // Patterns
@@ -226,27 +226,27 @@ function validate() {
     process.exit(1);
   }
 
-  // Dark theme consistency check (warning only, not blocking)
-  validateDarkThemeConsistency(tokens);
+  // Dark scheme consistency check (warning only, not blocking)
+  validateDarkSchemeConsistency(tokens);
 
   console.log('✅ All CSS variables validated successfully!\n');
 }
 
 /**
- * Check that theme-dark.css defines the same token names as tokens.css.
- * This is a warning-only check to catch token drift between themes.
+ * Check that scheme-dark.css defines the same token names as tokens.css.
+ * This is a warning-only check to catch token drift between schemes.
  */
-function validateDarkThemeConsistency(lightTokens) {
+function validateDarkSchemeConsistency(lightTokens) {
   if (!fs.existsSync(DARK_TOKENS_FILE)) return;
 
-  console.log('🌙 Dark theme consistency check...\n');
+  console.log('🌙 Dark scheme consistency check...\n');
   const darkTokens = parseTokensFile(DARK_TOKENS_FILE);
 
   const missingInDark = [...lightTokens].filter(t => !darkTokens.has(t));
   const extraInDark = [...darkTokens].filter(t => !lightTokens.has(t));
 
   if (missingInDark.length > 0) {
-    console.log(`   ⚠️  ${missingInDark.length} token(s) in light but missing in dark theme`);
+    console.log(`   ⚠️  ${missingInDark.length} token(s) in light but missing in dark scheme`);
     for (const token of missingInDark.slice(0, 5)) {
       console.log(`      └─ ${token}`);
     }
@@ -256,7 +256,7 @@ function validateDarkThemeConsistency(lightTokens) {
   }
 
   if (extraInDark.length > 0) {
-    console.log(`   ⚠️  ${extraInDark.length} token(s) in dark but missing in light theme`);
+    console.log(`   ⚠️  ${extraInDark.length} token(s) in dark but missing in light scheme`);
     for (const token of extraInDark.slice(0, 5)) {
       console.log(`      └─ ${token}`);
     }
@@ -266,7 +266,7 @@ function validateDarkThemeConsistency(lightTokens) {
   }
 
   if (missingInDark.length === 0 && extraInDark.length === 0) {
-    console.log(`   ✅ Dark theme has same ${darkTokens.size} tokens as light theme\n`);
+    console.log(`   ✅ Dark scheme has same ${darkTokens.size} tokens as light scheme\n`);
   } else {
     console.log('');
   }

--- a/scripts/validate-css-variables.js
+++ b/scripts/validate-css-variables.js
@@ -20,6 +20,7 @@ const ROOT_DIR = path.resolve(__dirname, '..');
 
 // Configuration
 const TOKENS_FILE = path.join(ROOT_DIR, 'dist/css/tokens.css');
+const DARK_TOKENS_FILE = path.join(ROOT_DIR, 'dist/css/theme-dark.css');
 const COMPONENTS_DIR = path.join(ROOT_DIR, 'src/components');
 
 // Patterns
@@ -225,7 +226,50 @@ function validate() {
     process.exit(1);
   }
 
+  // Dark theme consistency check (warning only, not blocking)
+  validateDarkThemeConsistency(tokens);
+
   console.log('✅ All CSS variables validated successfully!\n');
+}
+
+/**
+ * Check that theme-dark.css defines the same token names as tokens.css.
+ * This is a warning-only check to catch token drift between themes.
+ */
+function validateDarkThemeConsistency(lightTokens) {
+  if (!fs.existsSync(DARK_TOKENS_FILE)) return;
+
+  console.log('🌙 Dark theme consistency check...\n');
+  const darkTokens = parseTokensFile(DARK_TOKENS_FILE);
+
+  const missingInDark = [...lightTokens].filter(t => !darkTokens.has(t));
+  const extraInDark = [...darkTokens].filter(t => !lightTokens.has(t));
+
+  if (missingInDark.length > 0) {
+    console.log(`   ⚠️  ${missingInDark.length} token(s) in light but missing in dark theme`);
+    for (const token of missingInDark.slice(0, 5)) {
+      console.log(`      └─ ${token}`);
+    }
+    if (missingInDark.length > 5) {
+      console.log(`      ... and ${missingInDark.length - 5} more`);
+    }
+  }
+
+  if (extraInDark.length > 0) {
+    console.log(`   ⚠️  ${extraInDark.length} token(s) in dark but missing in light theme`);
+    for (const token of extraInDark.slice(0, 5)) {
+      console.log(`      └─ ${token}`);
+    }
+    if (extraInDark.length > 5) {
+      console.log(`      ... and ${extraInDark.length - 5} more`);
+    }
+  }
+
+  if (missingInDark.length === 0 && extraInDark.length === 0) {
+    console.log(`   ✅ Dark theme has same ${darkTokens.size} tokens as light theme\n`);
+  } else {
+    console.log('');
+  }
 }
 
 // Run validation

--- a/src/parser/figma-variables-parser.js
+++ b/src/parser/figma-variables-parser.js
@@ -5,25 +5,28 @@
 
 import { FONT_WEIGHT_MAP } from './font-weights.js';
 
-export const figmaVariablesParser = {
-  name: 'figma-variables',
-  pattern: /\.json$/,
+/**
+ * Factory function to create a Figma variables parser for a specific mode.
+ * @param {string} modeName - Mode to match via .includes() (e.g. 'Light', 'Dark')
+ * @param {string} [parserName='figma-variables'] - Unique name for Style Dictionary registration
+ */
+export function createFigmaVariablesParser(modeName, parserName = 'figma-variables') {
+  return {
+    name: parserName,
+    pattern: /\.json$/,
 
-  parser: ({ contents, _filePath }) => {
-    const figmaTokens = JSON.parse(contents);
-    const result = {};
+    parser: ({ contents, _filePath }) => {
+      const figmaTokens = JSON.parse(contents);
+      const result = {};
 
-    // Process all collections
-    for (const collection of figmaTokens.collections || []) {
-      // Only use Light mode - find mode with "Light" in name, or use first mode as fallback
-      const lightMode = collection.modes?.find(m => m.name.includes('Light')) || collection.modes?.[0];
-      if (!lightMode) continue;
+      for (const collection of figmaTokens.collections || []) {
+        const mode = collection.modes?.find(m => m.name.includes(modeName)) || collection.modes?.[0];
+        if (!mode) continue;
 
-      for (const variable of lightMode.variables || []) {
+        for (const variable of mode.variables || []) {
           const pathParts = variable.name.split('/');
           let current = result;
 
-          // Navigate/create nested structure
           for (let i = 0; i < pathParts.length - 1; i++) {
             const part = pathParts[i];
             if (!current[part]) {
@@ -37,9 +40,7 @@ export const figmaVariablesParser = {
             $type: mapType(variable.type, variable.name),
           };
 
-          // Handle alias vs direct value
           if (variable.isAlias && typeof variable.value === 'object' && variable.value.name) {
-            // Convert alias reference to Style Dictionary format
             const aliasPath = variable.value.name.split('/').join('.');
             token.$value = `{${aliasPath}}`;
           } else {
@@ -48,11 +49,15 @@ export const figmaVariablesParser = {
 
           current[tokenName] = token;
         }
-    }
+      }
 
-    return result;
-  },
-};
+      return result;
+    },
+  };
+}
+
+// Backward-compatible export for existing usage
+export const figmaVariablesParser = createFigmaVariablesParser('Light');
 
 /**
  * Map Figma variable types to DTCG types

--- a/style-dictionary.config.js
+++ b/style-dictionary.config.js
@@ -2,8 +2,8 @@ import StyleDictionary from 'style-dictionary';
 import { createFigmaVariablesParser } from './src/parser/figma-variables-parser.js';
 import { FONT_WEIGHT_MAP } from './src/parser/font-weights.js';
 
-// Theme definitions
-const THEMES = [
+// Scheme definitions
+const SCHEMES = [
   {
     name: 'light',
     mode: 'Light',
@@ -19,10 +19,10 @@ const THEMES = [
   {
     name: 'dark',
     mode: 'Dark',
-    selector: '[data-theme="dark"]',
+    selector: '[data-scheme="dark"]',
     parserName: 'figma-variables-dark',
     files: [
-      { destination: 'theme-dark.css' },
+      { destination: 'scheme-dark.css' },
     ],
   },
 ];
@@ -77,7 +77,7 @@ StyleDictionary.registerTransform({
 /**
  * Register a CSS custom properties format with a specific selector.
  */
-function registerThemeFormat(formatName, selector) {
+function registerSchemeFormat(formatName, selector) {
   StyleDictionary.registerFormat({
     name: formatName,
     format: ({ dictionary }) => {
@@ -100,19 +100,19 @@ function registerThemeFormat(formatName, selector) {
   });
 }
 
-// Build each theme
-for (const theme of THEMES) {
-  const parser = createFigmaVariablesParser(theme.mode, theme.parserName);
+// Build each scheme
+for (const scheme of SCHEMES) {
+  const parser = createFigmaVariablesParser(scheme.mode, scheme.parserName);
   StyleDictionary.registerParser(parser);
 
-  const formatName = `css/custom-properties-${theme.name}`;
-  registerThemeFormat(formatName, theme.selector);
+  const formatName = `css/custom-properties-${scheme.name}`;
+  registerSchemeFormat(formatName, scheme.selector);
 
   const platforms = {};
 
-  // CSS platforms for this theme
-  theme.files.forEach((file, index) => {
-    const platformName = index === 0 ? `css-${theme.name}` : `css-${theme.name}-${file.destination.replace('.css', '')}`;
+  // CSS platforms for this scheme
+  scheme.files.forEach((file, index) => {
+    const platformName = index === 0 ? `css-${scheme.name}` : `css-${scheme.name}-${file.destination.replace('.css', '')}`;
     platforms[platformName] = {
       transforms: TRANSFORMS,
       buildPath: 'dist/css/',
@@ -126,8 +126,8 @@ for (const theme of THEMES) {
     };
   });
 
-  // JSON output only for light theme
-  if (theme.name === 'light') {
+  // JSON output only for light scheme
+  if (scheme.name === 'light') {
     platforms['json'] = {
       transforms: ['name/kebab', 'size/px', 'number/value', 'fontWeight/number'],
       buildPath: 'dist/',
@@ -142,7 +142,7 @@ for (const theme of THEMES) {
 
   const config = {
     source: ['tokens/rr-tokens.json'],
-    parsers: [theme.parserName],
+    parsers: [scheme.parserName],
     platforms,
   };
 

--- a/style-dictionary.config.js
+++ b/style-dictionary.config.js
@@ -1,36 +1,49 @@
 import StyleDictionary from 'style-dictionary';
-import { figmaVariablesParser } from './src/parser/figma-variables-parser.js';
+import { createFigmaVariablesParser } from './src/parser/figma-variables-parser.js';
 import { FONT_WEIGHT_MAP } from './src/parser/font-weights.js';
 
-// Register custom parser for Figma variables2json format
-StyleDictionary.registerParser(figmaVariablesParser);
+// Theme definitions
+const THEMES = [
+  {
+    name: 'light',
+    mode: 'Light',
+    selector: ':root',
+    parserName: 'figma-variables-light',
+    files: [
+      { destination: 'tokens.css' },
+      { destination: 'primitives.css', filter: (token) => token.path[0] === 'primitives' },
+      { destination: 'semantics.css', filter: (token) => token.path[0] === 'semantics' },
+      { destination: 'components.css', filter: (token) => token.path[0] === 'components' },
+    ],
+  },
+  {
+    name: 'dark',
+    mode: 'Dark',
+    selector: '[data-theme="dark"]',
+    parserName: 'figma-variables-dark',
+    files: [
+      { destination: 'theme-dark.css' },
+    ],
+  },
+];
 
-// Custom transform for dimension values (number to px)
+const TRANSFORMS = ['name/kebab', 'size/px', 'number/value', 'fontWeight/number', 'typography/css', 'color/css'];
+
+// Register global transforms (once)
 StyleDictionary.registerTransform({
   name: 'size/px',
   type: 'value',
-  filter: (token) => {
-    return token.$type === 'dimension' && typeof token.$value === 'number';
-  },
-  transform: (token) => {
-    return `${token.$value}px`;
-  },
+  filter: (token) => token.$type === 'dimension' && typeof token.$value === 'number',
+  transform: (token) => `${token.$value}px`,
 });
 
-// Custom transform for number values that should stay as numbers
 StyleDictionary.registerTransform({
   name: 'number/value',
   type: 'value',
-  filter: (token) => {
-    return token.$type === 'number' && typeof token.$value === 'number';
-  },
-  transform: (token) => {
-    // Keep opacity, line-height etc as plain numbers
-    return token.$value;
-  },
+  filter: (token) => token.$type === 'number' && typeof token.$value === 'number',
+  transform: (token) => token.$value,
 });
 
-// Custom transform for fontWeight tokens - convert string names to numeric values
 StyleDictionary.registerTransform({
   name: 'fontWeight/number',
   type: 'value',
@@ -47,7 +60,6 @@ StyleDictionary.registerTransform({
   },
 });
 
-// Custom transform for typography to CSS font shorthand
 StyleDictionary.registerTransform({
   name: 'typography/css',
   type: 'value',
@@ -56,93 +68,67 @@ StyleDictionary.registerTransform({
   transform: (token) => {
     const val = token.$value;
     if (typeof val === 'object') {
-      // Return CSS font shorthand
       return `${val.fontWeight} ${val.fontSize}/${val.lineHeight} ${val.fontFamily}, system-ui`;
     }
     return val;
   },
 });
 
-// Custom format for CSS with organized sections
-StyleDictionary.registerFormat({
-  name: 'css/custom-properties-grouped',
-  format: ({ dictionary, options }) => {
-    const header = `/**
+/**
+ * Register a CSS custom properties format with a specific selector.
+ */
+function registerThemeFormat(formatName, selector) {
+  StyleDictionary.registerFormat({
+    name: formatName,
+    format: ({ dictionary }) => {
+      const header = `/**
  * RegelRecht Design System Tokens
  * Auto-generated from Figma - Do not edit directly
  * Generated: ${new Date().toISOString()}
  */\n\n`;
 
-    const tokens = dictionary.allTokens
-      .map((token) => {
-        const value =
-          typeof token.$value === 'object' ? JSON.stringify(token.$value) : token.$value;
-        return `  --${token.name}: ${value};`;
-      })
-      .join('\n');
+      const tokens = dictionary.allTokens
+        .map((token) => {
+          const value =
+            typeof token.$value === 'object' ? JSON.stringify(token.$value) : token.$value;
+          return `  --${token.name}: ${value};`;
+        })
+        .join('\n');
 
-    return `${header}:root {\n${tokens}\n}\n`;
-  },
-});
+      return `${header}${selector} {\n${tokens}\n}\n`;
+    },
+  });
+}
 
-const config = {
-  source: ['tokens/rr-tokens.json'],
-  parsers: ['figma-variables'],
+// Build each theme
+for (const theme of THEMES) {
+  const parser = createFigmaVariablesParser(theme.mode, theme.parserName);
+  StyleDictionary.registerParser(parser);
 
-  platforms: {
-    // All tokens combined
-    css: {
-      transforms: ['name/kebab', 'size/px', 'number/value', 'fontWeight/number', 'typography/css', 'color/css'],
+  const formatName = `css/custom-properties-${theme.name}`;
+  registerThemeFormat(formatName, theme.selector);
+
+  const platforms = {};
+
+  // CSS platforms for this theme
+  theme.files.forEach((file, index) => {
+    const platformName = index === 0 ? `css-${theme.name}` : `css-${theme.name}-${file.destination.replace('.css', '')}`;
+    platforms[platformName] = {
+      transforms: TRANSFORMS,
       buildPath: 'dist/css/',
       files: [
         {
-          destination: 'tokens.css',
-          format: 'css/custom-properties-grouped',
+          destination: file.destination,
+          format: formatName,
+          ...(file.filter && { filter: file.filter }),
         },
       ],
-    },
+    };
+  });
 
-    // Primitives only
-    'css-primitives': {
-      transforms: ['name/kebab', 'size/px', 'number/value', 'fontWeight/number', 'typography/css', 'color/css'],
-      buildPath: 'dist/css/',
-      files: [
-        {
-          destination: 'primitives.css',
-          format: 'css/custom-properties-grouped',
-          filter: (token) => token.path[0] === 'primitives',
-        },
-      ],
-    },
-
-    // Semantics only
-    'css-semantics': {
-      transforms: ['name/kebab', 'size/px', 'number/value', 'fontWeight/number', 'typography/css', 'color/css'],
-      buildPath: 'dist/css/',
-      files: [
-        {
-          destination: 'semantics.css',
-          format: 'css/custom-properties-grouped',
-          filter: (token) => token.path[0] === 'semantics',
-        },
-      ],
-    },
-
-    // Component tokens only
-    'css-components': {
-      transforms: ['name/kebab', 'size/px', 'number/value', 'fontWeight/number', 'typography/css', 'color/css'],
-      buildPath: 'dist/css/',
-      files: [
-        {
-          destination: 'components.css',
-          format: 'css/custom-properties-grouped',
-          filter: (token) => token.path[0] === 'components',
-        },
-      ],
-    },
-
-    // JSON output for debugging/reference
-    json: {
+  // JSON output only for light theme
+  if (theme.name === 'light') {
+    platforms['json'] = {
       transforms: ['name/kebab', 'size/px', 'number/value', 'fontWeight/number'],
       buildPath: 'dist/',
       files: [
@@ -151,11 +137,17 @@ const config = {
           format: 'json/nested',
         },
       ],
-    },
-  },
-};
+    };
+  }
 
-const sd = new StyleDictionary(config);
-await sd.buildAllPlatforms();
+  const config = {
+    source: ['tokens/rr-tokens.json'],
+    parsers: [theme.parserName],
+    platforms,
+  };
+
+  const sd = new StyleDictionary(config);
+  await sd.buildAllPlatforms();
+}
 
 console.log('Design tokens built successfully!');


### PR DESCRIPTION
## Summary
- Refactored token build pipeline to support multiple themes from Figma's dark mode variables (403 tokens, 177 different from light)
- New `dist/css/theme-dark.css` generated with `[data-theme="dark"]` selector containing all 485 tokens
- Storybook toolbar theme switcher (light/dark) via `@storybook/addon-themes`
- No component code changes needed — CSS custom properties cascade through Shadow DOM

## Changes
| File | Change |
|------|--------|
| `src/parser/figma-variables-parser.js` | `createFigmaVariablesParser(modeName, parserName)` factory function |
| `style-dictionary.config.js` | Refactored to `THEMES` loop for multi-theme builds |
| `.storybook/main.js` | Added `@storybook/addon-themes` addon |
| `.storybook/preview.js` | Dark CSS import + `withThemeByDataAttribute` decorator |
| `scripts/validate-css-variables.js` | Dark theme token consistency check (warning-only) |
| `package.json` | Added `./css/theme-dark` export + addon dependency |

## Usage
**Storybook:** Use toolbar dropdown to switch between Light and Dark themes

**Apps:**
```js
document.documentElement.setAttribute('data-theme', 'dark');
```

**Future themes:** Add entry to `THEMES` array in `style-dictionary.config.js`

## Test plan
- [ ] `npm run build:tokens` generates both `tokens.css` and `theme-dark.css`
- [ ] Storybook toolbar shows Light/Dark theme switcher
- [ ] Switching to Dark mode changes component colors
- [ ] FigmaComparison stories still work in Light mode
- [ ] Light mode output unchanged from before this PR