### PR TITLE
feat!: refactor pagination component

### DIFF
--- a/.claude/skills/component/SKILL.md
+++ b/.claude/skills/component/SKILL.md
@@ -13,205 +13,234 @@ Implementeer een web component: $ARGUMENTS
 |--------|-------------|
 | **Framework** | [Lit](https://lit.dev/) (LitElement) |
 | **Taal** | TypeScript (`.ts`) |
-| **Component bestand** | `src/components/{name}/rr-{name}.ts` |
-| **Stories bestand** | `src/components/{name}/rr-{name}.stories.js` |
-| **Referentie** | `src/components/inputs/toggle-button/rr-toggle-button.ts` |
-
-**BELANGRIJK:** Componenten worden ALTIJD geschreven in Lit + TypeScript. Gebruik de toggle-button als referentie implementatie.
-
----
+| **Prefix** | `ndd-` |
 
 ## WORKFLOW
 
-### Stap 1: Input Parsing
+### Stap 1: Bepaal component naam
 
-**Bepaal component naam:**
 1. Als gebruiker naam opgaf → gebruik die
 2. Converteer naar kebab-case: "Toggle Button" → "toggle-button"
-3. Voeg `rr-` prefix toe: → "rr-toggle-button"
+3. Voeg `ndd-` prefix toe: → "ndd-toggle-button"
+4. Class naam: `NDDToggleButton`
 
-### Stap 2: Bestaand Component Check
+### Stap 2: Bestaand component check
 
-Lees `docs/component-map.json` en check of component al bestaat.
+Zoek in `src/components/` of het component al bestaat.
 
 | Situatie | Mode |
 |----------|------|
-| Component bestaat niet | **CREATE** - nieuwe bestanden aanmaken |
-| Component bestaat al | **UPDATE** - bestaande bestanden bijwerken |
+| Component bestaat niet | **CREATE** — nieuwe bestanden aanmaken |
+| Component bestaat al | **UPDATE** — bestaande bestanden bijwerken |
 
-### Stap 3: Tokens Identificeren
+### Stap 3: CSS variabelen identificeren
 
-**Token hiërarchie (voorkeursvolgorde):**
+**Voorkeursvolgorde:**
 1. `--components-{name}-*` (component-specifiek)
 2. `--semantics-*` (betekenisvol)
 3. `--primitives-*` (alleen als backup)
 
-**Zoek tokens in `src/assets/styles/settings.css`:**
+**Naamconventies:**
+
+- **Primitives:** `--primitives-{property}-{variant}-{scale}`
+  bijv. `--primitives-color-accent-750`
+- **Semantics:** `--semantics-{group}-{variant}-{state}-{element}-{element-variant}-{element-state}-{property}`
+  bijv. `--semantics-buttons-neutral-tinted-is-hovered-background-color`
+- **Components:** `--components-{component}-{variant}-{state}-{element}-{element-variant}-{element-state}-{property}`
+  bijv. `--components-checkbox-md-check-icon-size`
+- **Context:** `--context-{context}-{property}`
+  Gedeelde variabelen voor communicatie tussen componenten. Niet gedefinieerd in settings.css.
+  bijv. `--context-parent-background-color`
+- **Lokaal:** `--_{variant}-{state}-{element}-{element-variant}-{element-state}-{property}`
+  Interne variabelen binnen een component. Definieer defaults in `:host`.
+  bijv. `--_background-color`
+
+Primitives zijn basiswaarden — gebruik ze niet direct in componenten. Semantics geven context voor een groep componenten. Component variabelen zijn specifiek voor één component.
+
+Zoek in `src/assets/styles/settings.css`:
 ```bash
 grep -i "{component-naam}" src/assets/styles/settings.css
-grep -i "controls.*min-size" src/assets/styles/settings.css
+grep -i "controls.*min-size\|controls.*corner-radius" src/assets/styles/settings.css
+grep -i "focus-ring" src/assets/styles/settings.css
 ```
 
-**Controleer ook bestaande componenten voor patronen:**
-- `src/components/inputs/toggle-button/rr-toggle-button.ts` (referentie implementatie)
+### Stap 4: Bestanden aanmaken
 
-### Spacer Component Gebruik
-
-**Gebruik `<rr-spacer>` voor spacing in componenten waar spacer elementen nodig zijn.**
-
-```html
-<!-- Vaste spacing -->
-<rr-spacer size="32"></rr-spacer>
-
-<!-- Flexibele spacing (vult beschikbare ruimte) -->
-<rr-spacer size="flexible"></rr-spacer>
-
-<!-- Container-responsive spacing -->
-<rr-spacer size="m" container="l"></rr-spacer>
 ```
-
-**Beschikbare sizes:** 2, 4, 6, 8, 12, 16, 20, 24, 32, 40, 44, 48, 64, 80, 96, m, flexible
-
-### Stap 4: Component Genereren/Updaten
-
-**Bestanden:**
-- Component: `src/components/{name}/rr-{name}.ts` (TypeScript)
-- Stories: `src/components/{name}/rr-{name}.stories.js` (JavaScript)
+src/components/{categorie}/{naam}/
+  ndd-{naam}.ts           # Component class
+  ndd-{naam}.styles.ts    # Styles
+  ndd-{naam}.template.ts  # Render template
+  ndd-{naam}.i18n.ts      # Vertalingen (optioneel, bij gebruikersgerichte tekst)
+  ndd-{naam}.stories.ts   # Storybook stories
+  ndd-{naam}.test.ts      # Tests
+```
 
 ---
 
-## COMPONENT TEMPLATE (Lit + TypeScript)
+## COMPONENT TEMPLATE
 
-**Locatie:** `src/components/{name}/rr-{name}.ts`
+**`ndd-{naam}.ts`:**
 
 ```typescript
 /**
- * RegelRecht {DisplayName} Component (Lit + TypeScript)
+ * Nederlandse Digitale Dienst {DisplayName} Component (Lit + TypeScript)
  *
- * @element rr-{name}
- * @attr {string} size - Component size: 'xs' | 'sm' | 'md' (default: 'md')
- * @attr {boolean} disabled - Disabled state
+ * @element ndd-{naam}
+ * @attr {string} size - Component size: 'xs' | 'sm' | 'md' (standaard: 'md')
+ * @attr {boolean} disabled - Uitgeschakelde staat
  *
- * @slot - Default slot for content
+ * @slot - Default slot voor content
  *
- * @fires {event-name} - Description of event (detail: { ... })
- *
- * @csspart {part-name} - Description of CSS part
+ * @fires {event-naam} - Beschrijving (detail: { ... })
  */
 
-import { LitElement, html, css } from 'lit';
+import { LitElement } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
+import { styles } from './ndd-{naam}.styles.ts';
+import { template } from './ndd-{naam}.template.ts';
 
 type Size = 'xs' | 'sm' | 'md';
 
-@customElement('rr-{name}')
-export class RR{PascalName} extends LitElement {
-  static override styles = css`
-    :host {
-      display: inline-block;
-      font-family: var(--rr-font-family-body);
-    }
+@customElement('ndd-{naam}')
+export class NDD{PascalName} extends LitElement {
+	static override styles = styles;
 
-    :host([hidden]) {
-      display: none;
-    }
+	@property({ type: String, reflect: true })
+	size: Size = 'md';
 
-    .{name} {
-      /* Reset */
-      appearance: none;
-      border: none;
-      margin: 0;
-      padding: 0;
-      background: none;
-      font: inherit;
-      cursor: pointer;
+	@property({ type: Boolean, reflect: true })
+	disabled = false;
 
-      /* Layout */
-      display: inline-flex;
-      align-items: center;
-      justify-content: center;
-
-      /* Animation */
-      transition: background-color 0.15s ease, color 0.15s ease, transform 0.1s ease;
-    }
-
-    .{name}:active:not(:disabled) {
-      transform: scale(0.98);
-    }
-
-    /* Size variants - ZOEK TOKENS OP in src/assets/styles/settings.css */
-    :host([size="xs"]) .{name} {
-      min-height: var(--semantics-controls-xs-min-size);
-      border-radius: var(--semantics-controls-xs-corner-radius);
-      /* padding en font: haal uit CSS variabelen */
-    }
-
-    :host([size="sm"]) .{name} {
-      min-height: var(--semantics-controls-sm-min-size);
-      border-radius: var(--semantics-controls-sm-corner-radius);
-    }
-
-    :host([size="md"]) .{name},
-    :host(:not([size])) .{name} {
-      min-height: var(--semantics-controls-md-min-size);
-      border-radius: var(--semantics-controls-md-corner-radius);
-    }
-
-    /* Focus state */
-    .{name}:focus-visible {
-      outline: var(--semantics-focus-ring-thickness) solid var(--semantics-focus-ring-color);
-      outline-offset: 2px;
-    }
-
-    /* Disabled state */
-    :host([disabled]) .{name} {
-      opacity: var(--primitives-opacity-disabled);
-      cursor: not-allowed;
-      pointer-events: none;
-    }
-
-    /* Accessibility: Reduced motion */
-    @media (prefers-reduced-motion: reduce) {
-      .{name} {
-        transition: none;
-      }
-    }
-
-    /* Accessibility: High Contrast Mode */
-    @media (forced-colors: active) {
-      .{name}:focus-visible {
-        outline: 2px solid CanvasText !important;
-        outline-offset: 2px !important;
-      }
-    }
-  `;
-
-  @property({ type: String, reflect: true })
-  size: Size = 'md';
-
-  @property({ type: Boolean, reflect: true })
-  disabled = false;
-
-  override render() {
-    return html`
-      <button
-        class="{name}"
-        part="{name}"
-        type="button"
-        ?disabled=${this.disabled}
-        aria-disabled=${this.disabled}
-        tabindex=${this.disabled ? -1 : 0}
-      >
-        <slot></slot>
-      </button>
-    `;
-  }
+	override render() {
+		return template(this);
+	}
 }
 
 declare global {
-  interface HTMLElementTagNameMap {
-    'rr-{name}': RR{PascalName};
-  }
+	interface HTMLElementTagNameMap {
+		'ndd-{naam}': NDD{PascalName};
+	}
+}
+```
+
+**`ndd-{naam}.styles.ts`:**
+
+```typescript
+import { css } from 'lit';
+import { unsafeCSS } from 'lit';
+import { breakpoints } from '../../../assets/styles/breakpoints.ts';
+
+const smMax = unsafeCSS(breakpoints.smMax);
+const mdMin = unsafeCSS(breakpoints.mdMin);
+const mdMax = unsafeCSS(breakpoints.mdMax);
+const lgMin = unsafeCSS(breakpoints.lgMin);
+
+export const styles = css`
+
+
+	/* # Host */
+
+	:host {
+		display: inline-block;
+	}
+
+	:host([hidden]) {
+		display: none;
+	}
+
+	:host([disabled]) {
+		opacity: var(--primitives-opacity-disabled);
+		pointer-events: none;
+	}
+
+
+	/* # Element */
+
+	.{naam} {
+		appearance: none;
+		border: none;
+		margin: 0;
+		padding: 0;
+		background: none;
+		font: inherit;
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		container-name: layout-area;
+		container-type: inline-size;
+	}
+
+	:host([size="md"]) .{naam},
+	:host(:not([size])) .{naam} {
+		min-height: var(--semantics-controls-md-min-size);
+		border-radius: var(--semantics-controls-md-corner-radius);
+	}
+
+
+	/* ## Responsive — container queries (binnen layout-area) */
+
+	.{naam}__content {
+		@container layout-area (max-width: ${smMax}) {
+			/* sm: compact weergave */
+		}
+
+		@container layout-area (min-width: ${mdMin}) and (max-width: ${mdMax}) {
+			/* md */
+		}
+
+		@container layout-area (min-width: ${lgMin}) {
+			/* lg */
+		}
+	}
+
+
+	/* # Focus */
+
+	.{naam}:focus-visible {
+		outline: none;
+	}
+
+	.{naam}__indicator {
+		position: absolute;
+		inset: var(--primitives-space-4);
+		border-radius: calc(var(--semantics-controls-md-corner-radius) - var(--primitives-space-4) / 2);
+		background-color: transparent;
+		pointer-events: none;
+	}
+
+	.{naam}:focus-visible .{naam}__indicator {
+		box-shadow: 0 0 0 var(--semantics-focus-ring-center-thickness) var(--semantics-focus-ring-center-color);
+		outline: var(--semantics-focus-ring-edge-thickness) double var(--semantics-focus-ring-edge-color);
+	}
+
+
+	/* # Toegankelijkheid */
+
+	@media (forced-colors: active) {
+		.{naam}:focus-visible .{naam}__indicator {
+			outline: 2px solid CanvasText;
+		}
+	}
+`;
+```
+
+**`ndd-{naam}.template.ts`:**
+
+```typescript
+import { html, TemplateResult } from 'lit';
+import type { NDD{PascalName} } from './ndd-{naam}.ts';
+
+export function template(component: NDD{PascalName}): TemplateResult {
+	return html`
+		<button class="{naam}"
+			type="button"
+			?disabled=${component.disabled}
+		>
+			<span class="{naam}__indicator"></span>
+			<slot></slot>
+		</button>
+	`;
 }
 ```
 
@@ -219,70 +248,96 @@ declare global {
 
 ## STORY TEMPLATE
 
-**Locatie:** `src/components/{name}/rr-{name}.stories.js`
+**`ndd-{naam}.stories.ts`:**
 
 ```javascript
 import { html } from 'lit';
-import './rr-{name}.js';
+import './ndd-{naam}.ts';
 
+/**
+ * Beschrijving van het component.
+ */
 export default {
-  title: 'Components/{DisplayName}',
-  component: 'rr-{name}',
-  tags: ['autodocs'],
-  argTypes: {
-    size: {
-      control: 'select',
-      options: ['xs', 'sm', 'md'],
-    },
-    disabled: {
-      control: 'boolean',
-    },
-  },
+	title: 'Components/{Categorie}/{DisplayName}',
+	component: 'ndd-{naam}',
+	tags: ['autodocs'],
+	parameters: {
+		componentSource: {
+			file: 'src/components/{categorie}/{naam}/ndd-{naam}.ts',
+			repository: 'https://github.com/MinBZK/storybook',
+		},
+		status: { type: 'stable' },
+	},
+	argTypes: {
+		size: {
+			control: 'select',
+			options: ['xs', 'sm', 'md'],
+			description: 'Componentmaat',
+		},
+		disabled: {
+			control: 'boolean',
+			description: 'Uitgeschakelde staat',
+		},
+	},
+	args: {
+		size: 'md',
+		disabled: false,
+	},
 };
 
-export const Default = {
-  args: { size: 'md', disabled: false },
-  render: (args) => html`<rr-{name} size=${args.size} ?disabled=${args.disabled}>Label</rr-{name}>`,
+export const Standaard = {
+	render: (args) => html`<ndd-{naam} size=${args.size} ?disabled=${args.disabled}>Label</ndd-{naam}>`,
 };
 ```
 
 ---
 
-## EXPORTS UPDATEN (alleen bij CREATE mode)
+## TEST TEMPLATE
 
-**Bestand:** `src/components/index.ts`
+**`ndd-{naam}.test.ts`:**
 
 ```typescript
-export { RR{PascalName} } from './{name}/rr-{name}.js';
+import { describe, it, expect, afterEach } from 'vitest';
+import { fixture, cleanup, waitForUpdate } from '../../../test-utils.ts';
+import './ndd-{naam}.ts';
+
+describe('ndd-{naam}', () => {
+	let el: HTMLElement;
+
+	afterEach(() => {
+		if (el) cleanup(el);
+	});
+
+	it('rendert zonder fouten', async () => {
+		el = await fixture('<ndd-{naam}></ndd-{naam}>');
+		await waitForUpdate(el);
+		expect(el.shadowRoot).not.toBeNull();
+	});
+});
 ```
 
 ---
 
-## COMPONENT-MAP UPDATEN
+## i18n
 
-**Bestand:** `docs/component-map.json`
-
-Voeg nieuwe entry toe of update bestaande met `lastUpdated`.
+Zie `/translation-keys` skill voor alle conventies rond translation keys, types en implementatie.
 
 ---
 
-## TOKENS OPZOEKEN
+## SPACER COMPONENT
 
-**Zoek ALTIJD actuele token waarden op in `src/assets/styles/settings.css`:**
+Gebruik `<ndd-spacer>` voor ruimte tussen verschillende soorten componenten die elkaar direct opvolgen:
 
-```bash
-grep -i "{component-naam}" src/assets/styles/settings.css
-grep -i "controls.*min-size\|controls.*corner-radius" src/assets/styles/settings.css
-grep -i "focus-ring" src/assets/styles/settings.css
-grep -i "primitives-space" src/assets/styles/settings.css
-grep -i "opacity" src/assets/styles/settings.css
+```html
+<ndd-spacer size="32"></ndd-spacer>
+<ndd-spacer size="flexible"></ndd-spacer>
 ```
 
-**LET OP:** Opacity tokens zijn decimale fracties (0-1). Gebruik: `var(--token)`
+**Beschikbare sizes:** 2, 4, 6, 8, 12, 16, 20, 24, 32, 40, 44, 48, 64, 80, 96, m, flexible
 
 ---
 
-## FORMATTING REGELS
+## FORMATTING
 
 Er is geen automatische formatter. Volg deze regels handmatig.
 
@@ -297,32 +352,19 @@ Er is geen automatische formatter. Volg deze regels handmatig.
 ```html
 <!-- GOED -->
 <input class="checkbox__input" type="checkbox">
-<hr class="divider">
 
-<!-- FOUT — geen XHTML self-closing -->
+<!-- FOUT -->
 <input class="checkbox__input" type="checkbox" />
-<hr class="divider" />
 ```
 
-### CSS (`.styles.ts` en `.css`)
+### CSS (`.styles.ts`)
 - Property waarden altijd op **één regel**, ook als ze lang zijn
 - Sorteer rules per element; houd alle gedrag voor een element bij elkaar
-- Gebruik **CSS nesting** voor `@container` en `@media` varianten — nest ze in de element rule block
+- Gebruik **CSS nesting** voor `@container` en `@media` — nest in de element rule block
 - Declareer CSS variable defaults in `:host`, nooit als fallback: `var(--_foo)` niet `var(--_foo, 100)`
-- Gebruik **nooit** flex shorthand (`flex: 1`), schrijf altijd de losse properties
+- Gebruik **nooit** flex shorthand (`flex: 1`), schrijf de losse properties
 - Level 1 headings (`/* # Section */`): 2 lege regels ervoor, 1 erna
 - Level 2 headings (`/* ## Subsection */`): 1 lege regel ervoor en erna
-- BEM voor blocks/elements; gebruik state classes (`.is-dragging`) niet BEM modifiers voor state
-
-```css
-/* GOED */
-outline: var(--semantics-focus-ring-edge-thickness) double var(--semantics-focus-ring-edge-color);
-box-shadow: 0 0 0 var(--semantics-focus-ring-center-thickness) var(--semantics-focus-ring-center-color);
-
-/* FOUT — niet afbreken */
-outline: var(--semantics-focus-ring-edge-thickness) double
-	var(--semantics-focus-ring-edge-color);
-```
 
 ```css
 /* GOED — CSS nesting */
@@ -336,13 +378,9 @@ outline: var(--semantics-focus-ring-edge-thickness) double
 }
 
 /* FOUT — niet nesten */
-.button {
-	display: inline-flex;
-}
+.button { display: inline-flex; }
 @container (min-width: 641px) {
-	.button {
-		padding: var(--_md-padding);
-	}
+	.button { padding: var(--_md-padding); }
 }
 ```
 
@@ -361,31 +399,15 @@ outline: var(--semantics-focus-ring-edge-thickness) double
 }
 ```
 
-```css
-/* GOED — state class */
-.list-item.is-dragging { opacity: 0.5; }
-
-/* FOUT — BEM modifier voor state */
-.list-item--dragging { opacity: 0.5; }
-```
-
-```css
-/* GOED — geen flex shorthand */
-flex-grow: 1;
-flex-shrink: 0;
-
-/* FOUT */
-flex: 1 0 auto;
-```
-
 ### Templates (`.template.ts`)
-- `class` attribuut op **dezelfde regel** als het element
-- Elementen met één attribuut (naast `class`) blijven op één regel
-- `<slot>` elementen zijn altijd compact
-- **Nooit een class op een child component** — gebruik altijd een wrapper element vanuit het parent:
-- Alle overige attributen op **eigen regels**:
+- Elk attribuut op een **eigen regel**, met twee uitzonderingen:
+  - `class` staat altijd op **dezelfde regel** als het element
+  - Een element met **één enkel attribuut** mag op één regel
+- **Nooit een class op een child component** — gebruik een wrapper element
+- Geen lege regels in templates
+
 ```html
-<!-- GOED — meerdere attributen -->
+<!-- GOED — class + meerdere attributen -->
 <input class="checkbox__input"
 	type="checkbox"
 	.checked=${component.checked}
@@ -393,19 +415,20 @@ flex: 1 0 auto;
 	@change=${component._handleChange}
 >
 
-<!-- GOED — één attribuut naast class, past op één regel -->
-<div class="checkbox__box" aria-hidden="true">
+<!-- GOED — class + één attribuut: attribuut op eigen regel -->
+<div class="checkbox__box"
+	aria-hidden="true"
+>
 
-<!-- GOED — slot is altijd compact -->
-<slot></slot>
+<!-- GOED — één attribuut zonder class: op één regel -->
 <slot name="header"></slot>
 
-<!-- GOED — child component in wrapper voor styling -->
+<!-- GOED — child component in wrapper -->
 <span class="checkbox__icon">
 	<ndd-icon name="check-mark-small"></ndd-icon>
 </span>
 
-<!-- FOUT — class direct op child component -->
+<!-- FOUT — class op child component -->
 <ndd-icon class="checkbox__icon" name="check-mark-small"></ndd-icon>
 
 <!-- FOUT — class op aparte regel -->
@@ -415,28 +438,47 @@ flex: 1 0 auto;
 >
 ```
 
-### Stories (`.stories.ts` en `.stories.js`)
-- Alle attributen van een element op **één regel**:
-```html
-<!-- GOED -->
-<ndd-button variant="primary" size="md" text="Opslaan" ?disabled=${args.disabled}></ndd-button>
+### Stories (`.stories.ts`)
+- Zelfde formatting conventies als templates
 
-<!-- FOUT — niet opsplitsen in stories -->
-<ndd-button
-	variant="primary"
-	size="md"
-	text="Opslaan"
-></ndd-button>
+---
+
+## BEM NAAMGEVING
+
+Gebruik BEM (Block Element Modifier) + state classes:
+
+```
+.block                    /* Zelfstandig component */
+.block__element           /* Onderdeel van block */
+.block--modifier          /* Variant van block */
+```
+
+- Block: logische naam (`.pagination`, `.checkbox`, `.button`)
+- Element: na dubbele underscore `__` (`.pagination__page-button`)
+- Modifier: na dubbele hyphen `--` (`.button--primary`)
+- Geen nesting: niet `.block__element__subelement`
+- Modifiers zijn aanvullend, nooit vervanging van base class
+
+**Varianten vs states:**
+- **BEM modifiers** voor varianten (vast): `button--primary`, `button--sm`
+- **State classes** voor wisselende toestanden: `list-item.is-dragging`, `page-button.is-current`
+
+```html
+<button class="button button--primary">
+<div class="list-item is-dragging">
+<button class="pagination__page-button is-current">
 ```
 
 ---
 
 ## CHECKLIST
 
-**Tokens:**
-- [ ] Semantics tokens waar mogelijk
-- [ ] Geen fallback waarden op CSS variabelen (enige uitzondering: override hooks `--rr-*`)
-- [ ] Opacity: `var(--token)`
+**CSS:**
+- [ ] Components → semantics → primitives volgorde
+- [ ] Geen fallback waarden
+- [ ] Geen hardcoded waarden, geen !important
+- [ ] Geen `cursor: pointer`
+- [ ] Disabled: `var(--primitives-opacity-disabled)`
 
 **Accessibility:**
 - [ ] ARIA attributes
@@ -444,10 +486,18 @@ flex: 1 0 auto;
 - [ ] `@media (prefers-reduced-motion)`
 - [ ] `@media (forced-colors: active)`
 
-**Code:**
+**TypeScript:**
 - [ ] TypeScript types correct
 - [ ] `declare global` block
 - [ ] Private methods met underscore
+- [ ] Geen inline styles of templates in de component class
+
+**Taal:**
+- [ ] Story namen, JSDoc en component docs in het Nederlands
+- [ ] Code comments in het Engels
+
+**Shadow DOM:**
+- [ ] Geen `part` attributen op shadow DOM elementen
 
 **Verificatie:**
 - [ ] Storybook gestart

--- a/.claude/skills/component/SKILL.md
+++ b/.claude/skills/component/SKILL.md
@@ -382,6 +382,7 @@ flex: 1 0 auto;
 - `class` attribuut op **dezelfde regel** als het element
 - Elementen met één attribuut (naast `class`) blijven op één regel
 - `<slot>` elementen zijn altijd compact
+- **Nooit een class op een child component** — gebruik altijd een wrapper element vanuit het parent:
 - Alle overige attributen op **eigen regels**:
 ```html
 <!-- GOED — meerdere attributen -->
@@ -399,7 +400,12 @@ flex: 1 0 auto;
 <slot></slot>
 <slot name="header"></slot>
 
-<!-- GOED — kort element -->
+<!-- GOED — child component in wrapper voor styling -->
+<span class="checkbox__icon">
+	<ndd-icon name="check-mark-small"></ndd-icon>
+</span>
+
+<!-- FOUT — class direct op child component -->
 <ndd-icon class="checkbox__icon" name="check-mark-small"></ndd-icon>
 
 <!-- FOUT — class op aparte regel -->

--- a/.claude/skills/translation-keys/SKILL.md
+++ b/.claude/skills/translation-keys/SKILL.md
@@ -1,0 +1,192 @@
+---
+name: translation-keys
+description: Conventies voor translation keys (i18n microcopy)
+user-invocable: true
+argument-hint: <component-naam>
+---
+
+Maak of controleer translation keys voor: $ARGUMENTS
+
+## Wat is microcopy?
+
+Woorden of zinnen in de interface die direct gerelateerd zijn aan gebruikersacties:
+- De motivatie vóór de actie
+- Instructies die de actie begeleiden
+- De feedback nadat de gebruiker de actie heeft uitgevoerd
+
+## Basisregels
+
+- **Taal:** Nederlands (standaard), te overschrijven door consumer via `translations` property
+- **Segmenten** gescheiden door punten (`.`)
+- **Woorden** binnen een segment gescheiden door koppeltekens (`-`)
+- **Placeholders** met enkele accolades: `{placeholder}`
+
+## Organisatie van keys
+
+### `general.*` — generieke vertalingen
+
+Stabiele termen die over componenten heen gelden, als een woordenboek.
+
+```
+general.edit-action: Bewerk
+general.optional-lowercase: optioneel
+```
+
+### `components.{naam}.*` — component-specifieke vertalingen
+
+Keys gebonden aan herbruikbare UI-componenten.
+
+```
+components.list.drag-grabbed-text: Item opgepakt
+components.toolbar.overflow-action: Meer
+```
+
+## Types (suffix van de key)
+
+Elk key eindigt met een type dat aangeeft hoe de tekst geschreven moet worden.
+
+### `-lowercase`, `-capitalize`
+
+Voor exacte vertalingen van een enkel woord of vaste woordcombinatie.
+
+```
+general.amount-capitalize: Bedrag
+general.amount-lowercase: bedrag
+```
+
+> Voor uppercase weergave: gebruik CSS `text-transform`. Maak geen `-uppercase` keys.
+
+### `-title`
+
+Kort en bondig. Taal-specifiek hoofdlettergebruik (Nederlands: alleen eerste letter).
+
+```
+components.modal-dialog.title: Modal dialoog
+```
+
+### `-text`
+
+Altijd in zinsopbouw (sentence case).
+
+```
+components.list.drag-grabbed-text: Item opgepakt. Gebruik de pijltjestoetsen om te verplaatsen.
+```
+
+### `-label`
+
+Korte tekst die iets beschrijft of aanduidt, zoals een form label, aria label of andere aanduiding. Kort als een titel, sentence case, geen punt.
+
+```
+general.email-label: E-mailadres
+components.pagination.accessibility-label: Paginering
+```
+
+### `-supporting-label`
+
+Korte ondersteuning naast een label, zonder opmaak.
+
+```
+my-website.my-form.email-supporting-label: We sturen enkel een bevestiging.
+```
+
+### `-error-text`
+
+Foutmelding na validatie. Alleen zichtbaar bij een fout.
+
+```
+my-website.my-form.email-is-empty-error-text: Vul een e-mailadres in.
+```
+
+### `-help-text`
+
+Langere hulptekst, kan links of rijkere content bevatten.
+
+```
+my-website.my-form.email-help-text: U ontvangt een bevestiging per e-mail. Lees onze <a href="/privacy">Privacybeleid</a>.
+```
+
+### `-action`
+
+Voor knoppen, links en andere acties.
+
+**Directe acties:** gebruik de gebiedende wijs (imperatief).
+```
+general.save-action: Bewaar
+general.delete-action: Verwijder
+components.pagination.previous-action: Vorige pagina
+```
+
+**Indirecte acties** (verwijzing naar een pagina/formulier): gebruik de infinitief in het Nederlands.
+```
+general.to-save-action: Bewaren
+general.to-login-action: Inloggen
+```
+
+### `-file-name`
+
+Bestandsnamen zonder extensie (die voegt de backend toe).
+
+```
+general.general-conditions-file-name: algemene-voorwaarden
+```
+
+### `short-` prefix
+
+Voeg `short-` toe vóór het type voor afkortingen.
+
+```
+general.mister-short-label: Dhr.
+general.friday-short-capitalize: Vr.
+```
+
+## Bestandsstructuur
+
+```typescript
+// ndd-{naam}.i18n.ts
+export const ndd{PascalName}Translations = {
+	'components.{naam}.label-text': 'Label',
+	'components.{naam}.previous-action': 'Vorige',
+};
+
+export type NDD{PascalName}Translations = typeof ndd{PascalName}Translations;
+```
+
+## Implementatie in component
+
+```typescript
+import { ndd{PascalName}Translations } from './ndd-{naam}.i18n.ts';
+import type { NDD{PascalName}Translations } from './ndd-{naam}.i18n.ts';
+
+// Property voor consumer override
+@property({ type: Object })
+translations: Partial<NDD{PascalName}Translations> = {};
+
+private _mergedTranslations = { ...ndd{PascalName}Translations };
+
+// Merge in willUpdate (vóór render)
+override willUpdate(changed: PropertyValues): void {
+	if (changed.has('translations')) {
+		this._mergedTranslations = { ...ndd{PascalName}Translations, ...this.translations };
+	}
+}
+
+// Helper
+_t(key: keyof NDD{PascalName}Translations, params?: Record<string, string | number>): string {
+	let text = this._mergedTranslations[key] ?? key;
+	if (params) {
+		for (const [k, v] of Object.entries(params)) {
+			text = text.replace(`{${k}}`, String(v));
+		}
+	}
+	return text;
+}
+```
+
+## Checklist
+
+- [ ] Keys volgen de `components.{naam}.*` conventie
+- [ ] Elk key eindigt met het juiste type suffix
+- [ ] Directe acties in gebiedende wijs
+- [ ] Placeholders met `{naam}` syntax
+- [ ] Consumer kan overschrijven via `translations` property
+- [ ] `willUpdate` gebruikt (niet `updated`)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -228,7 +228,7 @@ Geen automatische formatter. Handmatige regels:
 - **HTML:** gebruik `>` niet `/>` (HTML, geen XHTML)
 - **CSS:** property waarden altijd op één regel, CSS nesting voor @container/@media, defaults in `:host` niet als fallback, geen flex shorthand, state classes (`.is-dragging`) ipv BEM modifiers
 - **CSS headings:** Level 1 (`/* # */`): 2 lege regels ervoor, 1 erna. Level 2 (`/* ## */`): 1 lege regel ervoor en erna
-- **Templates:** `class` op dezelfde regel als element, elementen met 1 attribuut op één regel, `<slot>` altijd compact, overige attributen op eigen regels
+- **Templates:** `class` op dezelfde regel als element, elementen met 1 attribuut op één regel, `<slot>` altijd compact, overige attributen op eigen regels, nooit een class op een child component (gebruik een wrapper element)
 - **Stories:** alle attributen van een element op één regel
 
 Zie `/component` skill voor volledige formatting voorbeelden.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,23 +1,23 @@
-# Nederlandse Digitale Dienst Design System
+# NDD Design System
 
-Vanilla Web Components for Dutch Government (Rijksoverheid) apps. Single source of truth: **Storybook**.
+Web Components voor de Nederlandse Digitale Dienst (Rijksoverheid).
 
-## Quick Reference
+## Snelreferentie
 
 ```bash
-npm run storybook        # Dev server at localhost:6006
-npm run build:styles     # Copy CSS + fonts to dist
-npm run build            # Full build
+npm run storybook        # Dev server op localhost:6006
+npm run build:styles     # Kopieer CSS + fonts naar dist
+npm run build            # Volledige build
 ```
 
-## Development Workflow
+## Ontwikkelworkflow
 
 **Gebruik ALTIJD deze skills voor de juiste workflow:**
 
 | Taak | Skill | Beschrijving |
 |------|-------|--------------|
 | Nieuwe branch starten | `/worktree <branch>` | Maakt worktree + kopieert .env en .claude/ |
-| Component maken/updaten | `/component <naam>` | Genereert Lit+TS component |
+| Component maken/updaten | `/component <naam>` | Alle regels, formatting, BEM, CSS, templates |
 | Storybook beheren | `/storybook-manager` | Start/stop/status van Storybook instances |
 
 **Typische flow voor nieuwe feature:**
@@ -26,218 +26,69 @@ npm run build            # Full build
 /component my-component
 ```
 
-## Gotchas
-
-**Asymmetric Padding:** Components may use different top/bottom padding. Check design specs for each value:
-```css
-/* Button sm-size: top=8, right=8, bottom=6, left=8 */
-padding: 8px 8px 6px 8px;  /* NOT symmetric! */
-```
-
-**Disabled Opacity:** Always use `var(--primitives-opacity-disabled)` - the token is a decimal fraction (0.38).
-
-**Subpixel Font Drift:** Expect ~0.4px cumulative drift per text element due to font rendering differences. This is inherent and not fixable.
-
-## Token Hierarchy
+## Componentstructuur
 
 ```
-Primitives (--primitives-*)  →  base values (colors, space)
-Semantics (--semantics-*)    →  meaningful (buttons, controls)
-Components (--components-*)  →  component-specific
+src/components/{categorie}/{naam}/
+  ndd-{naam}.ts           # Lit + TypeScript component
+  ndd-{naam}.styles.ts    # Component styles
+  ndd-{naam}.template.ts  # Render template
+  ndd-{naam}.i18n.ts      # Vertalingen (optioneel)
+  ndd-{naam}.stories.ts   # Storybook stories
+  ndd-{naam}.test.ts      # Unit tests
 ```
 
-Always prefer semantic tokens. Only use primitives when no semantic exists.
+## CSS Variabelen
 
-## Component Structure
+### Structuur
 
-```
-src/components/{category}/{name}/
-  ndd-{name}.ts           # Lit + TypeScript component
-  ndd-{name}.styles.ts    # Component styles
-  ndd-{name}.template.ts  # Render template
-  ndd-{name}.stories.ts   # Storybook stories
-  ndd-{name}.test.ts      # Unit tests
-```
+| Laag | Prefix | Beschrijving |
+|------|--------|--------------|
+| **Primitives** | `--primitives-*` | Basiswaarden (kleuren, spacing, typografie) |
+| **Semantics** | `--semantics-*` | Betekenisvolle variabelen (buttons, controls, surfaces) |
+| **Components** | `--components-*` | Component-specifieke variabelen |
+| **Context** | `--context-*` | Gedeelde variabelen voor communicatie tussen componenten |
+| **Lokaal** | `--_*` | Interne variabelen binnen een component (niet voor extern gebruik) |
 
-## Components Maken/Updaten
+Voorkeursvolgorde: components → semantics → primitives.
 
-Gebruik `/component <naam>` voor het maken of updaten van componenten. Dit command:
-- Genereert Lit + TypeScript component
-- Maakt Storybook stories
+### Validatie
 
-## Button Sizes
+CSS variabelen worden gevalideerd tijdens de build (`npm run validate:styles`):
 
-| Size | Min Height | Padding | Gap | Border-radius |
-|------|------------|---------|-----|---------------|
-| xs | 24px | 4px 6px | 2px | 4px |
-| sm | 32px | 6px 8px | 2px | 6px |
-| md | 44px | 12px | 4px | 8px |
+- `--context-*` — Niet gevalideerd, niet in settings.css
+- `--_*` — Gevalideerd binnen hetzelfde bestand
+- `--primitives-*`, `--semantics-*`, `--components-*` — Gevalideerd tegen settings.css
 
-## Key Tokens
+Geen fallbacks. CI faalt als variabelen ontbreken.
 
-```css
-/* Controls */
---semantics-controls-xs-min-size: 24px
---semantics-controls-sm-min-size: 32px
---semantics-controls-md-min-size: 44px
---semantics-controls-{xs|sm|md}-corner-radius
-
-/* Focus */
---semantics-focus-ring-center-thickness: 2px
---semantics-focus-ring-center-color: #0f172a
---semantics-focus-ring-edge-thickness: 2px
---semantics-focus-ring-edge-color: #ffffff
-
-/* Buttons */
---semantics-buttons-accent-filled-background-color
---semantics-buttons-accent-filled-color
-
-/* Components */
---semantics-buttons-{xs|sm|md}-font
---components-checkbox-*
---components-radio-button-*
---components-switch-*
---components-toggle-button-*
---components-menu-bar-*
-```
-
-## Component Testing
+## Testen
 
 Elk component MOET minimaal een **smoke test** hebben. Run tests met `npm test`.
 
-**Minimale vereisten:**
 1. **Smoke test** (verplicht): rendert zonder errors, heeft een shadowRoot
-2. **Logic tests** (verplicht bij complexe logica): test MutationObservers, slot management, attribuut propagatie, event handlers, state transitions
-
-**Test bestand:** `src/components/{category}/{name}/ndd-{name}.test.ts`
-
-**Smoke test patroon:**
-```typescript
-import { describe, it, expect, afterEach } from 'vitest';
-import { fixture, cleanup, waitForUpdate } from '../../../test-utils.ts';
-import './ndd-{name}.ts';
-
-describe('ndd-{name}', () => {
-  let el: HTMLElement;
-
-  afterEach(() => {
-	if (el) cleanup(el);
-  });
-
-  it('renders without error', async () => {
-	el = await fixture('<ndd-{name}></ndd-{name}>');
-	await waitForUpdate(el);
-
-	expect(el.shadowRoot).not.toBeNull();
-  });
-});
-```
+2. **Logica tests** (verplicht bij complexe logica): test MutationObservers, slot management, attribuut propagatie, event handlers, state transitions
 
 **Test helpers** (`src/test-utils.ts`):
 - `fixture<T>(html)` — maakt DOM element, wacht op Lit updateComplete
 - `cleanup(el)` — verwijdert fixture wrapper uit DOM (gebruik in afterEach)
 - `waitForUpdate(el)` — wacht op MutationObserver + Lit re-render cycle
 
-## Code Quality
+## Codekwaliteit
 
 - Pre-commit hooks: ESLint, commitlint
-- Conventional commits: `feat(button): add variant`, `fix(checkbox): focus ring`
-- No hardcoded values, no !important, no frameworks
+- Conventionele commits: `feat(button): add variant`, `fix(checkbox): focus ring`
 
-## Package Versioning
+## Pakketversies
 
-Versions are **automatically** bumped by semantic-release on merge to main.
+Versies worden **automatisch** verhoogd door semantic-release bij merge naar main.
 
-| Commit Type | Version Bump |
-|-------------|--------------|
+| Commit type | Versieverhoging |
+|-------------|-----------------|
 | `feat:` | Patch (0.5.0 → 0.5.1) |
 | `fix:`, `perf:` | Patch (0.5.0 → 0.5.1) |
-| `feat!:` or `BREAKING CHANGE:` | Patch (0.5.0 → 0.5.1) |
-| `docs:`, `chore:`, `ci:`, etc. | No bump |
-| Unrecognized (no conventional prefix) | Patch (treated as feat) |
+| `feat!:` of `BREAKING CHANGE:` | Patch (0.5.0 → 0.5.1) |
+| `docs:`, `chore:`, `ci:`, etc. | Geen |
+| Niet-herkend (geen conventionele prefix) | Patch (behandeld als feat) |
 
-**Manual version bumping is not needed.** Use conventional commits and CI handles the rest.
-
-## BEM Naamgeving
-
-Gebruik BEM (Block Element Modifier) voor alle class namen in HTML/CSS:
-
-```
-.block                    /* Standalone component */
-.block__element           /* Onderdeel van block */
-.block--modifier          /* Variant of state van block */
-.block__element--modifier /* Variant van element */
-```
-
-**Voorbeelden:**
-
-```html
-<!-- Block -->
-<button class="button">
-
-<!-- Block met modifier -->
-<button class="button button--primary">
-<button class="button button--sm">
-
-<!-- Element binnen block -->
-<button class="button">
-  <span class="button__icon"></span>
-  <span class="button__label">Tekst</span>
-</button>
-
-<!-- Element met modifier -->
-<span class="button__icon button__icon--large"></span>
-```
-
-**Regels:**
-- Block: `ndd-{naam}` of simpelweg de component naam
-- Element: dubbele underscore `__`
-- Modifier: dubbele hyphen `--`
-- Geen nesting van blocks binnen element namen (niet: `block__element__subelement`)
-- Modifiers zijn altijd aanvullend, nooit vervanging van base class
-
-## CSS Variable Validation
-
-CSS variabelen worden gevalideerd tijdens de build (`npm run validate:styles`):
-
-**Token categorieën:**
-- `--context-*` - Context hooks voor consumers (niet gevalideerd, niet in settings.css)
-- `--_*` - Interne variabelen (gevalideerd binnen hetzelfde bestand)
-- `--primitives-*`, `--semantics-*`, `--components-*` - CSS variabelen (gevalideerd tegen settings.css)
-
-**Stricte aanpak - GEEN fallbacks:**
-```css
-/* FOUT */
-min-height: var(--semantics-controls-md-min-size, 44px);
-
-/* GOED */
-min-height: var(--semantics-controls-md-min-size);
-```
-
-**Uitzonderingen (behoud fallbacks):**
-- Override hooks: `var(--ndd-button-background-color, var(--_bg-color))`
-- Font-family: `var(--ndd-font-family-sans, 'RijksSansVF', system-ui, sans-serif)`
-
-CI faalt als tokens ontbreken. Dit dwingt af dat alle tokens gedefinieerd zijn in `src/assets/styles/settings.css`.
-
-## Formatting
-
-Geen automatische formatter. Handmatige regels:
-
-- **Tabs** voor indentatie, enkele aanhalingstekens, puntkomma's
-- **HTML:** gebruik `>` niet `/>` (HTML, geen XHTML)
-- **CSS:** property waarden altijd op één regel, CSS nesting voor @container/@media, defaults in `:host` niet als fallback, geen flex shorthand, state classes (`.is-dragging`) ipv BEM modifiers
-- **CSS headings:** Level 1 (`/* # */`): 2 lege regels ervoor, 1 erna. Level 2 (`/* ## */`): 1 lege regel ervoor en erna
-- **Templates:** `class` op dezelfde regel als element, elementen met 1 attribuut op één regel, `<slot>` altijd compact, overige attributen op eigen regels, nooit een class op een child component (gebruik een wrapper element)
-- **Stories:** alle attributen van een element op één regel
-
-Zie `/component` skill voor volledige formatting voorbeelden.
-
-## Rules
-
-1. Extend `LitElement`
-2. Use Shadow DOM
-3. Only CSS variabelen - never hardcode
-4. DigiToegankelijk (WCAG 2.1 AA) compliant
-5. RijksSansVF font with system-ui fallback
-6. BEM naamgeving voor alle class namen
+**Handmatig versie verhogen is niet nodig.** Gebruik conventionele commits en CI doet de rest.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,7 +93,7 @@ Gebruik `/component <naam>` voor het maken of updaten van componenten. Dit comma
 --semantics-buttons-accent-filled-color
 
 /* Components */
---components-button-{xs|sm|md}-font
+--semantics-buttons-{xs|sm|md}-font
 --components-checkbox-*
 --components-radio-button-*
 --components-switch-*

--- a/src/components/navigation/pagination/ndd-pagination.i18n.ts
+++ b/src/components/navigation/pagination/ndd-pagination.i18n.ts
@@ -3,7 +3,7 @@ export const nddPaginationTranslations = {
 	'components.pagination.previous-action': 'Vorige pagina',
 	'components.pagination.next-action': 'Volgende pagina',
 	'components.pagination.page-number-text': 'Pagina {page}',
-	'components.pagination.page-of-total-text': 'Pagina {page} van {total}',
+	'components.pagination.go-to-page-action': 'Ga naar pagina',
 };
 
 export type NDDPaginationTranslations = typeof nddPaginationTranslations;

--- a/src/components/navigation/pagination/ndd-pagination.i18n.ts
+++ b/src/components/navigation/pagination/ndd-pagination.i18n.ts
@@ -1,9 +1,9 @@
 export const nddPaginationTranslations = {
-	'components.pagination.label-text': 'Paginering',
-	'components.pagination.previous-action': 'Vorige pagina',
-	'components.pagination.next-action': 'Volgende pagina',
-	'components.pagination.page-number-text': 'Pagina {page}',
-	'components.pagination.go-to-page-action': 'Ga naar pagina',
+	'components.pagination.accessibility-label': 'Paginering',
+	'components.pagination.previous-action': 'Ga naar vorige pagina',
+	'components.pagination.next-action': 'Ga naar volgende pagina',
+	'components.pagination.page-action': 'Ga naar pagina {page}',
+	'components.pagination.go-to-page-label': 'Ga naar pagina',
 };
 
 export type NDDPaginationTranslations = typeof nddPaginationTranslations;

--- a/src/components/navigation/pagination/ndd-pagination.i18n.ts
+++ b/src/components/navigation/pagination/ndd-pagination.i18n.ts
@@ -1,0 +1,9 @@
+export const nddPaginationTranslations = {
+	'components.pagination.label-text': 'Paginering',
+	'components.pagination.previous-action': 'Vorige pagina',
+	'components.pagination.next-action': 'Volgende pagina',
+	'components.pagination.page-number-text': 'Pagina {page}',
+	'components.pagination.page-of-total-text': 'Pagina {page} van {total}',
+};
+
+export type NDDPaginationTranslations = typeof nddPaginationTranslations;

--- a/src/components/navigation/pagination/ndd-pagination.stories.js
+++ b/src/components/navigation/pagination/ndd-pagination.stories.js
@@ -57,7 +57,12 @@ export default {
 };
 
 const Template = ({ current, total, disabled, fullWidth }) => html`
-	<ndd-pagination current=${current} total=${total} ?disabled=${disabled} ?full-width=${fullWidth}></ndd-pagination>
+	<ndd-pagination
+		current=${current}
+		total=${total}
+		?disabled=${disabled}
+		?full-width=${fullWidth}
+	></ndd-pagination>
 `;
 
 export const Standaard = Template.bind({});

--- a/src/components/navigation/pagination/ndd-pagination.stories.js
+++ b/src/components/navigation/pagination/ndd-pagination.stories.js
@@ -7,6 +7,9 @@ import './ndd-pagination.ts';
  * ## Gebruik
  * ```html
  * <ndd-pagination current="1" total="10"></ndd-pagination>
+ *
+ * <!-- Met links in plaats van buttons -->
+ * <ndd-pagination current="1" total="10" href-pattern="/resultaten?pagina={page}"></ndd-pagination>
  * ```
  */
 export default {
@@ -68,3 +71,15 @@ WeinigPaginas.args = { current: 2, total: 3 };
 
 export const Uitgeschakeld = Template.bind({});
 Uitgeschakeld.args = { current: 3, total: 10, disabled: true };
+
+export const MetLinks = () => html`
+	<ndd-pagination current="3" total="10" href-pattern="/resultaten?pagina={page}"></ndd-pagination>
+`;
+MetLinks.parameters = {
+	controls: { disable: true },
+	docs: {
+		description: {
+			story: 'Met <code>href-pattern</code> worden pagina-knoppen als links gerenderd in plaats van buttons. Beter voor SEO en bookmarkbare pagina\'s.',
+		},
+	},
+};

--- a/src/components/navigation/pagination/ndd-pagination.stories.js
+++ b/src/components/navigation/pagination/ndd-pagination.stories.js
@@ -6,7 +6,7 @@ import './ndd-pagination.ts';
  *
  * ## Gebruik
  * ```html
- * <ndd-pagination current-page="1" total-pages="10"></ndd-pagination>
+ * <ndd-pagination current="1" total="10"></ndd-pagination>
  * ```
  */
 export default {
@@ -23,53 +23,48 @@ export default {
 		},
 	},
 	argTypes: {
-		currentPage: {
+		current: {
 			control: { type: 'number', min: 1 },
-			description: 'Currently active page (1-based)',
-			table: {
-				defaultValue: { summary: 1 },
-			},
+			description: 'Huidige actieve pagina (1-gebaseerd)',
+			table: { defaultValue: { summary: 1 } },
 		},
-		totalPages: {
+		total: {
 			control: { type: 'number', min: 1 },
-			description: 'Total number of pages',
-			table: {
-				defaultValue: { summary: 1 },
-			},
+			description: 'Totaal aantal pagina\'s',
+			table: { defaultValue: { summary: 1 } },
 		},
 		disabled: {
 			control: 'boolean',
-			description: 'Disabled state',
-			table: {
-				defaultValue: { summary: false },
-			},
+			description: 'Uitgeschakelde staat',
+			table: { defaultValue: { summary: false } },
+		},
+		fullWidth: {
+			control: 'boolean',
+			name: 'full-width',
+			description: 'Centreert de pagination in de container',
+			table: { defaultValue: { summary: false } },
 		},
 	},
 	args: {
-		currentPage: 1,
-		totalPages: 10,
+		current: 1,
+		total: 10,
 		disabled: false,
+		fullWidth: false,
 	},
 };
 
-const Template = ({ currentPage, totalPages, disabled }) => html`
-	<ndd-pagination
-		current-page=${currentPage}
-		total-pages=${totalPages}
-		?disabled=${disabled}
-	></ndd-pagination>
+const Template = ({ current, total, disabled, fullWidth }) => html`
+	<ndd-pagination current=${current} total=${total} ?disabled=${disabled} ?full-width=${fullWidth}></ndd-pagination>
 `;
 
-// Primary story
-export const Default = Template.bind({});
-Default.args = {
-	currentPage: 1,
-	totalPages: 10,
-};
+export const Standaard = Template.bind({});
+Standaard.args = { current: 1, total: 10 };
 
-// Many pages
-export const ManyPages = Template.bind({});
-ManyPages.args = {
-	currentPage: 25,
-	totalPages: 100,
-};
+export const VeelPaginas = Template.bind({});
+VeelPaginas.args = { current: 25, total: 100 };
+
+export const WeinigPaginas = Template.bind({});
+WeinigPaginas.args = { current: 2, total: 3 };
+
+export const Uitgeschakeld = Template.bind({});
+Uitgeschakeld.args = { current: 3, total: 10, disabled: true };

--- a/src/components/navigation/pagination/ndd-pagination.styles.ts
+++ b/src/components/navigation/pagination/ndd-pagination.styles.ts
@@ -57,7 +57,6 @@ export const paginationStyles = css`
 
 	a.pagination__page-button {
 		text-decoration: none;
-		color: inherit;
 	}
 
 	.pagination__page-button:hover,

--- a/src/components/navigation/pagination/ndd-pagination.styles.ts
+++ b/src/components/navigation/pagination/ndd-pagination.styles.ts
@@ -1,0 +1,218 @@
+import { css } from 'lit';
+
+export const paginationStyles = css`
+
+
+	/* # Host */
+
+	:host {
+		display: block;
+		container-type: inline-size;
+	}
+
+	:host([hidden]) {
+		display: none;
+	}
+
+	:host([full-width]) {
+		display: flex;
+		justify-content: center;
+	}
+
+	:host([disabled]) {
+		opacity: var(--primitives-opacity-disabled);
+		pointer-events: none;
+	}
+
+
+	/* # Container */
+
+	.pagination {
+		display: inline-flex;
+		align-items: center;
+		background-color: var(--semantics-buttons-neutral-tinted-background-color);
+		border-radius: var(--semantics-controls-md-corner-radius);
+	}
+
+
+	/* # Page button */
+
+	.pagination__page-button {
+		appearance: none;
+		border: none;
+		background: transparent;
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		height: var(--semantics-controls-md-min-size);
+		min-width: var(--semantics-controls-md-min-size);
+		padding-block: var(--primitives-space-8);
+		padding-inline: var(--primitives-space-12);
+		font: var(--semantics-buttons-md-font);
+		color: inherit;
+		box-sizing: border-box;
+		position: relative;
+		margin: 0;
+	}
+
+	.pagination__page-button:hover,
+	.pagination__page-button:focus-visible {
+		z-index: 1;
+	}
+
+	.pagination__page-button:focus-visible {
+		outline: none;
+	}
+
+	.pagination__page-button.is-current {
+		color: var(--semantics-buttons-neutral-tinted-is-selected-content-color);
+	}
+
+
+	/* ## Page button indicator */
+
+	.pagination__page-button-indicator {
+		position: absolute;
+		inset: var(--primitives-space-4);
+		border-radius: calc(var(--semantics-controls-md-corner-radius) - var(--primitives-space-4) / 2);
+		background-color: transparent;
+		pointer-events: none;
+	}
+
+	.pagination__page-button:hover:not(.is-current) .pagination__page-button-indicator {
+		background-color: var(--semantics-buttons-neutral-tinted-is-hovered-background-color);
+	}
+
+	.pagination__page-button.is-current .pagination__page-button-indicator {
+		background-color: var(--semantics-buttons-neutral-tinted-is-selected-background-color);
+	}
+
+	.pagination__page-button:focus-visible .pagination__page-button-indicator {
+		box-shadow: 0 0 0 var(--semantics-focus-ring-center-thickness) var(--semantics-focus-ring-center-color);
+		outline: var(--semantics-focus-ring-edge-thickness) double var(--semantics-focus-ring-edge-color);
+	}
+
+
+	/* ## Page button text */
+
+	.pagination__page-button-text {
+		position: relative;
+		z-index: 1;
+		pointer-events: none;
+	}
+
+
+	/* # Ellipsis */
+
+	.pagination__ellipsis {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		height: var(--semantics-controls-md-min-size);
+		min-width: var(--semantics-controls-md-min-size);
+		padding-block: var(--primitives-space-8);
+		padding-inline: var(--primitives-space-12);
+		font: var(--semantics-buttons-md-font);
+		color: inherit;
+		box-sizing: border-box;
+		pointer-events: none;
+	}
+
+
+	/* # Divider */
+
+	.pagination__divider {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		height: var(--semantics-controls-md-min-size);
+		flex-shrink: 0;
+	}
+
+	.pagination__divider-line {
+		width: var(--semantics-dividers-thickness);
+		height: var(--semantics-buttons-md-divider-length);
+		background-color: var(--semantics-buttons-neutral-tinted-divider-color);
+	}
+
+
+	/* # Select (compact fallback) */
+
+	.pagination__select-wrapper {
+		position: relative;
+		display: inline-flex;
+		align-items: center;
+	}
+
+	.pagination__select {
+		appearance: none;
+		border: none;
+		background: transparent;
+		height: var(--semantics-controls-md-min-size);
+		padding-block: var(--primitives-space-8);
+		padding-inline-start: var(--primitives-space-12);
+		padding-inline-end: calc(var(--primitives-space-24) + var(--primitives-space-12));
+		font: var(--semantics-buttons-md-font);
+		color: inherit;
+		box-sizing: border-box;
+		margin: 0;
+		position: relative;
+		z-index: 1;
+	}
+
+	.pagination__select:focus-visible {
+		box-shadow: 0 0 0 var(--semantics-focus-ring-center-thickness) var(--semantics-focus-ring-center-color);
+		outline: var(--semantics-focus-ring-edge-thickness) double var(--semantics-focus-ring-edge-color);
+		border-radius: calc(var(--semantics-controls-md-corner-radius) - var(--primitives-space-4) / 2);
+	}
+
+	.pagination__select-picker-icon {
+		position: absolute;
+		inset-inline-end: var(--primitives-space-8);
+		pointer-events: none;
+		width: var(--primitives-space-24);
+		height: var(--primitives-space-24);
+	}
+
+
+	/* # Responsive */
+
+	.pagination__page-buttons {
+		display: contents;
+	}
+
+	.pagination__compact {
+		display: none;
+	}
+
+	@container (max-width: 400px) {
+		.pagination__page-buttons {
+			display: none;
+		}
+
+		.pagination__compact {
+			display: contents;
+		}
+	}
+
+
+	/* # High contrast */
+
+	@media (forced-colors: active) {
+		.pagination {
+			border: 1px solid CanvasText;
+		}
+
+		.pagination__page-button.is-current {
+			color: HighlightText;
+		}
+
+		.pagination__page-button.is-current .pagination__page-button-indicator {
+			background-color: Highlight;
+		}
+
+		.pagination__page-button:focus-visible .pagination__page-button-indicator {
+			outline: 2px solid CanvasText;
+		}
+	}
+`;

--- a/src/components/navigation/pagination/ndd-pagination.styles.ts
+++ b/src/components/navigation/pagination/ndd-pagination.styles.ts
@@ -55,6 +55,11 @@ export const paginationStyles = css`
 		margin: 0;
 	}
 
+	a.pagination__page-button {
+		text-decoration: none;
+		color: inherit;
+	}
+
 	.pagination__page-button:hover,
 	.pagination__page-button:focus-visible {
 		z-index: 1;

--- a/src/components/navigation/pagination/ndd-pagination.template.ts
+++ b/src/components/navigation/pagination/ndd-pagination.template.ts
@@ -23,9 +23,10 @@ export function paginationTemplate(component: NDDPagination): TemplateResult {
 					aria-current=${isCurrent ? 'page' : nothing}
 					tabindex=${isDisabled ? -1 : nothing}
 					aria-disabled=${isDisabled ? 'true' : nothing}
+					@click=${(e: Event) => { e.preventDefault(); component._goToPage(page); }}
 				>
-					<div class="pagination__page-button-indicator"></div>
-					<div class="pagination__page-button-text">${page}</div>
+					<span class="pagination__page-button-indicator"></span>
+					<span class="pagination__page-button-text">${page}</span>
 				</a>
 			`;
 		}
@@ -38,8 +39,8 @@ export function paginationTemplate(component: NDDPagination): TemplateResult {
 				?disabled=${isDisabled}
 				@click=${() => component._goToPage(page)}
 			>
-				<div class="pagination__page-button-indicator"></div>
-				<div class="pagination__page-button-text">${page}</div>
+				<span class="pagination__page-button-indicator"></span>
+				<span class="pagination__page-button-text">${page}</span>
 			</button>
 		`;
 	};
@@ -54,7 +55,7 @@ export function paginationTemplate(component: NDDPagination): TemplateResult {
 				variant="neutral-tinted"
 				?disabled=${isDisabled || atFirst}
 				href=${hasHref && !isDisabled && !atFirst ? component._hrefForPage(component.current - 1) : nothing}
-				@click=${hasHref ? nothing : () => component._goToPage(component.current - 1)}
+				@click=${(e: Event) => { e.preventDefault(); component._goToPage(component.current - 1); }}
 			></ndd-icon-button>
 			<div class="pagination__divider" aria-hidden="true">
 				<div class="pagination__divider-line"></div>
@@ -71,14 +72,7 @@ export function paginationTemplate(component: NDDPagination): TemplateResult {
 					<select class="pagination__select"
 						aria-label=${t('components.pagination.go-to-page-action')}
 						?disabled=${isDisabled}
-						@change=${(e: Event) => {
-							const page = Number((e.target as HTMLSelectElement).value);
-							if (hasHref) {
-								window.location.href = component._hrefForPage(page);
-							} else {
-								component._goToPage(page);
-							}
-						}}
+						@change=${(e: Event) => component._goToPage(Number((e.target as HTMLSelectElement).value))}
 					>
 						${Array.from({ length: component.total }, (_, i) => i + 1).map((page) => html`
 							<option value=${page} ?selected=${page === component.current}>${page} / ${component.total}</option>
@@ -98,7 +92,7 @@ export function paginationTemplate(component: NDDPagination): TemplateResult {
 				variant="neutral-tinted"
 				?disabled=${isDisabled || atLast}
 				href=${hasHref && !isDisabled && !atLast ? component._hrefForPage(component.current + 1) : nothing}
-				@click=${hasHref ? nothing : () => component._goToPage(component.current + 1)}
+				@click=${(e: Event) => { e.preventDefault(); component._goToPage(component.current + 1); }}
 			></ndd-icon-button>
 		</nav>
 	`;

--- a/src/components/navigation/pagination/ndd-pagination.template.ts
+++ b/src/components/navigation/pagination/ndd-pagination.template.ts
@@ -1,0 +1,70 @@
+import { html, nothing, TemplateResult } from 'lit';
+import type { NDDPagination } from './ndd-pagination.ts';
+import '../../actions/icon-button/ndd-icon-button.ts';
+
+export function paginationTemplate(component: NDDPagination): TemplateResult {
+	const pages = component._getVisiblePages();
+	const atFirst = component.current <= 1;
+	const atLast = component.current >= component.total;
+	const t = component._t.bind(component);
+
+	return html`
+		<nav class="pagination"
+			role="navigation"
+			aria-label=${t('components.pagination.label-text')}
+		>
+			<ndd-icon-button
+				icon="chevron-left-small"
+				text=${t('components.pagination.previous-action')}
+				variant="neutral-tinted"
+				?disabled=${atFirst}
+				@click=${() => component._goToPage(component.current - 1)}
+			></ndd-icon-button>
+			<div class="pagination__divider" aria-hidden="true">
+				<div class="pagination__divider-line"></div>
+			</div>
+			<div class="pagination__page-buttons">
+				${pages.map((page) =>
+					page === 'ellipsis'
+						? html`<div class="pagination__ellipsis" aria-hidden="true">&hellip;</div>`
+						: html`
+							<button class="pagination__page-button ${page === component.current ? 'is-current' : ''}"
+								type="button"
+								aria-label=${t('components.pagination.page-number-text', { page })}
+								aria-current=${page === component.current ? 'page' : nothing}
+								@click=${() => component._goToPage(page as number)}
+							>
+								<div class="pagination__page-button-indicator"></div>
+								<div class="pagination__page-button-text">${page}</div>
+							</button>
+						`
+				)}
+			</div>
+			<div class="pagination__compact">
+				<div class="pagination__select-wrapper">
+					<select class="pagination__select"
+						aria-label=${t('components.pagination.page-of-total-text', { page: component.current, total: component.total })}
+						@change=${(e: Event) => component._goToPage(Number((e.target as HTMLSelectElement).value))}
+					>
+						${Array.from({ length: component.total }, (_, i) => i + 1).map((page) => html`
+							<option value=${page} ?selected=${page === component.current}>${page}</option>
+						`)}
+					</select>
+					<div class="pagination__select-picker-icon">
+						<ndd-icon name="chevron-up-down"></ndd-icon>
+					</div>
+				</div>
+			</div>
+			<div class="pagination__divider" aria-hidden="true">
+				<div class="pagination__divider-line"></div>
+			</div>
+			<ndd-icon-button
+				icon="chevron-right-small"
+				text=${t('components.pagination.next-action')}
+				variant="neutral-tinted"
+				?disabled=${atLast}
+				@click=${() => component._goToPage(component.current + 1)}
+			></ndd-icon-button>
+		</nav>
+	`;
+}

--- a/src/components/navigation/pagination/ndd-pagination.template.ts
+++ b/src/components/navigation/pagination/ndd-pagination.template.ts
@@ -1,6 +1,7 @@
 import { html, nothing, TemplateResult } from 'lit';
 import type { NDDPagination } from './ndd-pagination.ts';
 import '../../actions/icon-button/ndd-icon-button.ts';
+import '../../content/icon/ndd-icon.ts';
 
 export function paginationTemplate(component: NDDPagination): TemplateResult {
 	const pages = component._getVisiblePages();

--- a/src/components/navigation/pagination/ndd-pagination.template.ts
+++ b/src/components/navigation/pagination/ndd-pagination.template.ts
@@ -18,7 +18,7 @@ export function paginationTemplate(component: NDDPagination): TemplateResult {
 		if (hasHref) {
 			return html`
 				<a class="pagination__page-button ${isCurrent ? 'is-current' : ''}"
-					href=${component._hrefForPage(page)}
+					href=${!isDisabled ? component._hrefForPage(page) : nothing}
 					aria-label=${label}
 					aria-current=${isCurrent ? 'page' : nothing}
 					tabindex=${isDisabled ? -1 : nothing}
@@ -53,7 +53,7 @@ export function paginationTemplate(component: NDDPagination): TemplateResult {
 				text=${t('components.pagination.previous-action')}
 				variant="neutral-tinted"
 				?disabled=${isDisabled || atFirst}
-				href=${hasHref && !atFirst ? component._hrefForPage(component.current - 1) : nothing}
+				href=${hasHref && !isDisabled && !atFirst ? component._hrefForPage(component.current - 1) : nothing}
 				@click=${hasHref ? nothing : () => component._goToPage(component.current - 1)}
 			></ndd-icon-button>
 			<div class="pagination__divider" aria-hidden="true">
@@ -97,7 +97,7 @@ export function paginationTemplate(component: NDDPagination): TemplateResult {
 				text=${t('components.pagination.next-action')}
 				variant="neutral-tinted"
 				?disabled=${isDisabled || atLast}
-				href=${hasHref && !atLast ? component._hrefForPage(component.current + 1) : nothing}
+				href=${hasHref && !isDisabled && !atLast ? component._hrefForPage(component.current + 1) : nothing}
 				@click=${hasHref ? nothing : () => component._goToPage(component.current + 1)}
 			></ndd-icon-button>
 		</nav>

--- a/src/components/navigation/pagination/ndd-pagination.template.ts
+++ b/src/components/navigation/pagination/ndd-pagination.template.ts
@@ -42,7 +42,7 @@ export function paginationTemplate(component: NDDPagination): TemplateResult {
 			<div class="pagination__compact">
 				<div class="pagination__select-wrapper">
 					<select class="pagination__select"
-						aria-label=${t('components.pagination.page-of-total-text', { page: component.current, total: component.total })}
+						aria-label=${t('components.pagination.go-to-page-action')}
 						@change=${(e: Event) => component._goToPage(Number((e.target as HTMLSelectElement).value))}
 					>
 						${Array.from({ length: component.total }, (_, i) => i + 1).map((page) => html`

--- a/src/components/navigation/pagination/ndd-pagination.template.ts
+++ b/src/components/navigation/pagination/ndd-pagination.template.ts
@@ -55,7 +55,7 @@ export function paginationTemplate(component: NDDPagination): TemplateResult {
 				variant="neutral-tinted"
 				?disabled=${isDisabled || atFirst}
 				href=${hasHref && !isDisabled && !atFirst ? component._hrefForPage(component.current - 1) : nothing}
-				@click=${(e: Event) => { e.preventDefault(); component._goToPage(component.current - 1); }}
+				@click=${(e: Event) => { if (hasHref) e.preventDefault(); component._goToPage(component.current - 1); }}
 			></ndd-icon-button>
 			<div class="pagination__divider" aria-hidden="true">
 				<div class="pagination__divider-line"></div>
@@ -92,7 +92,7 @@ export function paginationTemplate(component: NDDPagination): TemplateResult {
 				variant="neutral-tinted"
 				?disabled=${isDisabled || atLast}
 				href=${hasHref && !isDisabled && !atLast ? component._hrefForPage(component.current + 1) : nothing}
-				@click=${(e: Event) => { e.preventDefault(); component._goToPage(component.current + 1); }}
+				@click=${(e: Event) => { if (hasHref) e.preventDefault(); component._goToPage(component.current + 1); }}
 			></ndd-icon-button>
 		</nav>
 	`;

--- a/src/components/navigation/pagination/ndd-pagination.template.ts
+++ b/src/components/navigation/pagination/ndd-pagination.template.ts
@@ -13,7 +13,7 @@ export function paginationTemplate(component: NDDPagination): TemplateResult {
 
 	const renderPageButton = (page: number) => {
 		const isCurrent = page === component.current;
-		const label = t('components.pagination.page-number-text', { page });
+		const label = t('components.pagination.page-action', { page });
 
 		if (hasHref) {
 			return html`
@@ -47,7 +47,7 @@ export function paginationTemplate(component: NDDPagination): TemplateResult {
 
 	return html`
 		<nav class="pagination"
-			aria-label=${t('components.pagination.label-text')}
+			aria-label=${t('components.pagination.accessibility-label')}
 		>
 			<ndd-icon-button
 				icon="chevron-left-small"
@@ -70,7 +70,7 @@ export function paginationTemplate(component: NDDPagination): TemplateResult {
 			<div class="pagination__compact">
 				<div class="pagination__select-wrapper">
 					<select class="pagination__select"
-						aria-label=${t('components.pagination.go-to-page-action')}
+						aria-label=${t('components.pagination.go-to-page-label')}
 						?disabled=${isDisabled}
 						@change=${(e: Event) => component._goToPage(Number((e.target as HTMLSelectElement).value))}
 					>

--- a/src/components/navigation/pagination/ndd-pagination.template.ts
+++ b/src/components/navigation/pagination/ndd-pagination.template.ts
@@ -9,6 +9,7 @@ export function paginationTemplate(component: NDDPagination): TemplateResult {
 	const atLast = component.current >= component.total;
 	const t = component._t.bind(component);
 	const hasHref = !!component.hrefPattern;
+	const isDisabled = component.disabled;
 
 	const renderPageButton = (page: number) => {
 		const isCurrent = page === component.current;
@@ -20,6 +21,8 @@ export function paginationTemplate(component: NDDPagination): TemplateResult {
 					href=${component._hrefForPage(page)}
 					aria-label=${label}
 					aria-current=${isCurrent ? 'page' : nothing}
+					tabindex=${isDisabled ? -1 : nothing}
+					aria-disabled=${isDisabled ? 'true' : nothing}
 				>
 					<div class="pagination__page-button-indicator"></div>
 					<div class="pagination__page-button-text">${page}</div>
@@ -32,6 +35,7 @@ export function paginationTemplate(component: NDDPagination): TemplateResult {
 				type="button"
 				aria-label=${label}
 				aria-current=${isCurrent ? 'page' : nothing}
+				?disabled=${isDisabled}
 				@click=${() => component._goToPage(page)}
 			>
 				<div class="pagination__page-button-indicator"></div>
@@ -48,7 +52,7 @@ export function paginationTemplate(component: NDDPagination): TemplateResult {
 				icon="chevron-left-small"
 				text=${t('components.pagination.previous-action')}
 				variant="neutral-tinted"
-				?disabled=${atFirst}
+				?disabled=${isDisabled || atFirst}
 				href=${hasHref && !atFirst ? component._hrefForPage(component.current - 1) : nothing}
 				@click=${hasHref ? nothing : () => component._goToPage(component.current - 1)}
 			></ndd-icon-button>
@@ -66,6 +70,7 @@ export function paginationTemplate(component: NDDPagination): TemplateResult {
 				<div class="pagination__select-wrapper">
 					<select class="pagination__select"
 						aria-label=${t('components.pagination.go-to-page-action')}
+						?disabled=${isDisabled}
 						@change=${(e: Event) => {
 							const page = Number((e.target as HTMLSelectElement).value);
 							if (hasHref) {
@@ -91,7 +96,7 @@ export function paginationTemplate(component: NDDPagination): TemplateResult {
 				icon="chevron-right-small"
 				text=${t('components.pagination.next-action')}
 				variant="neutral-tinted"
-				?disabled=${atLast}
+				?disabled=${isDisabled || atLast}
 				href=${hasHref && !atLast ? component._hrefForPage(component.current + 1) : nothing}
 				@click=${hasHref ? nothing : () => component._goToPage(component.current + 1)}
 			></ndd-icon-button>

--- a/src/components/navigation/pagination/ndd-pagination.template.ts
+++ b/src/components/navigation/pagination/ndd-pagination.template.ts
@@ -8,6 +8,37 @@ export function paginationTemplate(component: NDDPagination): TemplateResult {
 	const atFirst = component.current <= 1;
 	const atLast = component.current >= component.total;
 	const t = component._t.bind(component);
+	const hasHref = !!component.hrefPattern;
+
+	const renderPageButton = (page: number) => {
+		const isCurrent = page === component.current;
+		const label = t('components.pagination.page-number-text', { page });
+
+		if (hasHref) {
+			return html`
+				<a class="pagination__page-button ${isCurrent ? 'is-current' : ''}"
+					href=${component._hrefForPage(page)}
+					aria-label=${label}
+					aria-current=${isCurrent ? 'page' : nothing}
+				>
+					<div class="pagination__page-button-indicator"></div>
+					<div class="pagination__page-button-text">${page}</div>
+				</a>
+			`;
+		}
+
+		return html`
+			<button class="pagination__page-button ${isCurrent ? 'is-current' : ''}"
+				type="button"
+				aria-label=${label}
+				aria-current=${isCurrent ? 'page' : nothing}
+				@click=${() => component._goToPage(page)}
+			>
+				<div class="pagination__page-button-indicator"></div>
+				<div class="pagination__page-button-text">${page}</div>
+			</button>
+		`;
+	};
 
 	return html`
 		<nav class="pagination"
@@ -18,7 +49,8 @@ export function paginationTemplate(component: NDDPagination): TemplateResult {
 				text=${t('components.pagination.previous-action')}
 				variant="neutral-tinted"
 				?disabled=${atFirst}
-				@click=${() => component._goToPage(component.current - 1)}
+				href=${hasHref && !atFirst ? component._hrefForPage(component.current - 1) : nothing}
+				@click=${hasHref ? nothing : () => component._goToPage(component.current - 1)}
 			></ndd-icon-button>
 			<div class="pagination__divider" aria-hidden="true">
 				<div class="pagination__divider-line"></div>
@@ -27,24 +59,21 @@ export function paginationTemplate(component: NDDPagination): TemplateResult {
 				${pages.map((page) =>
 					page === 'ellipsis'
 						? html`<div class="pagination__ellipsis" aria-hidden="true">&hellip;</div>`
-						: html`
-							<button class="pagination__page-button ${page === component.current ? 'is-current' : ''}"
-								type="button"
-								aria-label=${t('components.pagination.page-number-text', { page })}
-								aria-current=${page === component.current ? 'page' : nothing}
-								@click=${() => component._goToPage(page as number)}
-							>
-								<div class="pagination__page-button-indicator"></div>
-								<div class="pagination__page-button-text">${page}</div>
-							</button>
-						`
+						: renderPageButton(page as number)
 				)}
 			</div>
 			<div class="pagination__compact">
 				<div class="pagination__select-wrapper">
 					<select class="pagination__select"
 						aria-label=${t('components.pagination.go-to-page-action')}
-						@change=${(e: Event) => component._goToPage(Number((e.target as HTMLSelectElement).value))}
+						@change=${(e: Event) => {
+							const page = Number((e.target as HTMLSelectElement).value);
+							if (hasHref) {
+								window.location.href = component._hrefForPage(page);
+							} else {
+								component._goToPage(page);
+							}
+						}}
 					>
 						${Array.from({ length: component.total }, (_, i) => i + 1).map((page) => html`
 							<option value=${page} ?selected=${page === component.current}>${page} / ${component.total}</option>
@@ -63,7 +92,8 @@ export function paginationTemplate(component: NDDPagination): TemplateResult {
 				text=${t('components.pagination.next-action')}
 				variant="neutral-tinted"
 				?disabled=${atLast}
-				@click=${() => component._goToPage(component.current + 1)}
+				href=${hasHref && !atLast ? component._hrefForPage(component.current + 1) : nothing}
+				@click=${hasHref ? nothing : () => component._goToPage(component.current + 1)}
 			></ndd-icon-button>
 		</nav>
 	`;

--- a/src/components/navigation/pagination/ndd-pagination.template.ts
+++ b/src/components/navigation/pagination/ndd-pagination.template.ts
@@ -10,7 +10,6 @@ export function paginationTemplate(component: NDDPagination): TemplateResult {
 
 	return html`
 		<nav class="pagination"
-			role="navigation"
 			aria-label=${t('components.pagination.label-text')}
 		>
 			<ndd-icon-button

--- a/src/components/navigation/pagination/ndd-pagination.template.ts
+++ b/src/components/navigation/pagination/ndd-pagination.template.ts
@@ -47,7 +47,7 @@ export function paginationTemplate(component: NDDPagination): TemplateResult {
 						@change=${(e: Event) => component._goToPage(Number((e.target as HTMLSelectElement).value))}
 					>
 						${Array.from({ length: component.total }, (_, i) => i + 1).map((page) => html`
-							<option value=${page} ?selected=${page === component.current}>${page}</option>
+							<option value=${page} ?selected=${page === component.current}>${page} / ${component.total}</option>
 						`)}
 					</select>
 					<div class="pagination__select-picker-icon">

--- a/src/components/navigation/pagination/ndd-pagination.test.ts
+++ b/src/components/navigation/pagination/ndd-pagination.test.ts
@@ -224,4 +224,20 @@ describe('ndd-pagination – keyboard navigation', () => {
 
 		expect(focusSpy).toHaveBeenCalled();
 	});
+
+	it('ArrowRight navigates across ellipsis gap', async () => {
+		el = await fixture<NDDPagination>('<ndd-pagination current="6" total="20"></ndd-pagination>');
+		await waitForUpdate(el);
+
+		// With ellipsis: page buttons are [1, 5, 6, 7, 20] (ellipses are not buttons)
+		const buttons = el.shadowRoot!.querySelectorAll<HTMLButtonElement>('.pagination__page-button');
+		expect(buttons.length).toBe(5);
+
+		// Navigate from first visible page button (1) to second (5) — skips ellipsis
+		const focusSpy = vi.spyOn(buttons[1], 'focus');
+		buttons[0].focus();
+		buttons[0].dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true, composed: true }));
+
+		expect(focusSpy).toHaveBeenCalled();
+	});
 });

--- a/src/components/navigation/pagination/ndd-pagination.test.ts
+++ b/src/components/navigation/pagination/ndd-pagination.test.ts
@@ -1,17 +1,16 @@
-import { describe, it, expect, afterEach } from 'vitest';
+import { describe, it, expect, afterEach, vi } from 'vitest';
 import { fixture, cleanup, waitForUpdate } from '../../../test-utils.ts';
 import type { NDDPagination } from './ndd-pagination.ts';
 import './ndd-pagination.ts';
 
-function getPageLabels(el: NDDPagination): (string | '...')[] {
-	// Collect all page buttons and ellipses in DOM order
+function getPageLabels(el: NDDPagination): (string | '…')[] {
 	const allItems = el.shadowRoot!.querySelectorAll(
-		'.pagination__button:not(.pagination__button--nav)'
+		'.pagination__page-button, .pagination__ellipsis'
 	);
 
-	return Array.from(allItems).map(btn => {
-		if (btn.classList.contains('pagination__button--ellipsis')) return '...';
-		return btn.querySelector('.pagination__button-label')!.textContent!.trim();
+	return Array.from(allItems).map(item => {
+		if (item.classList.contains('pagination__ellipsis')) return '…';
+		return item.querySelector('.pagination__page-button-text')!.textContent!.trim();
 	});
 }
 
@@ -25,7 +24,6 @@ describe('ndd-pagination', () => {
 	it('renders without error', async () => {
 		el = await fixture('<ndd-pagination></ndd-pagination>');
 		await waitForUpdate(el);
-
 		expect(el.shadowRoot).not.toBeNull();
 	});
 });
@@ -38,51 +36,39 @@ describe('ndd-pagination – visible page algorithm', () => {
 	});
 
 	it('shows all pages when total <= 7', async () => {
-		el = await fixture<NDDPagination>('<ndd-pagination current-page="3" total-pages="5"></ndd-pagination>');
+		el = await fixture<NDDPagination>('<ndd-pagination current="3" total="5"></ndd-pagination>');
 		await waitForUpdate(el);
-
-		const labels = getPageLabels(el);
-		expect(labels).toEqual(['1', '2', '3', '4', '5']);
+		expect(getPageLabels(el)).toEqual(['1', '2', '3', '4', '5']);
 	});
 
 	it('shows exactly 7 when total = 7', async () => {
-		el = await fixture<NDDPagination>('<ndd-pagination current-page="4" total-pages="7"></ndd-pagination>');
+		el = await fixture<NDDPagination>('<ndd-pagination current="4" total="7"></ndd-pagination>');
 		await waitForUpdate(el);
-
-		const labels = getPageLabels(el);
-		expect(labels).toEqual(['1', '2', '3', '4', '5', '6', '7']);
+		expect(getPageLabels(el)).toEqual(['1', '2', '3', '4', '5', '6', '7']);
 	});
 
 	it('near start: shows first 4 + ellipsis + last 2', async () => {
-		el = await fixture<NDDPagination>('<ndd-pagination current-page="2" total-pages="10"></ndd-pagination>');
+		el = await fixture<NDDPagination>('<ndd-pagination current="2" total="10"></ndd-pagination>');
 		await waitForUpdate(el);
-
-		const labels = getPageLabels(el);
-		expect(labels).toEqual(['1', '2', '3', '4', '...', '9', '10']);
+		expect(getPageLabels(el)).toEqual(['1', '2', '3', '4', '…', '9', '10']);
 	});
 
 	it('page 4 transition: shows first 5 + ellipsis + last 1', async () => {
-		el = await fixture<NDDPagination>('<ndd-pagination current-page="4" total-pages="10"></ndd-pagination>');
+		el = await fixture<NDDPagination>('<ndd-pagination current="4" total="10"></ndd-pagination>');
 		await waitForUpdate(el);
-
-		const labels = getPageLabels(el);
-		expect(labels).toEqual(['1', '2', '3', '4', '5', '...', '10']);
+		expect(getPageLabels(el)).toEqual(['1', '2', '3', '4', '5', '…', '10']);
 	});
 
 	it('near end: shows first 1 + ellipsis + last 5', async () => {
-		el = await fixture<NDDPagination>('<ndd-pagination current-page="9" total-pages="10"></ndd-pagination>');
+		el = await fixture<NDDPagination>('<ndd-pagination current="9" total="10"></ndd-pagination>');
 		await waitForUpdate(el);
-
-		const labels = getPageLabels(el);
-		expect(labels).toEqual(['1', '...', '6', '7', '8', '9', '10']);
+		expect(getPageLabels(el)).toEqual(['1', '…', '6', '7', '8', '9', '10']);
 	});
 
 	it('middle: shows first + ellipsis + 3 around current + ellipsis + last', async () => {
-		el = await fixture<NDDPagination>('<ndd-pagination current-page="6" total-pages="10"></ndd-pagination>');
+		el = await fixture<NDDPagination>('<ndd-pagination current="6" total="10"></ndd-pagination>');
 		await waitForUpdate(el);
-
-		const labels = getPageLabels(el);
-		expect(labels).toEqual(['1', '...', '5', '6', '7', '...', '10']);
+		expect(getPageLabels(el)).toEqual(['1', '…', '5', '6', '7', '…', '10']);
 	});
 });
 
@@ -94,7 +80,7 @@ describe('ndd-pagination – navigation', () => {
 	});
 
 	it('dispatches page-change on page button click', async () => {
-		el = await fixture<NDDPagination>('<ndd-pagination current-page="1" total-pages="5"></ndd-pagination>');
+		el = await fixture<NDDPagination>('<ndd-pagination current="1" total="5"></ndd-pagination>');
 		await waitForUpdate(el);
 
 		let detail: any;
@@ -102,20 +88,17 @@ describe('ndd-pagination – navigation', () => {
 			detail = e.detail;
 		}) as EventListener);
 
-		// Click page 3 button
-		const pageButtons = el.shadowRoot!.querySelectorAll(
-			'.pagination__button:not(.pagination__button--nav):not(.pagination__button--ellipsis)'
-		);
+		const pageButtons = el.shadowRoot!.querySelectorAll('.pagination__page-button');
 		(pageButtons[2] as HTMLElement).click();
 		await waitForUpdate(el);
 
 		expect(detail).toBeDefined();
 		expect(detail.page).toBe(3);
-		expect(el.currentPage).toBe(3);
+		expect(el.current).toBe(3);
 	});
 
 	it('previous button navigates to previous page', async () => {
-		el = await fixture<NDDPagination>('<ndd-pagination current-page="3" total-pages="5"></ndd-pagination>');
+		el = await fixture<NDDPagination>('<ndd-pagination current="3" total="5"></ndd-pagination>');
 		await waitForUpdate(el);
 
 		let detail: any;
@@ -123,7 +106,7 @@ describe('ndd-pagination – navigation', () => {
 			detail = e.detail;
 		}) as EventListener);
 
-		const prevBtn = el.shadowRoot!.querySelector('.pagination__button--nav') as HTMLElement;
+		const prevBtn = el.shadowRoot!.querySelector('ndd-icon-button') as HTMLElement;
 		prevBtn.click();
 		await waitForUpdate(el);
 
@@ -131,7 +114,7 @@ describe('ndd-pagination – navigation', () => {
 	});
 
 	it('next button navigates to next page', async () => {
-		el = await fixture<NDDPagination>('<ndd-pagination current-page="3" total-pages="5"></ndd-pagination>');
+		el = await fixture<NDDPagination>('<ndd-pagination current="3" total="5"></ndd-pagination>');
 		await waitForUpdate(el);
 
 		let detail: any;
@@ -139,7 +122,7 @@ describe('ndd-pagination – navigation', () => {
 			detail = e.detail;
 		}) as EventListener);
 
-		const navButtons = el.shadowRoot!.querySelectorAll('.pagination__button--nav');
+		const navButtons = el.shadowRoot!.querySelectorAll('ndd-icon-button');
 		(navButtons[1] as HTMLElement).click();
 		await waitForUpdate(el);
 
@@ -147,45 +130,98 @@ describe('ndd-pagination – navigation', () => {
 	});
 
 	it('previous button is disabled on first page', async () => {
-		el = await fixture<NDDPagination>('<ndd-pagination current-page="1" total-pages="5"></ndd-pagination>');
+		el = await fixture<NDDPagination>('<ndd-pagination current="1" total="5"></ndd-pagination>');
 		await waitForUpdate(el);
 
-		const prevBtn = el.shadowRoot!.querySelector('.pagination__button--nav') as HTMLButtonElement;
-		expect(prevBtn.disabled).toBe(true);
+		const prevBtn = el.shadowRoot!.querySelector('ndd-icon-button') as HTMLElement;
+		expect(prevBtn.hasAttribute('disabled')).toBe(true);
 	});
 
 	it('next button is disabled on last page', async () => {
-		el = await fixture<NDDPagination>('<ndd-pagination current-page="5" total-pages="5"></ndd-pagination>');
+		el = await fixture<NDDPagination>('<ndd-pagination current="5" total="5"></ndd-pagination>');
 		await waitForUpdate(el);
 
-		const navButtons = el.shadowRoot!.querySelectorAll('.pagination__button--nav');
-		expect((navButtons[1] as HTMLButtonElement).disabled).toBe(true);
+		const navButtons = el.shadowRoot!.querySelectorAll('ndd-icon-button');
+		expect((navButtons[1] as HTMLElement).hasAttribute('disabled')).toBe(true);
 	});
 
 	it('marks current page button as active', async () => {
-		el = await fixture<NDDPagination>('<ndd-pagination current-page="3" total-pages="5"></ndd-pagination>');
+		el = await fixture<NDDPagination>('<ndd-pagination current="3" total="5"></ndd-pagination>');
 		await waitForUpdate(el);
 
-		const activeBtn = el.shadowRoot!.querySelector('.pagination__button--active');
+		const activeBtn = el.shadowRoot!.querySelector('.pagination__page-button.is-current');
 		expect(activeBtn).not.toBeNull();
-		expect(activeBtn!.querySelector('.pagination__button-label')!.textContent!.trim()).toBe('3');
+		expect(activeBtn!.querySelector('.pagination__page-button-text')!.textContent!.trim()).toBe('3');
 		expect(activeBtn!.getAttribute('aria-current')).toBe('page');
 	});
 
 	it('does not dispatch page-change when clicking current page', async () => {
-		el = await fixture<NDDPagination>('<ndd-pagination current-page="2" total-pages="5"></ndd-pagination>');
+		el = await fixture<NDDPagination>('<ndd-pagination current="2" total="5"></ndd-pagination>');
 		await waitForUpdate(el);
 
 		let changeFired = false;
 		el.addEventListener('page-change', () => { changeFired = true; });
 
-		const pageButtons = el.shadowRoot!.querySelectorAll(
-			'.pagination__button:not(.pagination__button--nav):not(.pagination__button--ellipsis)'
-		);
-		// Click page 2 (already current)
+		const pageButtons = el.shadowRoot!.querySelectorAll('.pagination__page-button');
 		(pageButtons[1] as HTMLElement).click();
 		await waitForUpdate(el);
 
 		expect(changeFired).toBe(false);
+	});
+});
+
+describe('ndd-pagination – keyboard navigation', () => {
+	let el: NDDPagination;
+
+	afterEach(() => {
+		if (el) cleanup(el);
+	});
+
+	it('ArrowRight calls focus on next page button', async () => {
+		el = await fixture<NDDPagination>('<ndd-pagination current="1" total="5"></ndd-pagination>');
+		await waitForUpdate(el);
+
+		const buttons = el.shadowRoot!.querySelectorAll<HTMLButtonElement>('.pagination__page-button');
+		const focusSpy = vi.spyOn(buttons[1], 'focus');
+		buttons[0].focus();
+		buttons[0].dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true, composed: true }));
+
+		expect(focusSpy).toHaveBeenCalled();
+	});
+
+	it('ArrowLeft wraps focus to last page button', async () => {
+		el = await fixture<NDDPagination>('<ndd-pagination current="1" total="5"></ndd-pagination>');
+		await waitForUpdate(el);
+
+		const buttons = el.shadowRoot!.querySelectorAll<HTMLButtonElement>('.pagination__page-button');
+		const focusSpy = vi.spyOn(buttons[buttons.length - 1], 'focus');
+		buttons[0].focus();
+		buttons[0].dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowLeft', bubbles: true, composed: true }));
+
+		expect(focusSpy).toHaveBeenCalled();
+	});
+
+	it('Home calls focus on first page button', async () => {
+		el = await fixture<NDDPagination>('<ndd-pagination current="3" total="5"></ndd-pagination>');
+		await waitForUpdate(el);
+
+		const buttons = el.shadowRoot!.querySelectorAll<HTMLButtonElement>('.pagination__page-button');
+		const focusSpy = vi.spyOn(buttons[0], 'focus');
+		buttons[2].focus();
+		buttons[2].dispatchEvent(new KeyboardEvent('keydown', { key: 'Home', bubbles: true, composed: true }));
+
+		expect(focusSpy).toHaveBeenCalled();
+	});
+
+	it('End calls focus on last page button', async () => {
+		el = await fixture<NDDPagination>('<ndd-pagination current="1" total="5"></ndd-pagination>');
+		await waitForUpdate(el);
+
+		const buttons = el.shadowRoot!.querySelectorAll<HTMLButtonElement>('.pagination__page-button');
+		const focusSpy = vi.spyOn(buttons[buttons.length - 1], 'focus');
+		buttons[0].focus();
+		buttons[0].dispatchEvent(new KeyboardEvent('keydown', { key: 'End', bubbles: true, composed: true }));
+
+		expect(focusSpy).toHaveBeenCalled();
 	});
 });

--- a/src/components/navigation/pagination/ndd-pagination.test.ts
+++ b/src/components/navigation/pagination/ndd-pagination.test.ts
@@ -257,7 +257,7 @@ describe('ndd-pagination – translations', () => {
 
 	it('overrides translations via property', async () => {
 		el = await fixture<NDDPagination>('<ndd-pagination current="1" total="5"></ndd-pagination>');
-		el.translations = { 'components.pagination.label-text': 'Pagination' };
+		el.translations = { 'components.pagination.accessibility-label': 'Pagination' };
 		await waitForUpdate(el);
 
 		const nav = el.shadowRoot!.querySelector('nav');

--- a/src/components/navigation/pagination/ndd-pagination.test.ts
+++ b/src/components/navigation/pagination/ndd-pagination.test.ts
@@ -189,7 +189,7 @@ describe('ndd-pagination – keyboard navigation', () => {
 		expect(focusSpy).toHaveBeenCalled();
 	});
 
-	it('ArrowLeft wraps focus to last page button', async () => {
+	it('ArrowLeft stops at first page button', async () => {
 		el = await fixture<NDDPagination>('<ndd-pagination current="1" total="5"></ndd-pagination>');
 		await waitForUpdate(el);
 
@@ -198,7 +198,7 @@ describe('ndd-pagination – keyboard navigation', () => {
 		buttons[0].focus();
 		buttons[0].dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowLeft', bubbles: true, composed: true }));
 
-		expect(focusSpy).toHaveBeenCalled();
+		expect(focusSpy).not.toHaveBeenCalled();
 	});
 
 	it('Home calls focus on first page button', async () => {

--- a/src/components/navigation/pagination/ndd-pagination.test.ts
+++ b/src/components/navigation/pagination/ndd-pagination.test.ts
@@ -204,6 +204,40 @@ describe('ndd-pagination – href-pattern', () => {
 			expect(anchor.getAttribute('aria-disabled')).toBe('true');
 		}
 	});
+
+	it('dispatches page-change with href in detail', async () => {
+		el = await fixture<NDDPagination>('<ndd-pagination current="1" total="5" href-pattern="/page/{page}"></ndd-pagination>');
+		await waitForUpdate(el);
+
+		let detail: any;
+		el.addEventListener('page-change', ((e: CustomEvent) => {
+			e.preventDefault();
+			detail = e.detail;
+		}) as EventListener);
+
+		const anchors = el.shadowRoot!.querySelectorAll('a.pagination__page-button');
+		(anchors[2] as HTMLElement).click();
+		await waitForUpdate(el);
+
+		expect(detail).toBeDefined();
+		expect(detail.page).toBe(3);
+		expect(detail.href).toBe('/page/3');
+	});
+
+	it('updates current after anchor click', async () => {
+		el = await fixture<NDDPagination>('<ndd-pagination current="1" total="5" href-pattern="/page/{page}"></ndd-pagination>');
+		await waitForUpdate(el);
+
+		el.addEventListener('page-change', ((e: CustomEvent) => {
+			e.preventDefault();
+		}) as EventListener);
+
+		const anchors = el.shadowRoot!.querySelectorAll('a.pagination__page-button');
+		(anchors[2] as HTMLElement).click();
+		await waitForUpdate(el);
+
+		expect(el.current).toBe(3);
+	});
 });
 
 describe('ndd-pagination – translations', () => {

--- a/src/components/navigation/pagination/ndd-pagination.test.ts
+++ b/src/components/navigation/pagination/ndd-pagination.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, afterEach, vi } from 'vitest';
+import { describe, it, expect, afterEach } from 'vitest';
 import { fixture, cleanup, waitForUpdate } from '../../../test-utils.ts';
 import type { NDDPagination } from './ndd-pagination.ts';
 import './ndd-pagination.ts';
@@ -170,74 +170,3 @@ describe('ndd-pagination – navigation', () => {
 	});
 });
 
-describe('ndd-pagination – keyboard navigation', () => {
-	let el: NDDPagination;
-
-	afterEach(() => {
-		if (el) cleanup(el);
-	});
-
-	it('ArrowRight calls focus on next page button', async () => {
-		el = await fixture<NDDPagination>('<ndd-pagination current="1" total="5"></ndd-pagination>');
-		await waitForUpdate(el);
-
-		const buttons = el.shadowRoot!.querySelectorAll<HTMLButtonElement>('.pagination__page-button');
-		const focusSpy = vi.spyOn(buttons[1], 'focus');
-		buttons[0].focus();
-		buttons[0].dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true, composed: true }));
-
-		expect(focusSpy).toHaveBeenCalled();
-	});
-
-	it('ArrowLeft stops at first page button', async () => {
-		el = await fixture<NDDPagination>('<ndd-pagination current="1" total="5"></ndd-pagination>');
-		await waitForUpdate(el);
-
-		const buttons = el.shadowRoot!.querySelectorAll<HTMLButtonElement>('.pagination__page-button');
-		const focusSpy = vi.spyOn(buttons[buttons.length - 1], 'focus');
-		buttons[0].focus();
-		buttons[0].dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowLeft', bubbles: true, composed: true }));
-
-		expect(focusSpy).not.toHaveBeenCalled();
-	});
-
-	it('Home calls focus on first page button', async () => {
-		el = await fixture<NDDPagination>('<ndd-pagination current="3" total="5"></ndd-pagination>');
-		await waitForUpdate(el);
-
-		const buttons = el.shadowRoot!.querySelectorAll<HTMLButtonElement>('.pagination__page-button');
-		const focusSpy = vi.spyOn(buttons[0], 'focus');
-		buttons[2].focus();
-		buttons[2].dispatchEvent(new KeyboardEvent('keydown', { key: 'Home', bubbles: true, composed: true }));
-
-		expect(focusSpy).toHaveBeenCalled();
-	});
-
-	it('End calls focus on last page button', async () => {
-		el = await fixture<NDDPagination>('<ndd-pagination current="1" total="5"></ndd-pagination>');
-		await waitForUpdate(el);
-
-		const buttons = el.shadowRoot!.querySelectorAll<HTMLButtonElement>('.pagination__page-button');
-		const focusSpy = vi.spyOn(buttons[buttons.length - 1], 'focus');
-		buttons[0].focus();
-		buttons[0].dispatchEvent(new KeyboardEvent('keydown', { key: 'End', bubbles: true, composed: true }));
-
-		expect(focusSpy).toHaveBeenCalled();
-	});
-
-	it('ArrowRight navigates across ellipsis gap', async () => {
-		el = await fixture<NDDPagination>('<ndd-pagination current="6" total="20"></ndd-pagination>');
-		await waitForUpdate(el);
-
-		// With ellipsis: page buttons are [1, 5, 6, 7, 20] (ellipses are not buttons)
-		const buttons = el.shadowRoot!.querySelectorAll<HTMLButtonElement>('.pagination__page-button');
-		expect(buttons.length).toBe(5);
-
-		// Navigate from first visible page button (1) to second (5) — skips ellipsis
-		const focusSpy = vi.spyOn(buttons[1], 'focus');
-		buttons[0].focus();
-		buttons[0].dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true, composed: true }));
-
-		expect(focusSpy).toHaveBeenCalled();
-	});
-});

--- a/src/components/navigation/pagination/ndd-pagination.test.ts
+++ b/src/components/navigation/pagination/ndd-pagination.test.ts
@@ -170,3 +170,64 @@ describe('ndd-pagination – navigation', () => {
 	});
 });
 
+describe('ndd-pagination – href-pattern', () => {
+	let el: NDDPagination;
+
+	afterEach(() => {
+		if (el) cleanup(el);
+	});
+
+	it('renders anchor elements when href-pattern is set', async () => {
+		el = await fixture<NDDPagination>('<ndd-pagination current="2" total="5" href-pattern="/page/{page}"></ndd-pagination>');
+		await waitForUpdate(el);
+
+		const anchors = el.shadowRoot!.querySelectorAll('a.pagination__page-button');
+		expect(anchors.length).toBeGreaterThan(0);
+		expect(anchors[0].getAttribute('href')).toBe('/page/1');
+	});
+
+	it('renders no buttons when href-pattern is set', async () => {
+		el = await fixture<NDDPagination>('<ndd-pagination current="2" total="5" href-pattern="/page/{page}"></ndd-pagination>');
+		await waitForUpdate(el);
+
+		const buttons = el.shadowRoot!.querySelectorAll('button.pagination__page-button');
+		expect(buttons.length).toBe(0);
+	});
+
+	it('omits href on anchors when disabled', async () => {
+		el = await fixture<NDDPagination>('<ndd-pagination current="2" total="5" href-pattern="/page/{page}" disabled></ndd-pagination>');
+		await waitForUpdate(el);
+
+		const anchors = el.shadowRoot!.querySelectorAll('a.pagination__page-button');
+		for (const anchor of anchors) {
+			expect(anchor.hasAttribute('href')).toBe(false);
+			expect(anchor.getAttribute('aria-disabled')).toBe('true');
+		}
+	});
+});
+
+describe('ndd-pagination – translations', () => {
+	let el: NDDPagination;
+
+	afterEach(() => {
+		if (el) cleanup(el);
+	});
+
+	it('uses default Dutch labels', async () => {
+		el = await fixture<NDDPagination>('<ndd-pagination current="1" total="5"></ndd-pagination>');
+		await waitForUpdate(el);
+
+		const nav = el.shadowRoot!.querySelector('nav');
+		expect(nav!.getAttribute('aria-label')).toBe('Paginering');
+	});
+
+	it('overrides translations via property', async () => {
+		el = await fixture<NDDPagination>('<ndd-pagination current="1" total="5"></ndd-pagination>');
+		el.translations = { 'components.pagination.label-text': 'Pagination' };
+		await waitForUpdate(el);
+
+		const nav = el.shadowRoot!.querySelector('nav');
+		expect(nav!.getAttribute('aria-label')).toBe('Pagination');
+	});
+});
+

--- a/src/components/navigation/pagination/ndd-pagination.ts
+++ b/src/components/navigation/pagination/ndd-pagination.ts
@@ -10,7 +10,7 @@
  * @attr {boolean} full-width - Centreert de pagination in de container
  * @attr {string} href-pattern - URL patroon met {page} placeholder, rendert links in plaats van buttons
  *
- * @fires page-change - When the page changes (detail: { page: number })
+ * @fires page-change - When the page changes (detail: { page: number, href?: string }). In href mode, call event.preventDefault() to handle navigation yourself (SPA).
  */
 
 import { LitElement } from 'lit';
@@ -92,13 +92,25 @@ export class NDDPagination extends LitElement {
 		}
 
 		this.current = page;
-		this.dispatchEvent(
-			new CustomEvent('page-change', {
-				detail: { page: this.current },
-				bubbles: true,
-				composed: true,
-			})
-		);
+
+		const detail: { page: number; href?: string } = { page: this.current };
+		if (this.hrefPattern) {
+			detail.href = this._hrefForPage(this.current);
+		}
+
+		const event = new CustomEvent('page-change', {
+			detail,
+			bubbles: true,
+			composed: true,
+			cancelable: true,
+		});
+
+		const proceeded = this.dispatchEvent(event);
+
+		// In href mode, navigate unless consumer called preventDefault()
+		if (this.hrefPattern && proceeded) {
+			window.location.href = detail.href!;
+		}
 	}
 
 	override render() {

--- a/src/components/navigation/pagination/ndd-pagination.ts
+++ b/src/components/navigation/pagination/ndd-pagination.ts
@@ -84,7 +84,7 @@ export class NDDPagination extends LitElement {
 
 	_hrefForPage(page: number): string {
 		const href = this.hrefPattern.replace('{page}', String(page));
-		if (/^(https?:\/\/|\/|\.|\?|#)/.test(href)) return href;
+		if (/^(https?:\/\/|[^:]+$)/.test(href)) return href;
 		return '';
 	}
 
@@ -110,8 +110,8 @@ export class NDDPagination extends LitElement {
 		const proceeded = this.dispatchEvent(event);
 
 		// In href mode, navigate unless consumer called preventDefault()
-		if (this.hrefPattern && proceeded) {
-			window.location.href = detail.href!;
+		if (this.hrefPattern && proceeded && detail.href) {
+			window.location.href = detail.href;
 		}
 	}
 

--- a/src/components/navigation/pagination/ndd-pagination.ts
+++ b/src/components/navigation/pagination/ndd-pagination.ts
@@ -93,49 +93,6 @@ export class NDDPagination extends LitElement {
 		);
 	}
 
-	_handleKeyDown = (e: KeyboardEvent): void => {
-		const buttons = Array.from(
-			this.shadowRoot!.querySelectorAll<HTMLButtonElement>('.pagination__page-button')
-		);
-		const target = e.composedPath()[0] as HTMLElement;
-		const index = buttons.indexOf(target as HTMLButtonElement);
-
-		if (index === -1) return;
-
-		let next: number | undefined;
-
-		switch (e.key) {
-			case 'ArrowRight':
-				next = index < buttons.length - 1 ? index + 1 : undefined;
-				break;
-			case 'ArrowLeft':
-				next = index > 0 ? index - 1 : undefined;
-				break;
-			case 'Home':
-				next = 0;
-				break;
-			case 'End':
-				next = buttons.length - 1;
-				break;
-			default:
-				return;
-		}
-
-		if (next === undefined) return;
-		e.preventDefault();
-		buttons[next].focus();
-	}
-
-	override connectedCallback(): void {
-		super.connectedCallback();
-		this.addEventListener('keydown', this._handleKeyDown);
-	}
-
-	override disconnectedCallback(): void {
-		super.disconnectedCallback();
-		this.removeEventListener('keydown', this._handleKeyDown);
-	}
-
 	override render() {
 		return paginationTemplate(this);
 	}

--- a/src/components/navigation/pagination/ndd-pagination.ts
+++ b/src/components/navigation/pagination/ndd-pagination.ts
@@ -4,266 +4,138 @@
  * A pagination control for navigating between pages of content.
  *
  * @element ndd-pagination
- * @attr {number} current-page - Currently active page (1-based)
- * @attr {number} total-pages - Total number of pages
+ * @attr {number} current - Currently active page (1-based)
+ * @attr {number} total - Total number of pages
  * @attr {boolean} disabled - Disabled state
+ * @attr {boolean} full-width - Centreert de pagination in de container
  *
  * @fires page-change - When the page changes (detail: { page: number })
- *
- * @csspart container - The pagination container
- * @csspart button - Individual page buttons
- * @csspart button-active - The active page button
  */
 
-import { LitElement, html, css, nothing } from 'lit';
+import { LitElement } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
+import { paginationStyles } from './ndd-pagination.styles.ts';
+import { paginationTemplate } from './ndd-pagination.template.ts';
+import { nddPaginationTranslations } from './ndd-pagination.i18n.ts';
+import type { NDDPaginationTranslations } from './ndd-pagination.i18n.ts';
 
 @customElement('ndd-pagination')
 export class NDDPagination extends LitElement {
-	static override styles = css`
-		:host {
-			display: inline-block;
-			font-family: var(--ndd-font-family-body);
-		}
+	static override styles = paginationStyles;
 
-		:host([hidden]) {
-			display: none;
-		}
+	@property({ type: Number, reflect: true })
+	current = 1;
 
-		.pagination {
-			display: inline-flex;
-			align-items: center;
-			background-color: var(--primitives-color-neutral-100);
-			border-radius: var(--semantics-controls-md-corner-radius);
-			overflow: hidden;
-		}
-
-		.pagination__button {
-			appearance: none;
-			border: none;
-			background: transparent;
-			cursor: pointer;
-			display: inline-flex;
-			align-items: center;
-			justify-content: center;
-			height: 44px;
-			padding: var(--primitives-space-8) var(--primitives-space-12);
-			font: var(--semantics-buttons-md-font);
-			color: var(--primitives-color-neutral-900);
-			box-sizing: border-box;
-			position: relative;
-			min-width: 44px;
-			transition: background-color 0.15s ease;
-		}
-
-		.pagination__button:hover:not(:disabled):not(.pagination__button--active) {
-			background-color: var(--primitives-color-neutral-200);
-		}
-
-		.pagination__button:focus-visible {
-			box-shadow: 0 0 0 var(--semantics-focus-ring-center-thickness) var(--semantics-focus-ring-center-color);
-			outline: var(--semantics-focus-ring-edge-thickness) double var(--semantics-focus-ring-edge-color);
-			z-index: 1;
-		}
-
-		.pagination__button:disabled {
-			opacity: var(--primitives-opacity-disabled);
-		}
-
-		.pagination__button--active {
-			color: var(--primitives-color-neutral-0);
-		}
-
-		.pagination__button--active::before {
-			content: '';
-			position: absolute;
-			inset: 4px;
-			background-color: var(--primitives-color-accent-750);
-			border-radius: var(--primitives-corner-radius-sm);
-		}
-
-		.pagination__button-label {
-			position: relative;
-			z-index: 1;
-		}
-
-		.pagination__button--nav {
-			padding: 0 var(--primitives-space-8);
-			min-width: auto;
-		}
-
-		.pagination__divider {
-			width: 1px;
-			height: 28px;
-			background-color: var(--primitives-color-neutral-250);
-			flex-shrink: 0;
-		}
-
-		.pagination__button--ellipsis {
-			cursor: default;
-			pointer-events: none;
-		}
-
-		.pagination__icon {
-			width: 24px;
-			height: 24px;
-			display: block;
-		}
-
-		/* Disabled state for entire component */
-		:host([disabled]) .pagination {
-			opacity: var(--primitives-opacity-disabled);
-			pointer-events: none;
-		}
-
-		/* Accessibility: Reduced motion */
-		@media (prefers-reduced-motion: reduce) {
-			.pagination__button {
-				transition: none;
-			}
-		}
-
-		/* Accessibility: High Contrast Mode */
-		@media (forced-colors: active) {
-			.pagination {
-				border: 1px solid CanvasText;
-			}
-
-			.pagination__button--active {
-				color: HighlightText;
-			}
-
-			.pagination__button--active::before {
-				background-color: Highlight;
-			}
-
-			.pagination__button:focus-visible {
-				outline: 2px solid CanvasText !important;
-			}
-		}
-	`;
-
-	@property({ type: Number, reflect: true, attribute: 'current-page' })
-	currentPage = 1;
-
-	@property({ type: Number, reflect: true, attribute: 'total-pages' })
-	totalPages = 1;
+	@property({ type: Number, reflect: true })
+	total = 1;
 
 	@property({ type: Boolean, reflect: true })
 	disabled = false;
 
-	private _getVisiblePages(): (number | 'ellipsis')[] {
-		const total = this.totalPages;
-		const current = this.currentPage;
+	@property({ type: Boolean, reflect: true, attribute: 'full-width' })
+	fullWidth = false;
 
-		if (total <= 7) {
-			return Array.from({ length: total }, (_, i) => i + 1);
+	@property({ type: Object })
+	translations: Partial<NDDPaginationTranslations> = {};
+
+	private _mergedTranslations = { ...nddPaginationTranslations };
+
+	override updated(changed: Map<string, unknown>): void {
+		if (changed.has('translations')) {
+			this._mergedTranslations = { ...nddPaginationTranslations, ...this.translations };
+		}
+	}
+
+	_t(key: keyof NDDPaginationTranslations, params?: Record<string, string | number>): string {
+		let text = this._mergedTranslations[key] ?? key;
+		if (params) {
+			for (const [k, v] of Object.entries(params)) {
+				text = text.replace(`{${k}}`, String(v));
+			}
+		}
+		return text;
+	}
+
+	_getVisiblePages(): (number | 'ellipsis')[] {
+		if (this.total <= 7) {
+			return Array.from({ length: this.total }, (_, i) => i + 1);
 		}
 
 		// Always show exactly 7 slots for consistent width
-		if (current <= 3) {
-			// Near start: first 4 + ellipsis + last 2
-			return [1, 2, 3, 4, 'ellipsis', total - 1, total];
+		if (this.current <= 3) {
+			return [1, 2, 3, 4, 'ellipsis', this.total - 1, this.total];
 		}
 
-		if (current === 4) {
-			// Transition from start: first 5 + ellipsis + last 1
-			return [1, 2, 3, 4, 5, 'ellipsis', total];
+		if (this.current === 4) {
+			return [1, 2, 3, 4, 5, 'ellipsis', this.total];
 		}
 
-		if (current >= total - 3) {
-			// Near end: first 1 + ellipsis + last 5
-			return [1, 'ellipsis', total - 4, total - 3, total - 2, total - 1, total];
+		if (this.current >= this.total - 3) {
+			return [1, 'ellipsis', this.total - 4, this.total - 3, this.total - 2, this.total - 1, this.total];
 		}
 
-		// Middle: first 1 + ellipsis + 3 around current + ellipsis + last 1
-		return [1, 'ellipsis', current - 1, current, current + 1, 'ellipsis', total];
+		return [1, 'ellipsis', this.current - 1, this.current, this.current + 1, 'ellipsis', this.total];
 	}
 
-	private _goToPage(page: number): void {
-		if (this.disabled || page < 1 || page > this.totalPages || page === this.currentPage) {
+	_goToPage(page: number): void {
+		if (this.disabled || page < 1 || page > this.total || page === this.current) {
 			return;
 		}
 
-		this.currentPage = page;
+		this.current = page;
 		this.dispatchEvent(
 			new CustomEvent('page-change', {
-				detail: { page: this.currentPage },
+				detail: { page: this.current },
 				bubbles: true,
 				composed: true,
 			})
 		);
 	}
 
-	private _renderChevronLeft() {
-		return html`
-			<svg class="pagination__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-				<polyline points="15 18 9 12 15 6"></polyline>
-			</svg>
-		`;
+	_handleKeyDown = (e: KeyboardEvent): void => {
+		const buttons = Array.from(
+			this.shadowRoot!.querySelectorAll<HTMLButtonElement>('.pagination__page-button')
+		);
+		const target = e.composedPath()[0] as HTMLElement;
+		const index = buttons.indexOf(target as HTMLButtonElement);
+
+		if (index === -1) return;
+
+		let next: number | undefined;
+
+		switch (e.key) {
+			case 'ArrowRight':
+				next = index < buttons.length - 1 ? index + 1 : 0;
+				break;
+			case 'ArrowLeft':
+				next = index > 0 ? index - 1 : buttons.length - 1;
+				break;
+			case 'Home':
+				next = 0;
+				break;
+			case 'End':
+				next = buttons.length - 1;
+				break;
+			default:
+				return;
+		}
+
+		e.preventDefault();
+		buttons[next].focus();
 	}
 
-	private _renderChevronRight() {
-		return html`
-			<svg class="pagination__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-				<polyline points="9 18 15 12 9 6"></polyline>
-			</svg>
-		`;
+	override connectedCallback(): void {
+		super.connectedCallback();
+		this.addEventListener('keydown', this._handleKeyDown);
+	}
+
+	override disconnectedCallback(): void {
+		super.disconnectedCallback();
+		this.removeEventListener('keydown', this._handleKeyDown);
 	}
 
 	override render() {
-		const pages = this._getVisiblePages();
-		const atFirst = this.currentPage <= 1;
-		const atLast = this.currentPage >= this.totalPages;
-
-		return html`
-			<nav class="pagination" part="container" role="navigation" aria-label="Paginering">
-				<button
-					class="pagination__button pagination__button--nav"
-					part="button"
-					type="button"
-					?disabled=${atFirst}
-					aria-label="Vorige pagina"
-					@click=${() => this._goToPage(this.currentPage - 1)}
-				>
-					${this._renderChevronLeft()}
-				</button>
-
-				<div class="pagination__divider" aria-hidden="true"></div>
-
-				${pages.map((page) =>
-					page === 'ellipsis'
-						? html`<span class="pagination__button pagination__button--ellipsis" aria-hidden="true">
-								<span class="pagination__button-label">...</span>
-							</span>`
-						: html`
-								<button
-									class="pagination__button ${page === this.currentPage ? 'pagination__button--active' : ''}"
-									part=${page === this.currentPage ? 'button-active' : 'button'}
-									type="button"
-									aria-label="Pagina ${page}"
-									aria-current=${page === this.currentPage ? 'page' : nothing}
-									@click=${() => this._goToPage(page as number)}
-								>
-									<span class="pagination__button-label">${page}</span>
-								</button>
-							`
-				)}
-
-				<div class="pagination__divider" aria-hidden="true"></div>
-
-				<button
-					class="pagination__button pagination__button--nav"
-					part="button"
-					type="button"
-					?disabled=${atLast}
-					aria-label="Volgende pagina"
-					@click=${() => this._goToPage(this.currentPage + 1)}
-				>
-					${this._renderChevronRight()}
-				</button>
-			</nav>
-		`;
+		return paginationTemplate(this);
 	}
 }
 

--- a/src/components/navigation/pagination/ndd-pagination.ts
+++ b/src/components/navigation/pagination/ndd-pagination.ts
@@ -121,6 +121,7 @@ export class NDDPagination extends LitElement {
 				return;
 		}
 
+		if (next === undefined) return;
 		e.preventDefault();
 		buttons[next].focus();
 	}

--- a/src/components/navigation/pagination/ndd-pagination.ts
+++ b/src/components/navigation/pagination/ndd-pagination.ts
@@ -83,7 +83,9 @@ export class NDDPagination extends LitElement {
 	}
 
 	_hrefForPage(page: number): string {
-		return this.hrefPattern.replace('{page}', String(page));
+		const href = this.hrefPattern.replace('{page}', String(page));
+		if (/^(https?:\/\/|\/|\.|\?|#)/.test(href)) return href;
+		return '';
 	}
 
 	_goToPage(page: number): void {

--- a/src/components/navigation/pagination/ndd-pagination.ts
+++ b/src/components/navigation/pagination/ndd-pagination.ts
@@ -13,6 +13,7 @@
  */
 
 import { LitElement } from 'lit';
+import type { PropertyValues } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { paginationStyles } from './ndd-pagination.styles.ts';
 import { paginationTemplate } from './ndd-pagination.template.ts';
@@ -40,7 +41,7 @@ export class NDDPagination extends LitElement {
 
 	private _mergedTranslations = { ...nddPaginationTranslations };
 
-	override willUpdate(changed: Map<string, unknown>): void {
+	override willUpdate(changed: PropertyValues): void {
 		if (changed.has('translations')) {
 			this._mergedTranslations = { ...nddPaginationTranslations, ...this.translations };
 		}
@@ -105,10 +106,10 @@ export class NDDPagination extends LitElement {
 
 		switch (e.key) {
 			case 'ArrowRight':
-				next = index < buttons.length - 1 ? index + 1 : 0;
+				next = index < buttons.length - 1 ? index + 1 : undefined;
 				break;
 			case 'ArrowLeft':
-				next = index > 0 ? index - 1 : buttons.length - 1;
+				next = index > 0 ? index - 1 : undefined;
 				break;
 			case 'Home':
 				next = 0;

--- a/src/components/navigation/pagination/ndd-pagination.ts
+++ b/src/components/navigation/pagination/ndd-pagination.ts
@@ -8,6 +8,7 @@
  * @attr {number} total - Total number of pages (recommended max: 200 for compact select performance)
  * @attr {boolean} disabled - Disabled state
  * @attr {boolean} full-width - Centreert de pagination in de container
+ * @attr {string} href-pattern - URL patroon met {page} placeholder, rendert links in plaats van buttons
  *
  * @fires page-change - When the page changes (detail: { page: number })
  */
@@ -35,6 +36,9 @@ export class NDDPagination extends LitElement {
 
 	@property({ type: Boolean, reflect: true, attribute: 'full-width' })
 	fullWidth = false;
+
+	@property({ type: String, attribute: 'href-pattern' })
+	hrefPattern = '';
 
 	@property({ type: Object })
 	translations: Partial<NDDPaginationTranslations> = {};
@@ -76,6 +80,10 @@ export class NDDPagination extends LitElement {
 		}
 
 		return [1, 'ellipsis', this.current - 1, this.current, this.current + 1, 'ellipsis', this.total];
+	}
+
+	_hrefForPage(page: number): string {
+		return this.hrefPattern.replace('{page}', String(page));
 	}
 
 	_goToPage(page: number): void {

--- a/src/components/navigation/pagination/ndd-pagination.ts
+++ b/src/components/navigation/pagination/ndd-pagination.ts
@@ -5,7 +5,7 @@
  *
  * @element ndd-pagination
  * @attr {number} current - Currently active page (1-based)
- * @attr {number} total - Total number of pages
+ * @attr {number} total - Total number of pages (recommended max: 200 for compact select performance)
  * @attr {boolean} disabled - Disabled state
  * @attr {boolean} full-width - Centreert de pagination in de container
  *

--- a/src/components/navigation/pagination/ndd-pagination.ts
+++ b/src/components/navigation/pagination/ndd-pagination.ts
@@ -40,7 +40,7 @@ export class NDDPagination extends LitElement {
 
 	private _mergedTranslations = { ...nddPaginationTranslations };
 
-	override updated(changed: Map<string, unknown>): void {
+	override willUpdate(changed: Map<string, unknown>): void {
 		if (changed.has('translations')) {
 			this._mergedTranslations = { ...nddPaginationTranslations, ...this.translations };
 		}

--- a/src/components/navigation/pagination/ndd-pagination.ts
+++ b/src/components/navigation/pagination/ndd-pagination.ts
@@ -10,7 +10,7 @@
  * @attr {boolean} full-width - Centreert de pagination in de container
  * @attr {string} href-pattern - URL patroon met {page} placeholder, rendert links in plaats van buttons
  *
- * @fires page-change - When the page changes (detail: { page: number, href?: string }). In href mode, call event.preventDefault() to handle navigation yourself (SPA).
+ * @fires page-change - Bij paginawisseling (detail: { page: number, href?: string }). Alleen cancelable in href-mode: preventDefault() voorkomt navigatie (SPA).
  */
 
 import { LitElement } from 'lit';
@@ -93,21 +93,21 @@ export class NDDPagination extends LitElement {
 			return;
 		}
 
-		this.current = page;
-
-		const detail: { page: number; href?: string } = { page: this.current };
+		const detail: { page: number; href?: string } = { page };
 		if (this.hrefPattern) {
-			detail.href = this._hrefForPage(this.current);
+			detail.href = this._hrefForPage(page);
 		}
 
+		const cancelable = !!this.hrefPattern;
 		const event = new CustomEvent('page-change', {
 			detail,
 			bubbles: true,
 			composed: true,
-			cancelable: true,
+			cancelable,
 		});
 
 		const proceeded = this.dispatchEvent(event);
+		this.current = page;
 
 		// In href mode, navigate unless consumer called preventDefault()
 		if (this.hrefPattern && proceeded && detail.href) {


### PR DESCRIPTION
Split monolithic component into standard structure:
- ndd-pagination.styles.ts — BEM + state classes, semantic tokens
- ndd-pagination.template.ts — ndd-icon-button for nav, indicator pattern
- ndd-pagination.i18n.ts — translatable strings (ndd-list pattern)

Changes:
- current-page → current, total-pages → total
- ndd-icon-button for prev/next navigation
- Indicator overlay for hover/selected/focus (segmented-control pattern)
- Responsive: @container query switches to <select> picker on small widths
- i18n: all strings translatable via translations property
- No cursor:pointer, no overflow:hidden, focus ring on indicator only

BREAKING CHANGE: current-page → current, total-pages → total