### PR TITLE
fix(toolbar): preserve children when descendant attributes change

### DIFF
--- a/src/components/actions/toolbar/rr-toolbar.test.ts
+++ b/src/components/actions/toolbar/rr-toolbar.test.ts
@@ -255,8 +255,6 @@ describe('rr-toolbar', () => {
 		// Simulate a descendant attribute change (like rr-segmented-control-item)
 		const button = el.querySelector('button')!;
 		button.removeAttribute('selected');
-		// MutationObserver fires asynchronously; setTimeout ensures the callback runs before we assert.
-		await new Promise(resolve => setTimeout(resolve, 50));
 		await waitForUpdate(el);
 
 		// Toolbar children must still be intact

--- a/src/components/actions/toolbar/rr-toolbar.test.ts
+++ b/src/components/actions/toolbar/rr-toolbar.test.ts
@@ -255,6 +255,7 @@ describe('rr-toolbar', () => {
 		// Simulate a descendant attribute change (like rr-segmented-control-item)
 		const button = el.querySelector('button')!;
 		button.removeAttribute('selected');
+		// MutationObserver fires asynchronously; setTimeout ensures the callback runs before we assert.
 		await new Promise(resolve => setTimeout(resolve, 50));
 		await waitForUpdate(el);
 

--- a/src/components/actions/toolbar/rr-toolbar.test.ts
+++ b/src/components/actions/toolbar/rr-toolbar.test.ts
@@ -237,6 +237,35 @@ describe('rr-toolbar', () => {
 		expect(spy).toHaveBeenCalled();
 	});
 
+	it('preserves children when a descendant selected attribute changes', async () => {
+		el = await fixture(`
+			<rr-toolbar>
+				<rr-toolbar-start-area>
+					<rr-toolbar-item label="Item">
+						<button selected>Toggle</button>
+					</rr-toolbar-item>
+				</rr-toolbar-start-area>
+			</rr-toolbar>
+		`);
+		await waitForUpdate(el);
+
+		const toolbar = el as unknown as { _startChildren: unknown[] };
+		expect(toolbar._startChildren.length).toBe(1);
+
+		// Simulate a descendant attribute change (like rr-segmented-control-item)
+		const button = el.querySelector('button')!;
+		button.removeAttribute('selected');
+		await new Promise(resolve => setTimeout(resolve, 50));
+		await waitForUpdate(el);
+
+		// Toolbar children must still be intact
+		expect(toolbar._startChildren.length).toBe(1);
+
+		// Slot must still exist in shadow DOM
+		const slot = el.shadowRoot?.querySelector('slot[name^="child-"]');
+		expect(slot).not.toBeNull();
+	});
+
 	// ## _computeSpacerZeros
 
 	it('returns both zeros true when start and end are both empty', async () => {

--- a/src/components/actions/toolbar/rr-toolbar.ts
+++ b/src/components/actions/toolbar/rr-toolbar.ts
@@ -117,7 +117,10 @@ export class RRToolbar extends LitElement {
 				'rr-toolbar-overflow-area',
 			]);
 			const onlyInternalMoves = mutations.every(m => {
-				// Attribute change — only rebuild for toolbar-structural elements
+				// Attribute change — only rebuild for toolbar-structural elements.
+				// Deeply nested descendants (e.g. rr-segmented-control-item) can change
+				// selected/disabled/type without affecting toolbar layout. The attributeFilter
+				// values (label, priority, min-width, etc.) are only meaningful on these two tags.
 				if (m.type === 'attributes') {
 					const tag = (m.target as Element).tagName.toLowerCase();
 					return tag !== 'rr-toolbar-item' && tag !== 'rr-toolbar-title-group';
@@ -540,6 +543,8 @@ export class RRToolbar extends LitElement {
 				el.removeAttribute('slot');
 				delete el.dataset.toolbarArea;
 				area.appendChild(el);
+			} else {
+				delete el.dataset.toolbarArea;
 			}
 		}
 	}

--- a/src/components/actions/toolbar/rr-toolbar.ts
+++ b/src/components/actions/toolbar/rr-toolbar.ts
@@ -117,8 +117,11 @@ export class RRToolbar extends LitElement {
 				'rr-toolbar-overflow-area',
 			]);
 			const onlyInternalMoves = mutations.every(m => {
-				// Attribute change on a consumer-relevant attribute — always rebuild
-				if (m.type === 'attributes') return false;
+				// Attribute change — only rebuild for toolbar-structural elements
+				if (m.type === 'attributes') {
+					const tag = (m.target as Element).tagName.toLowerCase();
+					return tag !== 'rr-toolbar-item' && tag !== 'rr-toolbar-title-group';
+				}
 				// childList change on the toolbar root — ignore if it's just internal slot moves
 				if (m.target !== this) return false;
 				const nodes = [...Array.from(m.addedNodes), ...Array.from(m.removedNodes)];
@@ -468,6 +471,7 @@ export class RRToolbar extends LitElement {
 				const id = this._getId(el);
 				if (el.parentElement !== this) this.appendChild(el);
 				el.setAttribute('slot', `child-${id}`);
+				(el as HTMLElement).dataset.toolbarArea = areaTag;
 				return {
 					type: 'title-group',
 					title: el.getAttribute('text') ?? '',
@@ -494,6 +498,7 @@ export class RRToolbar extends LitElement {
 
 				if (el.parentElement !== this) this.appendChild(el);
 				el.setAttribute('slot', `child-${id}`);
+				(el as HTMLElement).dataset.toolbarArea = areaTag;
 
 				const overflowItems = Array.from(el.children).filter(child => {
 					const childTag = child.tagName.toLowerCase();
@@ -507,6 +512,7 @@ export class RRToolbar extends LitElement {
 			const id = this._getId(el);
 			if (el.parentElement !== this) this.appendChild(el);
 			el.setAttribute('slot', `child-${id}`);
+			(el as HTMLElement).dataset.toolbarArea = areaTag;
 			return { type: 'other', element: el, id } as ToolbarChild;
 		});
 	}
@@ -523,11 +529,28 @@ export class RRToolbar extends LitElement {
 		});
 	}
 
+	private _restoreItemsToAreas(): void {
+		const reparented = Array.from(this.children).filter(
+			(child): child is HTMLElement => child instanceof HTMLElement && !!child.dataset.toolbarArea
+		);
+		for (const el of reparented) {
+			const areaTag = el.dataset.toolbarArea!;
+			const area = this.querySelector(areaTag);
+			if (area) {
+				el.removeAttribute('slot');
+				delete el.dataset.toolbarArea;
+				area.appendChild(el);
+			}
+		}
+	}
+
 	private _buildChildren(): void {
 		if (this._isBuilding) return;
 		this._isBuilding = true;
 
 		this._observer?.disconnect();
+
+		this._restoreItemsToAreas();
 
 		this._startChildren = this._buildChildrenForArea('rr-toolbar-start-area');
 		this._centerChildren = this._buildChildrenForArea('rr-toolbar-center-area');

--- a/src/components/actions/toolbar/rr-toolbar.ts
+++ b/src/components/actions/toolbar/rr-toolbar.ts
@@ -118,9 +118,11 @@ export class RRToolbar extends LitElement {
 			]);
 			const onlyInternalMoves = mutations.every(m => {
 				// Attribute change — only rebuild for toolbar-structural elements.
-				// Deeply nested descendants (e.g. rr-segmented-control-item) can change
-				// selected/disabled/type without affecting toolbar layout. The attributeFilter
-				// values (label, priority, min-width, etc.) are only meaningful on these two tags.
+				// The watched attributeFilter values (label, priority, min-width, width,
+				// text, disabled, selected, type) only affect toolbar layout when they
+				// change on rr-toolbar-item or rr-toolbar-title-group. Changes on area
+				// elements or deeply nested descendants (e.g. rr-segmented-control-item)
+				// are safe to ignore.
 				if (m.type === 'attributes') {
 					const tag = (m.target as Element).tagName.toLowerCase();
 					return tag !== 'rr-toolbar-item' && tag !== 'rr-toolbar-title-group';


### PR DESCRIPTION
## Summary

- Narrowed MutationObserver to only trigger rebuilds for `rr-toolbar-item` and `rr-toolbar-title-group` attribute changes, ignoring deeply nested descendants like `rr-segmented-control-item`
- Added `_restoreItemsToAreas()` safety net that moves re-parented items back to their source areas before each rebuild
- Added regression test for descendant `selected` attribute changes

## Context

Clicking a segmented control inside an `rr-toolbar` (e.g. Machine/YAML toggle) caused the toolbar's `_buildChildren` to re-fire. Since items were already re-parented from their area elements to the toolbar root, re-scanning the now-empty areas returned zero children, removing all slots and making items invisible.

## Test plan

- [x] All 437 existing tests pass
- [x] New regression test: descendant `selected` attribute change preserves toolbar children and slots
- [x] `build:components` succeeds