### PR TITLE
feat!: rename title-bar to title, move from layout to content

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@minbzk/storybook",
-  "version": "0.8.16",
+  "version": "0.8.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@minbzk/storybook",
-      "version": "0.8.16",
+      "version": "0.8.17",
       "license": "EUPL-1.2",
       "dependencies": {
         "@floating-ui/dom": "^1.7.6",

--- a/src/assets/styles/settings.css
+++ b/src/assets/styles/settings.css
@@ -927,14 +927,14 @@
 	--components-page-fixed-area-tinted-background-gradient-color-3: rgba(245, 246, 249, 0);
 
 
-	--components-title-bar-sm-overline-font: var(--primitives-font-body-sm-regular-tight);
-	--components-title-bar-sm-subtitle-font: var(--primitives-font-body-md-regular-tight);
+	--components-title-sm-overline-font: var(--primitives-font-body-sm-regular-tight);
+	--components-title-sm-subtitle-font: var(--primitives-font-body-md-regular-tight);
 
-	--components-title-bar-md-overline-font: var(--primitives-font-body-sm-regular-tight);
-	--components-title-bar-md-subtitle-font: var(--primitives-font-body-md-regular-tight);
+	--components-title-md-overline-font: var(--primitives-font-body-sm-regular-tight);
+	--components-title-md-subtitle-font: var(--primitives-font-body-md-regular-tight);
 
-	--components-title-bar-lg-overline-font: var(--primitives-font-body-md-regular-tight);
-	--components-title-bar-lg-subtitle-font: var(--primitives-font-body-md-regular-tight);
+	--components-title-lg-overline-font: var(--primitives-font-body-md-regular-tight);
+	--components-title-lg-subtitle-font: var(--primitives-font-body-md-regular-tight);
 
 	--components-sheet-box-shadow: var(--primitives-box-shadows-level-5);
 	--components-sheet-side-inset: var(--primitives-space-16);

--- a/src/components/content/title/ndd-title.stories.js
+++ b/src/components/content/title/ndd-title.stories.js
@@ -1,7 +1,7 @@
 import { html } from 'lit';
-import './ndd-title-bar.ts';
+import './ndd-title.ts';
 import '../../actions/button/ndd-button.ts';
-import '../spacer/ndd-spacer.ts';
+import '../../layout/spacer/ndd-spacer.ts';
 
 /**
  * Gebruik een title bar om een paginatitel of sectietitel te tonen met
@@ -10,21 +10,21 @@ import '../spacer/ndd-spacer.ts';
  *
  * ## Gebruik
  * ```html
- * <ndd-title-bar size="3">
+ * <ndd-title size="3">
  *   <p slot="overline">Overline</p>
  *   <h1>Paginatitel</h1>
  *   <p slot="subtitle">Ondertitel</p>
  *   <ndd-button slot="actions" text="Actie"></ndd-button>
- * </ndd-title-bar>
+ * </ndd-title>
  * ```
  */
 export default {
-	title: 'Components/Layout/Title Bar',
-	component: 'ndd-title-bar',
+	title: 'Components/Content/Title',
+	component: 'ndd-title',
 	tags: ['autodocs'],
 	parameters: {
 		componentSource: {
-			file: 'src/components/layout/title-bar/ndd-title-bar.ts',
+			file: 'src/components/content/title/ndd-title.ts',
 			repository: 'https://github.com/MinBZK/storybook',
 		},
 		status: {
@@ -46,52 +46,52 @@ export default {
 
 export const Standaard = ({ size }) => html`
 	<div style="display: block; padding: 24px; container-type: inline-size; container-name: layout-area;">
-		<ndd-title-bar size=${size}>
+		<ndd-title size=${size}>
 			<h1>Paginatitel</h1>
 			<ndd-button slot="actions" variant="secondary" size="sm" text="Actie"></ndd-button>
-		</ndd-title-bar>
+		</ndd-title>
 	</div>
 `;
 
 export const MetOverline = () => html`
 	<div style="display: block; padding: 24px; container-type: inline-size; container-name: layout-area;">
-		<ndd-title-bar>
+		<ndd-title>
 			<p slot="overline">Wet op de zorgtoeslag</p>
 			<h1>Artikel 1</h1>
-		</ndd-title-bar>
+		</ndd-title>
 	</div>
 `;
 MetOverline.parameters = { controls: { disable: true } };
 
 export const MetOndertitel = () => html`
 	<div style="display: block; padding: 24px; container-type: inline-size; container-name: layout-area;">
-		<ndd-title-bar>
+		<ndd-title>
 			<h1>Wet op de zorgtoeslag</h1>
 			<p slot="subtitle">Laatste wijziging: 1 januari 2024</p>
-		</ndd-title-bar>
+		</ndd-title>
 	</div>
 `;
 MetOndertitel.parameters = { controls: { disable: true } };
 
 export const MetOverlineEnOndertitel = () => html`
 	<div style="display: block; padding: 24px; container-type: inline-size; container-name: layout-area;">
-		<ndd-title-bar>
+		<ndd-title>
 			<p slot="overline">Hoofdstuk 1</p>
 			<h1>Begripsbepalingen</h1>
 			<p slot="subtitle">Ingangsdatum: 1 januari 2024</p>
-		</ndd-title-bar>
+		</ndd-title>
 	</div>
 `;
 MetOverlineEnOndertitel.parameters = { controls: { disable: true } };
 
 export const MetActies = () => html`
 	<div style="display: block; padding: 24px; container-type: inline-size; container-name: layout-area;">
-		<ndd-title-bar>
+		<ndd-title>
 			<h1>Wet op de zorgtoeslag</h1>
 			<ndd-button slot="actions" variant="secondary" size="sm" text="Bewerken"></ndd-button>
 			<ndd-spacer slot="actions" size="8"></ndd-spacer>
 			<ndd-button slot="actions" size="sm" text="Opslaan"></ndd-button>
-		</ndd-title-bar>
+		</ndd-title>
 	</div>
 `;
 MetActies.parameters = { controls: { disable: true } };
@@ -99,9 +99,9 @@ MetActies.parameters = { controls: { disable: true } };
 export const AlleGrootten = () => html`
 	<div style="display: flex; flex-direction: column; gap: 24px; padding: 24px; container-type: inline-size; container-name: layout-area;">
 		${[1, 2, 3, 4, 5, 6].map(s => html`
-			<ndd-title-bar size=${s}>
+			<ndd-title size=${s}>
 				<h1>Grootte ${s}</h1>
-			</ndd-title-bar>
+			</ndd-title>
 		`)}
 	</div>
 `;

--- a/src/components/content/title/ndd-title.styles.ts
+++ b/src/components/content/title/ndd-title.styles.ts
@@ -7,9 +7,9 @@ const mdMax = unsafeCSS(breakpoints.mdMax);
 const lgMin = unsafeCSS(breakpoints.lgMin);
 
 
-/* # ndd-title-bar styles */
+/* # ndd-title styles */
 
-export const titleBarStyles = css`
+export const titleStyles = css`
 	:host {
 		display: flex;
 		container-type: inline-size;
@@ -22,7 +22,7 @@ export const titleBarStyles = css`
 
 	/* # Title bar */
 
-	.title-bar {
+	.title {
 		display: flex;
 		flex-direction: row;
 		align-items: center;
@@ -33,7 +33,7 @@ export const titleBarStyles = css`
 
 	/* # Title group */
 
-	.title-bar__title-group {
+	.title__title-group {
 		display: flex;
 		flex-direction: column;
 		flex: 1;
@@ -70,7 +70,7 @@ export const titleBarStyles = css`
 
 	/* # Actions */
 
-	.title-bar__actions {
+	.title__actions {
 		display: flex;
 		flex-direction: row;
 		align-items: center;

--- a/src/components/content/title/ndd-title.template.ts
+++ b/src/components/content/title/ndd-title.template.ts
@@ -1,14 +1,14 @@
 import { html, TemplateResult } from 'lit';
 
-export function titleBarTemplate(): TemplateResult {
+export function titleTemplate(): TemplateResult {
 	return html`
-		<div class="title-bar">
-			<div class="title-bar__title-group">
+		<div class="title">
+			<div class="title__title-group">
 				<slot name="overline"></slot>
 				<slot></slot>
 				<slot name="subtitle"></slot>
 			</div>
-			<div class="title-bar__actions">
+			<div class="title__actions">
 				<slot name="actions"></slot>
 			</div>
 		</div>

--- a/src/components/content/title/ndd-title.test.ts
+++ b/src/components/content/title/ndd-title.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect, afterEach } from 'vitest';
 import { fixture, cleanup, waitForUpdate } from '../../../test-utils.ts';
-import './ndd-title-bar.ts';
+import './ndd-title.ts';
 
-describe('ndd-title-bar', () => {
+describe('ndd-title', () => {
 	let el: HTMLElement;
 
 	afterEach(() => {
@@ -10,46 +10,46 @@ describe('ndd-title-bar', () => {
 	});
 
 	it('renders without error', async () => {
-		el = await fixture('<ndd-title-bar></ndd-title-bar>');
+		el = await fixture('<ndd-title></ndd-title>');
 		await waitForUpdate(el);
 		expect(el.shadowRoot).not.toBeNull();
 	});
 
 	it('defaults to size 3', async () => {
-		el = await fixture('<ndd-title-bar></ndd-title-bar>');
+		el = await fixture('<ndd-title></ndd-title>');
 		await waitForUpdate(el);
 		expect(el.getAttribute('size')).toBe('3');
 	});
 
 	it('reflects size attribute', async () => {
-		el = await fixture('<ndd-title-bar size="1"></ndd-title-bar>');
+		el = await fixture('<ndd-title size="1"></ndd-title>');
 		await waitForUpdate(el);
 		expect(el.getAttribute('size')).toBe('1');
 	});
 
 	it('renders slotted title content', async () => {
-		el = await fixture('<ndd-title-bar><h1>Paginatitel</h1></ndd-title-bar>');
+		el = await fixture('<ndd-title><h1>Paginatitel</h1></ndd-title>');
 		await waitForUpdate(el);
 		expect(el.querySelector('h1')?.textContent?.trim()).toBe('Paginatitel');
 		expect(el.shadowRoot!.querySelector('slot:not([name])')!.assignedElements().length).toBeGreaterThan(0);
 	});
 
 	it('renders slotted overline content', async () => {
-		el = await fixture('<ndd-title-bar><p slot="overline">Overline</p></ndd-title-bar>');
+		el = await fixture('<ndd-title><p slot="overline">Overline</p></ndd-title>');
 		await waitForUpdate(el);
 		expect(el.querySelector('[slot="overline"]')?.textContent?.trim()).toBe('Overline');
 		expect(el.shadowRoot!.querySelector('slot[name="overline"]')!.assignedElements().length).toBeGreaterThan(0);
 	});
 
 	it('renders slotted subtitle content', async () => {
-		el = await fixture('<ndd-title-bar><p slot="subtitle">Ondertitel</p></ndd-title-bar>');
+		el = await fixture('<ndd-title><p slot="subtitle">Ondertitel</p></ndd-title>');
 		await waitForUpdate(el);
 		expect(el.querySelector('[slot="subtitle"]')?.textContent?.trim()).toBe('Ondertitel');
 		expect(el.shadowRoot!.querySelector('slot[name="subtitle"]')!.assignedElements().length).toBeGreaterThan(0);
 	});
 
 	it('renders slotted actions', async () => {
-		el = await fixture('<ndd-title-bar><button slot="actions">Actie</button></ndd-title-bar>');
+		el = await fixture('<ndd-title><button slot="actions">Actie</button></ndd-title>');
 		await waitForUpdate(el);
 		expect(el.querySelector('[slot="actions"]')?.textContent?.trim()).toBe('Actie');
 		expect(el.shadowRoot!.querySelector('slot[name="actions"]')!.assignedElements().length).toBeGreaterThan(0);

--- a/src/components/content/title/ndd-title.ts
+++ b/src/components/content/title/ndd-title.ts
@@ -4,7 +4,7 @@
  * A title bar with an optional overline, title, and subtitle on the left,
  * and a slot for actions on the right.
  *
- * @element ndd-title-bar
+ * @element ndd-title
  *
  * @attr {number} size - Visual size of the title: 1–6 (default: 3)
  *
@@ -15,25 +15,25 @@
  */
 import { LitElement } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
-import { titleBarStyles } from './ndd-title-bar.styles.ts';
-import { titleBarTemplate } from './ndd-title-bar.template.ts';
+import { titleStyles } from './ndd-title.styles.ts';
+import { titleTemplate } from './ndd-title.template.ts';
 
 type Size = 1 | 2 | 3 | 4 | 5 | 6;
 
-@customElement('ndd-title-bar')
-export class NDDTitleBar extends LitElement {
-	static override styles = titleBarStyles;
+@customElement('ndd-title')
+export class NDDTitle extends LitElement {
+	static override styles = titleStyles;
 
 	@property({ type: Number, reflect: true })
 	size: Size = 3;
 
 	override render() {
-		return titleBarTemplate();
+		return titleTemplate();
 	}
 }
 
 declare global {
 	interface HTMLElementTagNameMap {
-		'ndd-title-bar': NDDTitleBar;
+		'ndd-title': NDDTitle;
 	}
 }

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -72,7 +72,7 @@ export { NDDOneThirdTwoThirdsSection } from './layout/page-sections/one-third-tw
 export { NDDTwoThirdsOneThirdSection } from './layout/page-sections/two-thirds-one-third-section/ndd-two-thirds-one-third-section.ts';
 export { NDDOneHalfOneHalfSection } from './layout/page-sections/one-half-one-half-section/ndd-one-half-one-half-section.ts';
 
-export { NDDTitleBar } from './layout/title-bar/ndd-title-bar.ts';
+export { NDDTitle } from './content/title/ndd-title.ts';
 
 export { NDDBox } from './layout/box/ndd-box.ts';
 export { NDDCollection } from './layout/collection/ndd-collection.ts';

--- a/src/components/lists-and-menus/list/ndd-list.stories.js
+++ b/src/components/lists-and-menus/list/ndd-list.stories.js
@@ -5,7 +5,7 @@ import '../cells/title-cell/ndd-title-cell.ts';
 import '../cells/text-cell/ndd-text-cell.ts';
 import '../cells/spacer-cell/ndd-spacer-cell.ts';
 import '../cells/drag-handle-cell/ndd-drag-handle-cell.ts';
-import '../../layout/title-bar/ndd-title-bar.ts';
+import '../../content/title/ndd-title.ts';
 import '../../content/rich-text/ndd-rich-text.ts';
 
 export default {
@@ -93,9 +93,9 @@ export const VariantInset = {
 export const WithHeaderAndFooter = {
 	render: () => html`
 		<ndd-list variant="box">
-			<ndd-title-bar slot="header" size="4">
+			<ndd-title slot="header" size="4">
 				<h5>Notifications</h5>
-			</ndd-title-bar>
+			</ndd-title>
 			<ndd-list-item>
 				<ndd-text-cell text="Allow notifications" />
 			</ndd-list-item>

--- a/src/components/lists-and-menus/list/ndd-list.ts
+++ b/src/components/lists-and-menus/list/ndd-list.ts
@@ -18,7 +18,7 @@ export interface NDDReorderEventDetail {
  * When `reorderable` is set, items can be reordered by drag or keyboard.
  *
  * @slot         - List items (`ndd-list-item`)
- * @slot header  - Content above the list body (e.g. `ndd-title-bar`)
+ * @slot header  - Content above the list body (e.g. `ndd-title`)
  * @slot footer  - Content below the list body (e.g. a short description)
  *
  * @fires ndd-reorder - Fired on successful drop: `{ fromIndex, toIndex }`

--- a/src/components/navigation/top-title-bar/ndd-top-title-bar.stories.js
+++ b/src/components/navigation/top-title-bar/ndd-top-title-bar.stories.js
@@ -5,7 +5,7 @@ import '../../actions/button/ndd-button.ts';
 import '../../actions/icon-button/ndd-icon-button.ts';
 import '../../layout/page/ndd-page.ts';
 import '../../layout/page-sections/simple-section/ndd-simple-section.ts';
-import '../../layout/title-bar/ndd-title-bar.ts';
+import '../../content/title/ndd-title.ts';
 
 /**
  * De Top Title Bar is de werkbalk van een pagina of container.
@@ -184,10 +184,10 @@ export const MetTitelAnker = () => html`
 			@dismiss=${action('dismiss')}
 		></ndd-top-title-bar>
 		<ndd-simple-section>
-			<ndd-title-bar id="page-title-bar" size="2">
+			<ndd-title id="page-title-bar" size="2">
 				<h1>Paginatitel</h1>
 				<p slot="subtitle">Scroll omlaag om te zien hoe de compacte stand wordt geactiveerd.</p>
-			</ndd-title-bar>
+			</ndd-title>
 			<div style="height: 600px;"></div>
 		</ndd-simple-section>
 	</ndd-page>
@@ -211,10 +211,10 @@ export const MetTitelAnkerZonderActies = () => html`
 			@dismiss=${action('dismiss')}
 		></ndd-top-title-bar>
 		<ndd-simple-section>
-			<ndd-title-bar id="page-title-bar-2" size="2">
+			<ndd-title id="page-title-bar-2" size="2">
 				<h1>Paginatitel</h1>
 				<p slot="subtitle">Zonder terugknop of sluitknop.</p>
-			</ndd-title-bar>
+			</ndd-title>
 			<div style="height: 600px;"></div>
 		</ndd-simple-section>
 	</ndd-page>


### PR DESCRIPTION
- ndd-title-bar → ndd-title
- NDDTitleBar → NDDTitle
- layout/title-bar/ → content/title/
- --components-title-bar-* → --components-title-*
- Updated all imports, stories, tests, exports and CSS variables

BREAKING CHANGE: ndd-title-bar renamed to ndd-title, moved to content category