### PR TITLE
feat(layout): stretch last page section and add align attribute

### DIFF
--- a/src/components/layout/page-sections/full-bleed-section/ndd-full-bleed-section.styles.ts
+++ b/src/components/layout/page-sections/full-bleed-section/ndd-full-bleed-section.styles.ts
@@ -17,6 +17,10 @@ export const fullBleedSectionStyles = css`
 		display: none;
 	}
 
+	:host([align="center"]) {
+		justify-content: center;
+	}
+
 
 	/* # Section */
 

--- a/src/components/layout/page-sections/full-bleed-section/ndd-full-bleed-section.test.ts
+++ b/src/components/layout/page-sections/full-bleed-section/ndd-full-bleed-section.test.ts
@@ -21,8 +21,10 @@ describe('ndd-full-bleed-section', () => {
 		expect(el.shadowRoot!.querySelector('.full-bleed-section')).not.toBeNull();
 	});
 
-	it('reflects align attribute to the host', async () => {
-		el = await fixture('<ndd-full-bleed-section align="center"></ndd-full-bleed-section>');
+	it('reflects align property to attribute', async () => {
+		el = await fixture('<ndd-full-bleed-section></ndd-full-bleed-section>');
+		await waitForUpdate(el);
+		(el as any).align = 'center';
 		await waitForUpdate(el);
 		expect(el.getAttribute('align')).toBe('center');
 	});

--- a/src/components/layout/page-sections/full-bleed-section/ndd-full-bleed-section.test.ts
+++ b/src/components/layout/page-sections/full-bleed-section/ndd-full-bleed-section.test.ts
@@ -20,4 +20,10 @@ describe('ndd-full-bleed-section', () => {
 		await waitForUpdate(el);
 		expect(el.shadowRoot!.querySelector('.full-bleed-section')).not.toBeNull();
 	});
+
+	it('reflects align attribute to the host', async () => {
+		el = await fixture('<ndd-full-bleed-section align="center"></ndd-full-bleed-section>');
+		await waitForUpdate(el);
+		expect(el.getAttribute('align')).toBe('center');
+	});
 });

--- a/src/components/layout/page-sections/full-bleed-section/ndd-full-bleed-section.ts
+++ b/src/components/layout/page-sections/full-bleed-section/ndd-full-bleed-section.ts
@@ -12,13 +12,16 @@
  * @slot footer - Content below the main content
  */
 import { LitElement } from 'lit';
-import { customElement } from 'lit/decorators.js';
+import { customElement, property } from 'lit/decorators.js';
 import { fullBleedSectionStyles } from './ndd-full-bleed-section.styles.ts';
 import { fullBleedSectionTemplate } from './ndd-full-bleed-section.template.ts';
 
 @customElement('ndd-full-bleed-section')
 export class NDDFullBleedSection extends LitElement {
 	static override styles = fullBleedSectionStyles;
+
+	@property({ type: String, reflect: true })
+	align?: 'center';
 
 	override render() {
 		return fullBleedSectionTemplate(this);

--- a/src/components/layout/page-sections/full-bleed-section/ndd-full-bleed-section.ts
+++ b/src/components/layout/page-sections/full-bleed-section/ndd-full-bleed-section.ts
@@ -21,7 +21,7 @@ export class NDDFullBleedSection extends LitElement {
 	static override styles = fullBleedSectionStyles;
 
 	@property({ type: String, reflect: true })
-	align?: 'center';
+	align?: string;
 
 	override render() {
 		return fullBleedSectionTemplate(this);

--- a/src/components/layout/page-sections/one-half-one-half-section/ndd-one-half-one-half-section.styles.ts
+++ b/src/components/layout/page-sections/one-half-one-half-section/ndd-one-half-one-half-section.styles.ts
@@ -17,6 +17,10 @@ export const oneHalfOneHalfSectionStyles = css`
 		display: none;
 	}
 
+	:host([align="center"]) {
+		justify-content: center;
+	}
+
 
 	/* # Section */
 

