### PR TITLE
fix(ci): catch-all release rule and prevent duplicate publishes

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -18,6 +18,11 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    # Only publish when triggered by version-bump commit, release, or manual dispatch
+    if: >-
+      github.event_name == 'release' ||
+      github.event_name == 'workflow_dispatch' ||
+      startsWith(github.event.head_commit.message, 'chore(release):')
     permissions:
       contents: read
       packages: write

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -6,7 +6,15 @@
         { "type": "feat", "release": "patch" },
         { "type": "fix", "release": "patch" },
         { "type": "perf", "release": "patch" },
-        { "breaking": true, "release": "patch" }
+        { "breaking": true, "release": "patch" },
+        { "type": "chore", "release": false },
+        { "type": "docs", "release": false },
+        { "type": "ci", "release": false },
+        { "type": "style", "release": false },
+        { "type": "test", "release": false },
+        { "type": "build", "release": false },
+        { "type": "refactor", "release": false },
+        { "message": "*", "release": "patch" }
       ]
     }],
     "@semantic-release/release-notes-generator",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,6 +115,7 @@ Versions are **automatically** bumped by semantic-release on merge to main.
 | `fix:`, `perf:` | Patch (0.5.0 → 0.5.1) |
 | `feat!:` or `BREAKING CHANGE:` | Patch (0.5.0 → 0.5.1) |
 | `docs:`, `chore:`, `ci:`, etc. | No bump |
+| Unrecognized (no conventional prefix) | Patch (treated as feat) |
 
 **Manual version bumping is not needed.** Use conventional commits and CI handles the rest.
 


### PR DESCRIPTION
## Summary

- Add catch-all `releaseRule` in `.releaserc.json` so commits without conventional commit prefixes (e.g. PR merge commits like `Feat/improve buttons (#36)`) trigger a patch release instead of being silently ignored
- Explicitly exclude `chore`, `docs`, `ci`, `style`, `test`, `build`, `refactor` types from triggering releases
- Add `if` condition to `publish-npm.yml` so it only publishes on version-bump commits (`chore(release):` prefix), GitHub releases, or manual dispatch — preventing 409 Conflict errors when other commits touch `package.json`

Fixes the failed run: https://github.com/MinBZK/storybook/actions/runs/22398309841

## Test plan

- [ ] Merge a PR with a non-conventional commit message → should trigger version bump + publish
- [ ] Merge a PR with `chore:` prefix → should NOT trigger version bump
- [ ] Verify publish workflow skips when `package.json` changes without a version bump