### PR TITLE
fix(button-bar): preserve individual variant overrides on child buttons

### DIFF
--- a/src/components/actions/button-bar/rr-button-bar.test.ts
+++ b/src/components/actions/button-bar/rr-button-bar.test.ts
@@ -178,6 +178,84 @@ describe('rr-button-bar – child building & attribute propagation', () => {
     expect(namedSlot).not.toBeNull();
   });
 
+  it('preserves individual variant set in markup', async () => {
+    el = await fixture<RRButtonBar>(`
+      <rr-button-bar variant="neutral-tinted">
+        <rr-button variant="accent-filled">Active</rr-button>
+        <rr-button>Inactive</rr-button>
+      </rr-button-bar>
+    `);
+    await waitForUpdate(el);
+
+    const buttons = el.querySelectorAll('rr-button');
+    expect(buttons[0].getAttribute('variant')).toBe('accent-filled');
+    expect(buttons[1].getAttribute('variant')).toBe('neutral-tinted');
+  });
+
+  it('preserves individual variant after bar variant changes', async () => {
+    el = await fixture<RRButtonBar>(`
+      <rr-button-bar variant="neutral-tinted">
+        <rr-button variant="accent-filled">Active</rr-button>
+        <rr-button>Inactive</rr-button>
+      </rr-button-bar>
+    `);
+    await waitForUpdate(el);
+
+    el.variant = 'accent-tinted';
+    await waitForUpdate(el);
+
+    const buttons = el.querySelectorAll('rr-button');
+    // Individually-set variant should be preserved
+    expect(buttons[0].getAttribute('variant')).toBe('accent-filled');
+    // Non-individual button should follow the bar
+    expect(buttons[1].getAttribute('variant')).toBe('accent-tinted');
+  });
+
+  it('preserves individual variant when variant is changed via setAttribute', async () => {
+    el = await fixture<RRButtonBar>(`
+      <rr-button-bar variant="neutral-tinted">
+        <rr-button>A</rr-button>
+        <rr-button>B</rr-button>
+      </rr-button-bar>
+    `);
+    await waitForUpdate(el);
+
+    // Simulate a framework (e.g. Vue) setting variant on one button
+    const btnA = el.querySelectorAll('rr-button')[0];
+    btnA.setAttribute('variant', 'accent-filled');
+
+    // Trigger a rebuild by adding a new child
+    const btnC = document.createElement('rr-button');
+    btnC.textContent = 'C';
+    el.appendChild(btnC);
+    await waitForUpdate(el);
+
+    // btnA's individual variant should be preserved
+    expect(btnA.getAttribute('variant')).toBe('accent-filled');
+    // btnC (new, no individual variant) should get bar's variant
+    expect(btnC.getAttribute('variant')).toBe('neutral-tinted');
+  });
+
+  it('preserves individual variant set via setAttribute when bar variant changes', async () => {
+    el = await fixture<RRButtonBar>(`
+      <rr-button-bar variant="neutral-tinted">
+        <rr-button>A</rr-button>
+        <rr-button>B</rr-button>
+      </rr-button-bar>
+    `);
+    await waitForUpdate(el);
+
+    const btnA = el.querySelectorAll('rr-button')[0];
+    btnA.setAttribute('variant', 'accent-filled');
+
+    // Change bar variant WITHOUT adding a child
+    el.variant = 'accent-tinted';
+    await waitForUpdate(el);
+
+    expect(btnA.getAttribute('variant')).toBe('accent-filled');
+    expect(el.querySelectorAll('rr-button')[1].getAttribute('variant')).toBe('accent-tinted');
+  });
+
   it('updates slots when a child is removed after mount', async () => {
     el = await fixture<RRButtonBar>(`
       <rr-button-bar>

--- a/src/components/actions/button-bar/rr-button-bar.ts
+++ b/src/components/actions/button-bar/rr-button-bar.ts
@@ -18,7 +18,6 @@ import { LitElement } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import { styles } from './rr-button-bar.styles.ts';
 import { template } from './rr-button-bar.template.ts';
-import { repeat } from 'lit/directives/repeat.js';
 
 if (!customElements.get('rr-button-bar-divider')) {
 	customElements.define('rr-button-bar-divider', class extends HTMLElement {});
@@ -52,6 +51,7 @@ export class RRButtonBar extends LitElement {
 	private _observer: MutationObserver | null = null;
 	private _building = false;
 	private _individuallyDisabled = new WeakSet<Element>();
+	private _individuallyVarianted = new WeakSet<Element>();
 
 	override connectedCallback(): void {
 		super.connectedCallback();
@@ -75,7 +75,8 @@ export class RRButtonBar extends LitElement {
 			this._propagateSize();
 		}
 		if (changedProperties.has('variant') || changedProperties.has('_children')) {
-			this._propagateVariant();
+			const oldVariant = changedProperties.get('variant') as string | undefined;
+			this._propagateVariant(oldVariant);
 		}
 		if (changedProperties.has('disabled')) {
 			this._propagateDisabled();
@@ -107,10 +108,22 @@ export class RRButtonBar extends LitElement {
 			.forEach(el => el.setAttribute('size', this.size));
 	}
 
-	private _propagateVariant(): void {
+	private _propagateVariant(oldVariant?: string): void {
 		Array.from(this.children)
 			.filter(el => BUTTON_TAGS.includes(el.tagName.toLowerCase()))
-			.forEach(el => el.setAttribute('variant', this.variant));
+			.forEach(el => {
+				if (
+					!this._individuallyVarianted.has(el) &&
+					el.hasAttribute('variant') &&
+					el.getAttribute('variant') !== this.variant &&
+					(oldVariant == null || el.getAttribute('variant') !== oldVariant)
+				) {
+					this._individuallyVarianted.add(el);
+				}
+				if (!this._individuallyVarianted.has(el)) {
+					el.setAttribute('variant', this.variant);
+				}
+			});
 	}
 
 	private _propagateDisabled(): void {
@@ -149,7 +162,12 @@ export class RRButtonBar extends LitElement {
 
 			if (BUTTON_TAGS.includes(tag)) {
 				el.setAttribute('size', this.size);
-				el.setAttribute('variant', this.variant);
+				if (el.hasAttribute('variant') && el.getAttribute('variant') !== this.variant) {
+					this._individuallyVarianted.add(el);
+				}
+				if (!this._individuallyVarianted.has(el)) {
+					el.setAttribute('variant', this.variant);
+				}
 			}
 
 			const id = this._idCounter++;


### PR DESCRIPTION
## Summary

- `_propagateVariant()` and `_buildChildren()` unconditionally overwrote the `variant` attribute on all child buttons, making it impossible for consumers to set different variants on individual buttons within a bar
- Track individually-varianted buttons in a `WeakSet` (mirroring the existing `_individuallyDisabled` pattern) and skip them during propagation
- Removes unused `repeat` import

## Test plan

- [x] Existing 11 tests still pass
- [x] New test: preserves individual variant set in markup
- [x] New test: preserves individual variant after bar variant changes
- [x] New test: preserves individual variant when variant is changed via `setAttribute` (simulates Vue/React)