### PR TITLE
fix: accept commits without conventional prefix for release

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -2,6 +2,10 @@
   "branches": ["main"],
   "plugins": [
     ["@semantic-release/commit-analyzer", {
+      "parserOpts": {
+        "headerPattern": "^(?:(\\w+)(?:\\(([^)]*)\\))?!?:\\s*)?(.+)$",
+        "headerCorrespondence": ["type", "scope", "subject"]
+      },
       "releaseRules": [
         { "type": "feat", "release": "patch" },
         { "type": "fix", "release": "patch" },


### PR DESCRIPTION
## Summary
- The `conventional-changelog-angular` headerPattern rejects commits without `type: ` prefix, so squash-merged PRs like `Feat/improve layouts 2 (#59)` never reach the catch-all releaseRule
- Adds a lenient `headerPattern` that makes the `type:` prefix optional — commits without a prefix fall through to `{ "message": "*", "release": "patch" }`
- This is why v1.0.0 layout components were never published after merge

## Test plan
- [ ] Merge this PR, verify semantic-release creates a `chore(release):` commit
- [ ] Verify the new version is published to GitHub Packages