--- a/src/components/layout/page-sections/one-half-one-half-section/ndd-one-half-one-half-section.test.ts
+++ b/src/components/layout/page-sections/one-half-one-half-section/ndd-one-half-one-half-section.test.ts
@@ -27,4 +27,10 @@ describe('ndd-one-half-one-half-section', () => {
 		expect(el.shadowRoot!.querySelector('.one-half-one-half-section__left-column')).not.toBeNull();
 		expect(el.shadowRoot!.querySelector('.one-half-one-half-section__right-column')).not.toBeNull();
 	});
+
+	it('reflects align attribute to the host', async () => {
+		el = await fixture('<ndd-one-half-one-half-section align="center"></ndd-one-half-one-half-section>');
+		await waitForUpdate(el);
+		expect(el.getAttribute('align')).toBe('center');
+	});
 });

--- a/src/components/layout/page-sections/one-half-one-half-section/ndd-one-half-one-half-section.test.ts
+++ b/src/components/layout/page-sections/one-half-one-half-section/ndd-one-half-one-half-section.test.ts
@@ -28,8 +28,10 @@ describe('ndd-one-half-one-half-section', () => {
 		expect(el.shadowRoot!.querySelector('.one-half-one-half-section__right-column')).not.toBeNull();
 	});
 
-	it('reflects align attribute to the host', async () => {
-		el = await fixture('<ndd-one-half-one-half-section align="center"></ndd-one-half-one-half-section>');
+	it('reflects align property to attribute', async () => {
+		el = await fixture('<ndd-one-half-one-half-section></ndd-one-half-one-half-section>');
+		await waitForUpdate(el);
+		(el as any).align = 'center';
 		await waitForUpdate(el);
 		expect(el.getAttribute('align')).toBe('center');
 	});

--- a/src/components/layout/page-sections/one-half-one-half-section/ndd-one-half-one-half-section.ts
+++ b/src/components/layout/page-sections/one-half-one-half-section/ndd-one-half-one-half-section.ts
@@ -23,7 +23,7 @@ export class NDDOneHalfOneHalfSection extends LitElement {
 	static override styles = oneHalfOneHalfSectionStyles;
 
 	@property({ type: String, reflect: true })
-	align?: 'center';
+	align?: string;
 
 	override render() {
 		return oneHalfOneHalfSectionTemplate(this);

--- a/src/components/layout/page-sections/one-half-one-half-section/ndd-one-half-one-half-section.ts
+++ b/src/components/layout/page-sections/one-half-one-half-section/ndd-one-half-one-half-section.ts
@@ -14,13 +14,16 @@
  * @slot footer - Content below the columns
  */
 import { LitElement } from 'lit';
-import { customElement } from 'lit/decorators.js';
+import { customElement, property } from 'lit/decorators.js';
 import { oneHalfOneHalfSectionStyles } from './ndd-one-half-one-half-section.styles.ts';
 import { oneHalfOneHalfSectionTemplate } from './ndd-one-half-one-half-section.template.ts';
 
 @customElement('ndd-one-half-one-half-section')
 export class NDDOneHalfOneHalfSection extends LitElement {
 	static override styles = oneHalfOneHalfSectionStyles;
+
+	@property({ type: String, reflect: true })
+	align?: 'center';
 
 	override render() {
 		return oneHalfOneHalfSectionTemplate(this);

--- a/src/components/layout/page-sections/one-third-two-thirds-section/ndd-one-third-two-thirds-section.styles.ts
+++ b/src/components/layout/page-sections/one-third-two-thirds-section/ndd-one-third-two-thirds-section.styles.ts
@@ -17,6 +17,10 @@ export const oneThirdTwoThirdsSectionStyles = css`
 		display: none;
 	}
 
+	:host([align="center"]) {
+		justify-content: center;
+	}
+
 
 	/* # Section */
 

--- a/src/components/layout/page-sections/one-third-two-thirds-section/ndd-one-third-two-thirds-section.test.ts
+++ b/src/components/layout/page-sections/one-third-two-thirds-section/ndd-one-third-two-thirds-section.test.ts
@@ -28,8 +28,10 @@ describe('ndd-one-third-two-thirds-section', () => {
 		expect(el.shadowRoot!.querySelector('.one-third-two-thirds-section__right-column')).not.toBeNull();
 	});
 
-	it('reflects align attribute to the host', async () => {
-		el = await fixture('<ndd-one-third-two-thirds-section align="center"></ndd-one-third-two-thirds-section>');
+	it('reflects align property to attribute', async () => {
+		el = await fixture('<ndd-one-third-two-thirds-section></ndd-one-third-two-thirds-section>');
+		await waitForUpdate(el);
+		(el as any).align = 'center';
 		await waitForUpdate(el);
 		expect(el.getAttribute('align')).toBe('center');
 	});

--- a/src/components/layout/page-sections/one-third-two-thirds-section/ndd-one-third-two-thirds-section.test.ts
+++ b/src/components/layout/page-sections/one-third-two-thirds-section/ndd-one-third-two-thirds-section.test.ts
@@ -27,4 +27,10 @@ describe('ndd-one-third-two-thirds-section', () => {
 		expect(el.shadowRoot!.querySelector('.one-third-two-thirds-section__left-column')).not.toBeNull();
 		expect(el.shadowRoot!.querySelector('.one-third-two-thirds-section__right-column')).not.toBeNull();
 	});
+
+	it('reflects align attribute to the host', async () => {
+		el = await fixture('<ndd-one-third-two-thirds-section align="center"></ndd-one-third-two-thirds-section>');
+		await waitForUpdate(el);
+		expect(el.getAttribute('align')).toBe('center');
+	});
 });

--- a/src/components/layout/page-sections/one-third-two-thirds-section/ndd-one-third-two-thirds-section.ts
+++ b/src/components/layout/page-sections/one-third-two-thirds-section/ndd-one-third-two-thirds-section.ts
@@ -14,13 +14,16 @@
  * @slot footer - Content below the columns
  */
 import { LitElement } from 'lit';
-import { customElement } from 'lit/decorators.js';
+import { customElement, property } from 'lit/decorators.js';
 import { oneThirdTwoThirdsSectionStyles } from './ndd-one-third-two-thirds-section.styles.ts';
 import { oneThirdTwoThirdsSectionTemplate } from './ndd-one-third-two-thirds-section.template.ts';
 
 @customElement('ndd-one-third-two-thirds-section')
 export class NDDOneThirdTwoThirdsSection extends LitElement {
 	static override styles = oneThirdTwoThirdsSectionStyles;
+
+	@property({ type: String, reflect: true })
+	align?: 'center';
 
 	override render() {
 		return oneThirdTwoThirdsSectionTemplate(this);

--- a/src/components/layout/page-sections/one-third-two-thirds-section/ndd-one-third-two-thirds-section.ts
+++ b/src/components/layout/page-sections/one-third-two-thirds-section/ndd-one-third-two-thirds-section.ts
@@ -23,7 +23,7 @@ export class NDDOneThirdTwoThirdsSection extends LitElement {
 	static override styles = oneThirdTwoThirdsSectionStyles;
 
 	@property({ type: String, reflect: true })
-	align?: 'center';
+	align?: string;
 
 	override render() {
 		return oneThirdTwoThirdsSectionTemplate(this);

--- a/src/components/layout/page-sections/simple-section/ndd-simple-section.styles.ts
+++ b/src/components/layout/page-sections/simple-section/ndd-simple-section.styles.ts
@@ -17,6 +17,10 @@ export const simpleSectionStyles = css`
 		display: none;
 	}
 
+	:host([align="center"]) {
+		justify-content: center;
+	}
+
 
 	/* # Section */
 

--- a/src/components/layout/page-sections/simple-section/ndd-simple-section.test.ts
+++ b/src/components/layout/page-sections/simple-section/ndd-simple-section.test.ts
@@ -21,8 +21,10 @@ describe('ndd-simple-section', () => {
 		expect(el.shadowRoot!.querySelector('.simple-section')).not.toBeNull();
 	});
 
-	it('reflects align attribute to the host', async () => {
-		el = await fixture('<ndd-simple-section align="center"></ndd-simple-section>');
+	it('reflects align property to attribute', async () => {
+		el = await fixture('<ndd-simple-section></ndd-simple-section>');
+		await waitForUpdate(el);
+		(el as any).align = 'center';
 		await waitForUpdate(el);
 		expect(el.getAttribute('align')).toBe('center');
 	});

--- a/src/components/layout/page-sections/simple-section/ndd-simple-section.test.ts
+++ b/src/components/layout/page-sections/simple-section/ndd-simple-section.test.ts
@@ -20,4 +20,10 @@ describe('ndd-simple-section', () => {
 		await waitForUpdate(el);
 		expect(el.shadowRoot!.querySelector('.simple-section')).not.toBeNull();
 	});
+
+	it('reflects align attribute to the host', async () => {
+		el = await fixture('<ndd-simple-section align="center"></ndd-simple-section>');
+		await waitForUpdate(el);
+		expect(el.getAttribute('align')).toBe('center');
+	});
 });

--- a/src/components/layout/page-sections/simple-section/ndd-simple-section.ts
+++ b/src/components/layout/page-sections/simple-section/ndd-simple-section.ts
@@ -21,7 +21,7 @@ export class NDDSimpleSection extends LitElement {
 	static override styles = simpleSectionStyles;
 
 	@property({ type: String, reflect: true })
-	align?: 'center';
+	align?: string;
 
 	override render() {
 		return simpleSectionTemplate(this);

--- a/src/components/layout/page-sections/simple-section/ndd-simple-section.ts
+++ b/src/components/layout/page-sections/simple-section/ndd-simple-section.ts
@@ -12,13 +12,16 @@
  * @slot footer - Content below the main content
  */
 import { LitElement } from 'lit';
-import { customElement } from 'lit/decorators.js';
+import { customElement, property } from 'lit/decorators.js';
 import { simpleSectionStyles } from './ndd-simple-section.styles.ts';
 import { simpleSectionTemplate } from './ndd-simple-section.template.ts';
 
 @customElement('ndd-simple-section')
 export class NDDSimpleSection extends LitElement {
 	static override styles = simpleSectionStyles;
+
+	@property({ type: String, reflect: true })
+	align?: 'center';
 
 	override render() {
 		return simpleSectionTemplate(this);

--- a/src/components/layout/page-sections/two-thirds-one-third-section/ndd-two-thirds-one-third-section.styles.ts
+++ b/src/components/layout/page-sections/two-thirds-one-third-section/ndd-two-thirds-one-third-section.styles.ts
@@ -17,6 +17,10 @@ export const twoThirdsOneThirdSectionStyles = css`
 		display: none;
 	}
 
+	:host([align="center"]) {
+		justify-content: center;
+	}
+
 
 	/* # Section */
 

--- a/src/components/layout/page-sections/two-thirds-one-third-section/ndd-two-thirds-one-third-section.test.ts
+++ b/src/components/layout/page-sections/two-thirds-one-third-section/ndd-two-thirds-one-third-section.test.ts
@@ -28,8 +28,10 @@ describe('ndd-two-thirds-one-third-section', () => {
 		expect(el.shadowRoot!.querySelector('.two-thirds-one-third-section__right-column')).not.toBeNull();
 	});
 
-	it('reflects align attribute to the host', async () => {
-		el = await fixture('<ndd-two-thirds-one-third-section align="center"></ndd-two-thirds-one-third-section>');
+	it('reflects align property to attribute', async () => {
+		el = await fixture('<ndd-two-thirds-one-third-section></ndd-two-thirds-one-third-section>');
+		await waitForUpdate(el);
+		(el as any).align = 'center';
 		await waitForUpdate(el);
 		expect(el.getAttribute('align')).toBe('center');
 	});

--- a/src/components/layout/page-sections/two-thirds-one-third-section/ndd-two-thirds-one-third-section.test.ts
+++ b/src/components/layout/page-sections/two-thirds-one-third-section/ndd-two-thirds-one-third-section.test.ts
@@ -27,4 +27,10 @@ describe('ndd-two-thirds-one-third-section', () => {
 		expect(el.shadowRoot!.querySelector('.two-thirds-one-third-section__left-column')).not.toBeNull();
 		expect(el.shadowRoot!.querySelector('.two-thirds-one-third-section__right-column')).not.toBeNull();
 	});
+
+	it('reflects align attribute to the host', async () => {
+		el = await fixture('<ndd-two-thirds-one-third-section align="center"></ndd-two-thirds-one-third-section>');
+		await waitForUpdate(el);
+		expect(el.getAttribute('align')).toBe('center');
+	});
 });

--- a/src/components/layout/page-sections/two-thirds-one-third-section/ndd-two-thirds-one-third-section.ts
+++ b/src/components/layout/page-sections/two-thirds-one-third-section/ndd-two-thirds-one-third-section.ts
@@ -23,7 +23,7 @@ export class NDDTwoThirdsOneThirdSection extends LitElement {
 	static override styles = twoThirdsOneThirdSectionStyles;
 
 	@property({ type: String, reflect: true })
-	align?: 'center';
+	align?: string;
 
 	override render() {
 		return twoThirdsOneThirdSectionTemplate(this);

--- a/src/components/layout/page-sections/two-thirds-one-third-section/ndd-two-thirds-one-third-section.ts
+++ b/src/components/layout/page-sections/two-thirds-one-third-section/ndd-two-thirds-one-third-section.ts
@@ -14,13 +14,16 @@
  * @slot footer - Content below the columns
  */
 import { LitElement } from 'lit';
-import { customElement } from 'lit/decorators.js';
+import { customElement, property } from 'lit/decorators.js';
 import { twoThirdsOneThirdSectionStyles } from './ndd-two-thirds-one-third-section.styles.ts';
 import { twoThirdsOneThirdSectionTemplate } from './ndd-two-thirds-one-third-section.template.ts';
 
 @customElement('ndd-two-thirds-one-third-section')
 export class NDDTwoThirdsOneThirdSection extends LitElement {
 	static override styles = twoThirdsOneThirdSectionStyles;
+
+	@property({ type: String, reflect: true })
+	align?: 'center';
 
 	override render() {
 		return twoThirdsOneThirdSectionTemplate(this);

--- a/src/components/layout/page/ndd-page.styles.ts
+++ b/src/components/layout/page/ndd-page.styles.ts
@@ -45,6 +45,7 @@ export const pageStyles = css`
 	:host([sticky-header]) .page__header {
 		position: sticky;
 		top: 0;
+		z-index: 1;
 		background-color: color-mix(in srgb, var(--_background-color) 95%, transparent);
 	}
 
@@ -93,6 +94,7 @@ export const pageStyles = css`
 	:host([sticky-footer]) .page__footer {
 		position: sticky;
 		bottom: 0;
+		z-index: 1;
 		background-color: color-mix(in srgb, var(--_background-color) 95%, transparent);
 	}
 

--- a/src/components/layout/page/ndd-page.styles.ts
+++ b/src/components/layout/page/ndd-page.styles.ts
@@ -76,6 +76,10 @@ export const pageStyles = css`
 		container-name: layout-area;
 	}
 
+	.page__main ::slotted(:last-child) {
+		flex: 1;
+	}
+
 
 	/* # Footer */
 

--- a/src/components/layout/page/ndd-page.test.ts
+++ b/src/components/layout/page/ndd-page.test.ts
@@ -32,4 +32,12 @@ describe('ndd-page', () => {
 		await waitForUpdate(el);
 		expect(el.getAttribute('background')).toBe('tinted');
 	});
+
+	it('stretches the last slotted child in main with flex: 1', async () => {
+		el = await fixture('<ndd-page><div id="section">content</div></ndd-page>');
+		await waitForUpdate(el);
+		const section = el.querySelector('#section') as HTMLElement;
+		const style = getComputedStyle(section);
+		expect(style.flexGrow).toBe('1');
+	});
 });


### PR DESCRIPTION
- Page main slot stretches its last child (flex: 1) so footer stays at bottom
- All page section variants support align="center" for vertical centering
- Enables centering inline-dialog on empty pages