### PR TITLE
chore: add context hooks to code review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -74,6 +74,7 @@ jobs:
             - Are semantic tokens preferred over primitives?
             - No fallback values on design tokens (strict validation)?
             - Override hooks use `--rr-*` prefix?
+            - Context hooks use `--context-*` prefix?
             - Internal variables use `--_*` prefix?
 
             ### 4. CSS and styling

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -70,6 +70,7 @@ export default [
       'node_modules/**',
       'storybook-static/**',
       '.storybook/**',
+      '.claude/**',
       'scripts/**',
       '*.config.js',
     ],


### PR DESCRIPTION
## Summary
- Add `--context-*` prefix check to the code review workflow
- Exclude `.claude/` directory from eslint (tooling scripts use Node.js globals)

Split from #59 because workflow files must match the version on the default branch. Once this is merged, #59 can be rebased on top.