### PR TITLE
feat: consumer fixes batch 3

### DIFF
--- a/src/assets/styles/settings.css
+++ b/src/assets/styles/settings.css
@@ -900,7 +900,7 @@
 	--components-box-padding: var(--primitives-space-16);
 
 
-	--components-top-title-bar-button-bar-divider-color: #c9ced8;
+	--components-top-title-bar-divider-color: light-dark(var(--primitives-color-neutral-150),var(--primitives-color-neutral-350));
 
 
 	--components-form-gap: var(--primitives-space-16);

--- a/src/components/actions/button-bar/ndd-button-bar.stories.js
+++ b/src/components/actions/button-bar/ndd-button-bar.stories.js
@@ -13,10 +13,12 @@ export default {
 			control: 'select',
 			options: ['xs', 'sm', 'md'],
 			description: 'Button bar size',
+			table: { defaultValue: { summary: 'md' } },
 		},
 		disabled: {
 			control: 'boolean',
 			description: 'Disabled state',
+			table: { defaultValue: { summary: 'false' } },
 		},
 	},
 };

--- a/src/components/actions/button-group/ndd-button-group.stories.js
+++ b/src/components/actions/button-group/ndd-button-group.stories.js
@@ -12,19 +12,21 @@ export default {
 		control: 'select',
 		options: ['sm', 'md'],
 		description: 'Button group size',
+		table: { defaultValue: { summary: 'md' } },
 	  },
-	  flow: {
+	  orientation: {
 		control: 'select',
 		options: ['horizontal', 'vertical'],
 		description: 'Layout direction',
+		table: { defaultValue: { summary: 'vertical' } },
 	  },
 	}
 };
 
 export const Default = {
-	args: { size: 'md', flow: 'vertical' },
+	args: { size: 'md', orientation: 'vertical' },
 	render: (args) => html`
-	<ndd-button-group size=${args.size} flow=${args.flow}>
+	<ndd-button-group size=${args.size} orientation=${args.orientation}>
 		<ndd-button variant="primary" text="Bewaar"></ndd-button>
 		<ndd-button variant="secondary" text="Bewaar en maak nieuwe"></ndd-button>
 	</ndd-button-group>
@@ -32,9 +34,9 @@ export const Default = {
 };
 
 export const Horizontal = {
-	args: { size: 'md', flow: 'horizontal' },
+	args: { size: 'md', orientation: 'horizontal' },
 	render: (args) => html`
-	<ndd-button-group size=${args.size} flow=${args.flow}>
+	<ndd-button-group size=${args.size} orientation=${args.orientation}>
 		<ndd-button variant="primary" text="Bewaar"></ndd-button>
 		<ndd-button variant="secondary" text="Bewaar en maak nieuwe"></ndd-button>
 	</ndd-button-group>
@@ -42,9 +44,9 @@ export const Horizontal = {
 };
 
 export const SizeSmall = {
-	args: { size: 'sm', flow: 'horizontal' },
+	args: { size: 'sm', orientation: 'horizontal' },
 	render: (args) => html`
-	<ndd-button-group size=${args.size} flow=${args.flow}>
+	<ndd-button-group size=${args.size} orientation=${args.orientation}>
 		<ndd-button variant="primary" text="Bewaar"></ndd-button>
 		<ndd-button variant="secondary" text="Bewaar en maak nieuwe"></ndd-button>
 	</ndd-button-group>
@@ -52,9 +54,9 @@ export const SizeSmall = {
 };
 
 export const ThreeButtons = {
-	args: { size: 'md', flow: 'vertical' },
+	args: { size: 'md', orientation: 'vertical' },
 	render: (args) => html`
-	<ndd-button-group size=${args.size} flow=${args.flow}>
+	<ndd-button-group size=${args.size} orientation=${args.orientation}>
 		<ndd-button variant="primary" text="Bewaar"></ndd-button>
 		<ndd-button variant="secondary" text="Bewaar en maak nieuwe"></ndd-button>
 		<ndd-button variant="destructive" text="Verwijder"></ndd-button>
@@ -63,9 +65,9 @@ export const ThreeButtons = {
 };
 
 export const MaxEnforced = {
-	args: { size: 'md', flow: 'vertical' },
+	args: { size: 'md', orientation: 'vertical' },
 	render: (args) => html`
-	<ndd-button-group size=${args.size} flow=${args.flow}>
+	<ndd-button-group size=${args.size} orientation=${args.orientation}>
 		<ndd-button variant="primary" text="Bewaar"></ndd-button>
 		<ndd-button variant="secondary" text="Bewaar en maak nieuwe"></ndd-button>
 		<ndd-button variant="destructive" text="Verwijder"></ndd-button>

--- a/src/components/actions/button-group/ndd-button-group.styles.ts
+++ b/src/components/actions/button-group/ndd-button-group.styles.ts
@@ -20,20 +20,20 @@ export const styles = css`
 
 	/* # Flow: Horizontal */
 
-	:host([flow="horizontal"]) .button-group,
-	:host(:not([flow])) .button-group {
+	:host([orientation="horizontal"]) .button-group,
+	:host(:not([orientation])) .button-group {
 		flex-direction: row;
 		flex-wrap: wrap;
 	}
 
 	/* # Flow: Vertical */
 
-	:host([flow="vertical"]) {
+	:host([orientation="vertical"]) {
 		display: flex;
 		width: 100%;
 	}
 
-	:host([flow="vertical"]) .button-group {
+	:host([orientation="vertical"]) .button-group {
 		flex-direction: column;
 		width: 100%;
 	}

--- a/src/components/actions/button-group/ndd-button-group.styles.ts
+++ b/src/components/actions/button-group/ndd-button-group.styles.ts
@@ -18,15 +18,14 @@ export const styles = css`
 		justify-content: center;
 	}
 
-	/* # Flow: Horizontal */
+	/* # Orientation: Horizontal */
 
-	:host([orientation="horizontal"]) .button-group,
-	:host(:not([orientation])) .button-group {
+	:host([orientation="horizontal"]) .button-group {
 		flex-direction: row;
 		flex-wrap: wrap;
 	}
 
-	/* # Flow: Vertical */
+	/* # Orientation: Vertical */
 
 	:host([orientation="vertical"]) {
 		display: flex;

--- a/src/components/actions/button-group/ndd-button-group.ts
+++ b/src/components/actions/button-group/ndd-button-group.ts
@@ -5,7 +5,7 @@
  *
  * @element ndd-button-group
  * @attr {string} size - Button group size: 'sm' | 'md' (default: 'md')
- * @attr {string} orientation - Layout direction: 'horizontal' | 'vertical' (default: 'horizontal')
+ * @attr {string} orientation - Layout direction: 'horizontal' | 'vertical' (default: 'vertical')
  *
  * @slot - Default slot for buttons (max 3)
  *

--- a/src/components/actions/button-group/ndd-button-group.ts
+++ b/src/components/actions/button-group/ndd-button-group.ts
@@ -5,7 +5,7 @@
  *
  * @element ndd-button-group
  * @attr {string} size - Button group size: 'sm' | 'md' (default: 'md')
- * @attr {string} flow - Layout direction: 'horizontal' | 'vertical' (default: 'horizontal')
+ * @attr {string} orientation - Layout direction: 'horizontal' | 'vertical' (default: 'horizontal')
  *
  * @slot - Default slot for buttons (max 3)
  *
@@ -17,7 +17,7 @@ import { styles } from './ndd-button-group.styles.ts';
 import { template } from './ndd-button-group.template.ts';
 
 type Size = 'sm' | 'md';
-type Flow = 'horizontal' | 'vertical';
+type Orientation = 'horizontal' | 'vertical';
 
 @customElement('ndd-button-group')
 export class NDDButtonGroup extends LitElement {
@@ -27,7 +27,7 @@ export class NDDButtonGroup extends LitElement {
 	size: Size = 'md';
 
 	@property({ type: String, reflect: true })
-	flow: Flow = 'vertical';
+	orientation: Orientation = 'vertical';
 
 	@query('slot')
 	private _slot!: HTMLSlotElement;
@@ -43,7 +43,7 @@ export class NDDButtonGroup extends LitElement {
 				console.warn('ndd-button-group: Only 3 buttons are allowed. Extra buttons will be hidden.');
 			}
 
-			if (this.flow === 'vertical') {
+			if (this.orientation === 'vertical') {
 				el.setAttribute('full-width', '');
 			} else {
 				el.removeAttribute('full-width');
@@ -54,7 +54,7 @@ export class NDDButtonGroup extends LitElement {
 	}
 
 	override updated(changedProperties: Map<string, unknown>) {
-		if (changedProperties.has('flow') || changedProperties.has('size')) {
+		if (changedProperties.has('orientation') || changedProperties.has('size')) {
 			this.handleSlotChange();
 		}
 	}

--- a/src/components/actions/toolbar/ndd-toolbar.stories.js
+++ b/src/components/actions/toolbar/ndd-toolbar.stories.js
@@ -17,10 +17,12 @@ export default {
 			control: 'select',
 			options: ['sm', 'md'],
 			description: 'Toolbar size',
+			table: { defaultValue: { summary: 'md' } },
 		},
 		showItemLabels: {
 			control: 'boolean',
 			description: 'Show labels below toolbar items',
+			table: { defaultValue: { summary: 'false' } },
 		},
 	},
 };

--- a/src/components/content/rich-text/ndd-rich-text.stories.js
+++ b/src/components/content/rich-text/ndd-rich-text.stories.js
@@ -10,6 +10,7 @@ export default {
 			control: 'select',
 			options: ['flat', 'tight', 'snug', 'loose'],
 			description: 'Spacing between elements',
+			table: { defaultValue: { summary: 'snug' } },
 		},
 	},
 };

--- a/src/components/forms/form-field/ndd-form-field.stories.js
+++ b/src/components/forms/form-field/ndd-form-field.stories.js
@@ -59,7 +59,7 @@ export default {
 		labelAlignment: {
 			control: 'select',
 			options: ['top', 'right', 'left'],
-			table: { order: 1 },
+			table: { order: 1, defaultValue: { summary: 'top' } },
 		},
 		label: {
 			control: 'text',
@@ -71,7 +71,7 @@ export default {
 		},
 		optional: {
 			control: 'boolean',
-			table: { order: 4 },
+			table: { order: 4, defaultValue: { summary: 'false' } },
 		},
 	},
 	args: {

--- a/src/components/layout/page/ndd-page.stories.js
+++ b/src/components/layout/page/ndd-page.stories.js
@@ -4,8 +4,11 @@ import '../container/ndd-container.ts';
 import '../page-sections/simple-section/ndd-simple-section.ts';
 import '../../actions/button/ndd-button.ts';
 import '../../layout/spacer/ndd-spacer.ts';
+import '../../actions/button-group/ndd-button-group.ts';
 import '../../content/rich-text/ndd-rich-text.ts';
 import '../../status-and-feedback/inline-dialog/ndd-inline-dialog.ts';
+import '../../navigation/top-title-bar/ndd-top-title-bar.ts';
+import '../../content/title/ndd-title.ts';
 
 /**
  * Gebruik de page-component als buitenste wrapper van een pagina.
@@ -63,25 +66,30 @@ export default {
 };
 
 const header = html`
-	<ndd-container padding="16">
-		<ndd-rich-text spacing="tight">
-			<strong>Header</strong>
-		</ndd-rich-text>
-	</ndd-container>
+	<ndd-top-title-bar
+		slot="header"
+		text="Paginatitel"
+		back-text="Overzicht"
+		collapse-anchor="page-title"
+	></ndd-top-title-bar>
 `;
 
 const footer = html`
 	<ndd-container padding="16">
-		<ndd-button variant="secondary" text="Annuleren"></ndd-button>
-		<ndd-spacer size="8" direction="horizontal"></ndd-spacer>
-		<ndd-button text="Opslaan"></ndd-button>
+		<ndd-button-group orientation="horizontal">
+			<ndd-button variant="primary" text="Opslaan"></ndd-button>
+			<ndd-button variant="secondary" text="Annuleren"></ndd-button>
+		</ndd-button-group>
 	</ndd-container>
 `;
 
 const content = html`
 	<ndd-simple-section>
-		<ndd-rich-text>
+		<ndd-title id="page-title" size="2">
 			<h1>Paginatitel</h1>
+		</ndd-title>
+		<ndd-spacer size="16"></ndd-spacer>
+		<ndd-rich-text>
 			<p>
 				Dit is het scrollbare hoofdgebied van de pagina. Voeg hier de inhoud van de pagina toe.
 				Wanneer de inhoud langer is dan de viewport, wordt het gebied scrollbaar.
@@ -107,7 +115,7 @@ export const Standaard = ({ stickyHeader, stickyFooter, background }) => html`
 		background=${background}
 		style="height: 400px;"
 	>
-		<div slot="header">${header}</div>
+		${header}
 		${content}
 		<div slot="footer">${footer}</div>
 	</ndd-page>
@@ -115,7 +123,7 @@ export const Standaard = ({ stickyHeader, stickyFooter, background }) => html`
 
 export const StickyHeader = () => html`
 	<ndd-page sticky-header style="height: 400px;">
-		<div slot="header">${header}</div>
+		${header}
 		${content}
 		<div slot="footer">${footer}</div>
 	</ndd-page>
@@ -124,7 +132,7 @@ StickyHeader.parameters = { controls: { disable: true } };
 
 export const StickyFooter = () => html`
 	<ndd-page sticky-footer style="height: 400px;">
-		<div slot="header">${header}</div>
+		${header}
 		${content}
 		<div slot="footer">${footer}</div>
 	</ndd-page>
@@ -133,7 +141,7 @@ StickyFooter.parameters = { controls: { disable: true } };
 
 export const StickyBeide = () => html`
 	<ndd-page sticky-header sticky-footer style="height: 400px;">
-		<div slot="header">${header}</div>
+		${header}
 		${content}
 		<div slot="footer">${footer}</div>
 	</ndd-page>
@@ -142,7 +150,7 @@ StickyBeide.parameters = { controls: { disable: true } };
 
 export const Tinted = () => html`
 	<ndd-page sticky-header sticky-footer background="tinted" style="height: 400px;">
-		<div slot="header">${header}</div>
+		${header}
 		${content}
 		<div slot="footer">${footer}</div>
 	</ndd-page>
@@ -151,7 +159,7 @@ Tinted.parameters = { controls: { disable: true } };
 
 export const GecentreerdeDialoog = () => html`
 	<ndd-page sticky-header sticky-footer style="height: 400px;">
-		<div slot="header">${header}</div>
+		${header}
 		<ndd-simple-section align="center">
 			<ndd-inline-dialog
 				icon-name="search"

--- a/src/components/layout/page/ndd-page.styles.ts
+++ b/src/components/layout/page/ndd-page.styles.ts
@@ -18,6 +18,9 @@ export const pageStyles = css`
 		padding-bottom: var(--context-bar-split-view-bottom-bars-height, 0px);
 	}
 
+	/* Overflow hidden prevents content from escaping the scroll wrapper.
+	   Overlays inside slotted content should use popover, dialog, or
+	   position: fixed to render in the top layer. */
 	:host([sticky-header]) {
 		position: relative;
 		overflow: hidden;

--- a/src/components/layout/page/ndd-page.styles.ts
+++ b/src/components/layout/page/ndd-page.styles.ts
@@ -6,7 +6,6 @@ import { css } from 'lit';
 export const pageStyles = css`
 	:host {
 		--_background-color: var(--context-parent-background-color, var(--semantics-surfaces-background-color));
-		--_initial-header-height: 0px;
 
 		display: flex;
 		flex-direction: column;
@@ -19,9 +18,6 @@ export const pageStyles = css`
 		padding-bottom: var(--context-bar-split-view-bottom-bars-height, 0px);
 	}
 
-	/* Overflow hidden prevents content from escaping the scroll wrapper.
-	   Overlays inside slotted content should use popover, dialog, or
-	   position: fixed to render in the top layer. */
 	:host([sticky-header]) {
 		position: relative;
 		overflow: hidden;
@@ -90,7 +86,6 @@ export const pageStyles = css`
 	:host([sticky-header]) .page__scroll {
 		overflow-y: auto;
 		overflow-x: hidden;
-		padding-top: var(--_initial-header-height);
 	}
 
 

--- a/src/components/layout/page/ndd-page.test.ts
+++ b/src/components/layout/page/ndd-page.test.ts
@@ -39,4 +39,12 @@ describe('ndd-page', () => {
 		expect(el.shadowRoot!.querySelector('.page__scroll')).not.toBeNull();
 	});
 
+	it('sets paddingTop on scroll wrapper when sticky-header is set', async () => {
+		el = await fixture('<ndd-page sticky-header><div slot="header" style="height: 48px;">Header</div></ndd-page>');
+		await waitForUpdate(el);
+		await new Promise(r => requestAnimationFrame(r));
+		const scroll = el.shadowRoot!.querySelector('.page__scroll') as HTMLElement;
+		expect(scroll.style.paddingTop).not.toBe('');
+	});
+
 });

--- a/src/components/layout/page/ndd-page.test.ts
+++ b/src/components/layout/page/ndd-page.test.ts
@@ -39,12 +39,4 @@ describe('ndd-page', () => {
 		expect(el.shadowRoot!.querySelector('.page__scroll')).not.toBeNull();
 	});
 
-	it('sets --_initial-header-height when sticky-header is set', async () => {
-		el = await fixture('<ndd-page sticky-header><div slot="header" style="height: 48px;">Header</div></ndd-page>');
-		await waitForUpdate(el);
-		await new Promise(r => requestAnimationFrame(() => requestAnimationFrame(r)));
-		const value = el.style.getPropertyValue('--_initial-header-height');
-		expect(value).not.toBe('');
-	});
-
 });

--- a/src/components/layout/page/ndd-page.test.ts
+++ b/src/components/layout/page/ndd-page.test.ts
@@ -42,7 +42,8 @@ describe('ndd-page', () => {
 	it('sets paddingTop on scroll wrapper when sticky-header is set', async () => {
 		el = await fixture('<ndd-page sticky-header><div slot="header" style="height: 48px;">Header</div></ndd-page>');
 		await waitForUpdate(el);
-		await new Promise(r => requestAnimationFrame(r));
+		// ResizeObserver fires asynchronously — wait for it to settle
+		await new Promise(r => setTimeout(r, 100));
 		const scroll = el.shadowRoot!.querySelector('.page__scroll') as HTMLElement;
 		expect(scroll.style.paddingTop).not.toBe('');
 	});

--- a/src/components/layout/page/ndd-page.ts
+++ b/src/components/layout/page/ndd-page.ts
@@ -2,10 +2,10 @@
  * Nederlandse Digitale Dienst Page Component (Lit + TypeScript)
  *
  * A page layout with optional sticky header and footer.
- * Without sticky-header, the host itself is the scroll container.
- * With sticky-header, the header becomes absolute-positioned and a
- * scroll wrapper (.page__scroll) takes over scrolling. The initial
- * header height is measured once to set padding-top on the scroll wrapper.
+ * Without sticky-header, the host is the scroll container and the header
+ * is in normal flow. With sticky-header, the header becomes absolute and
+ * .page__scroll takes over scrolling. A ResizeObserver on the header
+ * sets padding-top on the scroll wrapper (only when not scrolled).
  *
  * @element ndd-page
  *
@@ -39,10 +39,9 @@ export class NDDPage extends LitElement {
 	_scrolled = false;
 
 	private _scrollTarget: EventTarget | null = null;
+	private _headerObserver: ResizeObserver | null = null;
 
-	/** Only valid after firstUpdated — before that, falls back to the host. */
 	get scrollTarget(): HTMLElement {
-		if (!this.hasUpdated) return this;
 		return (this.stickyHeader ? (this._scrollEl ?? this) : this);
 	}
 
@@ -58,19 +57,19 @@ export class NDDPage extends LitElement {
 		super.connectedCallback();
 		if (this.hasUpdated) {
 			this._setupScrollListener();
+			if (this.stickyHeader) this._setupHeaderObserver();
 		}
 	}
 
 	override disconnectedCallback() {
 		super.disconnectedCallback();
 		this._teardownScrollListener();
+		this._teardownHeaderObserver();
 	}
 
 	override firstUpdated() {
 		this._setupScrollListener();
-		if (this.stickyHeader) {
-			this._measureInitialHeaderHeight();
-		}
+		if (this.stickyHeader) this._setupHeaderObserver();
 	}
 
 	override updated(changed: PropertyValues) {
@@ -79,9 +78,10 @@ export class NDDPage extends LitElement {
 			this._setupScrollListener();
 
 			if (this.stickyHeader) {
-				this._measureInitialHeaderHeight();
+				this._setupHeaderObserver();
 			} else {
-				this.style.removeProperty('--_initial-header-height');
+				this._teardownHeaderObserver();
+				if (this._scrollEl) this._scrollEl.style.paddingTop = '';
 			}
 		}
 	}
@@ -100,19 +100,27 @@ export class NDDPage extends LitElement {
 		}
 	}
 
-	private _measureInitialHeaderHeight() {
-		// Double rAF ensures slotted Lit components have rendered their shadow DOM
-		requestAnimationFrame(() => {
-			requestAnimationFrame(() => {
-				const header = this._headerEl;
-				if (!header) return;
-				this.style.setProperty('--_initial-header-height', `${header.offsetHeight}px`);
-			});
+	private _setupHeaderObserver() {
+		const header = this._headerEl;
+		const scroll = this._scrollEl;
+		if (!header || !scroll) return;
+
+		this._headerObserver = new ResizeObserver(() => {
+			if (scroll.scrollTop > 0) return;
+			scroll.style.paddingTop = `${header.offsetHeight}px`;
 		});
+		this._headerObserver.observe(header);
 	}
 
-	private _onScroll = (e: Event) => {
-		const target = e.target as HTMLElement;
+	private _teardownHeaderObserver() {
+		if (this._headerObserver) {
+			this._headerObserver.disconnect();
+			this._headerObserver = null;
+		}
+	}
+
+	private _onScroll = () => {
+		const target = (this.stickyHeader ? this._scrollEl : this) as HTMLElement;
 		this._scrolled = target.scrollTop > 0;
 	};
 

--- a/src/components/layout/page/ndd-page.ts
+++ b/src/components/layout/page/ndd-page.ts
@@ -101,6 +101,7 @@ export class NDDPage extends LitElement {
 	}
 
 	private _setupHeaderObserver() {
+		this._teardownHeaderObserver();
 		const header = this._headerEl;
 		const scroll = this._scrollEl;
 		if (!header || !scroll) return;

--- a/src/components/layout/sheet/ndd-sheet.stories.ts
+++ b/src/components/layout/sheet/ndd-sheet.stories.ts
@@ -3,6 +3,7 @@ import './ndd-sheet.ts';
 import '../../navigation/top-title-bar/ndd-top-title-bar.ts';
 import '../../layout/page/ndd-page.ts';
 import '../../actions/button/ndd-button.ts';
+import '../../actions/button-group/ndd-button-group.ts';
 import '../../content/rich-text/ndd-rich-text.ts';
 import '../../layout/page-sections/simple-section/ndd-simple-section.ts';
 import '../../layout/container/ndd-container.ts';
@@ -147,8 +148,10 @@ export const MetStickyFooter = {
 				></ndd-top-title-bar>
 				${pageContent}
 				<ndd-container slot="footer" padding="16">
-					<ndd-button variant="secondary" text="Annuleer"></ndd-button>
-					<ndd-button variant="primary" text="Opslaan"></ndd-button>
+					<ndd-button-group orientation="vertical">
+						<ndd-button variant="primary" text="Opslaan" full-width></ndd-button>
+						<ndd-button variant="secondary" text="Annuleer" full-width></ndd-button>
+					</ndd-button-group>
 				</ndd-container>
 			</ndd-page>
 		</ndd-sheet>

--- a/src/components/layout/sheet/ndd-sheet.styles.ts
+++ b/src/components/layout/sheet/ndd-sheet.styles.ts
@@ -59,6 +59,8 @@ export const sheetStyles = css`
 	/* # Sheet base */
 
 	.sheet {
+		display: flex;
+		flex-direction: column;
 		border: none;
 		padding: 0;
 		margin: 0;
@@ -203,8 +205,9 @@ export const sheetStyles = css`
 	.sheet__body {
 		display: flex;
 		flex-direction: column;
+		flex-grow: 1;
+		min-height: 0;
 		width: 100%;
-		height: 100%;
 	}
 
 	::slotted(*) {

--- a/src/components/layout/split-views/navigation-split-view/ndd-navigation-split-view.styles.ts
+++ b/src/components/layout/split-views/navigation-split-view/ndd-navigation-split-view.styles.ts
@@ -1,6 +1,7 @@
 import { css, unsafeCSS } from 'lit';
 import { breakpoints } from '../../../../assets/styles/breakpoints.ts';
 
+const smMax = unsafeCSS(breakpoints.smMax);
 const lgMin = unsafeCSS(breakpoints.lgMin);
 
 
@@ -128,6 +129,8 @@ export const navigationSplitViewStyles = css`
 	}
 
 	.navigation-split-view__inspector-sheet {
+		display: flex;
+		flex-direction: column;
 		border: none;
 		padding: 0;
 		margin: 0;
@@ -169,8 +172,9 @@ export const navigationSplitViewStyles = css`
 	.navigation-split-view__inspector-sheet-body {
 		display: flex;
 		flex-direction: column;
+		flex-grow: 1;
+		min-height: 0;
 		width: 100%;
-		height: 100%;
 	}
 
 
@@ -187,6 +191,8 @@ export const navigationSplitViewStyles = css`
 	}
 
 	.navigation-split-view__sidebar-sheet {
+		display: flex;
+		flex-direction: column;
 		border: none;
 		padding: 0;
 		margin: 0;
@@ -228,11 +234,61 @@ export const navigationSplitViewStyles = css`
 	.navigation-split-view__sidebar-sheet-body {
 		display: flex;
 		flex-direction: column;
+		flex-grow: 1;
+		min-height: 0;
 		width: 100%;
-		height: 100%;
 
 		/* Show dismiss button inside sidebar sheet */
 		--context-dismiss-button-display: block;
+	}
+
+
+	/* # Responsive: sm viewport — sheets become bottom sheets */
+
+	@keyframes navigation-split-view-slide-in-bottom {
+		from { transform: translateY(100%); }
+		to { transform: translateY(0); }
+	}
+
+	@keyframes navigation-split-view-slide-out-bottom {
+		from { transform: translateY(0); }
+		to { transform: translateY(100%); }
+	}
+
+	@media (max-width: ${smMax}) {
+		.navigation-split-view__inspector-sheet {
+			inset: auto 0 0 0;
+			width: 100%;
+			max-width: 100%;
+			height: auto;
+			max-height: calc(100dvh - var(--components-sheet-bottom-top-inset));
+			border-radius: var(--semantics-overlays-corner-radius) var(--semantics-overlays-corner-radius) 0 0;
+
+			&[open] {
+				animation: navigation-split-view-slide-in-bottom var(--components-sheet-bottom-animation-duration) ease both;
+			}
+
+			&.is-closing {
+				animation: navigation-split-view-slide-out-bottom var(--components-sheet-bottom-animation-duration) ease both;
+			}
+		}
+
+		.navigation-split-view__sidebar-sheet {
+			inset: auto 0 0 0;
+			width: 100%;
+			max-width: 100%;
+			height: auto;
+			max-height: calc(100dvh - var(--components-sheet-bottom-top-inset));
+			border-radius: var(--semantics-overlays-corner-radius) var(--semantics-overlays-corner-radius) 0 0;
+
+			&[open] {
+				animation: navigation-split-view-slide-in-bottom var(--components-sheet-bottom-animation-duration) ease both;
+			}
+
+			&.is-closing {
+				animation: navigation-split-view-slide-out-bottom var(--components-sheet-bottom-animation-duration) ease both;
+			}
+		}
 	}
 
 

--- a/src/components/lists-and-menus/cells/icon-cell/ndd-icon-cell.stories.js
+++ b/src/components/lists-and-menus/cells/icon-cell/ndd-icon-cell.stories.js
@@ -11,15 +11,18 @@ export default {
 			control: 'select',
 			options: ['center', 'top'],
 			description: 'Vertical alignment of the icon',
+			table: { defaultValue: { summary: 'center' } },
 		},
 		size: {
 			control: 'select',
 			options: ['16', '20', '24', '32'],
 			description: 'Icon size in pixels',
+			table: { defaultValue: { summary: '24' } },
 		},
 		selected: {
 			control: 'boolean',
 			description: 'Selected state',
+			table: { defaultValue: { summary: 'false' } },
 		},
 		icon: {
 			control: 'select',

--- a/src/components/lists-and-menus/cells/title-cell/ndd-title-cell.stories.js
+++ b/src/components/lists-and-menus/cells/title-cell/ndd-title-cell.stories.js
@@ -10,7 +10,8 @@ export default {
 			control: 'select',
 			options: [undefined, 1, 2, 3, 4, 5, 6],
 			name: 'heading-level',
-			description: 'Heading level (1–6). When not set, renders a <p>.',
+			description: 'Heading level (1–6). When not set, renders a &lt;p&gt;.',
+			table: { defaultValue: { summary: '-' } },
 		},
 		text: {
 			control: 'text',

--- a/src/components/lists-and-menus/list-item/ndd-list-item.stories.js
+++ b/src/components/lists-and-menus/list-item/ndd-list-item.stories.js
@@ -14,15 +14,18 @@ export default {
 			control: 'select',
 			options: ['sm', 'md'],
 			description: 'Size of the list item',
+			table: { defaultValue: { summary: 'md' } },
 		},
 		selected: {
 			control: 'boolean',
 			description: 'Whether the item is selected',
+			table: { defaultValue: { summary: 'false' } },
 		},
 		type: {
 			control: 'select',
 			options: [undefined, 'button', 'link'],
 			description: 'Interactive mode of the list item',
+			table: { defaultValue: { summary: '-' } },
 		},
 		href: {
 			control: 'text',

--- a/src/components/lists-and-menus/list/ndd-list.stories.js
+++ b/src/components/lists-and-menus/list/ndd-list.stories.js
@@ -17,6 +17,7 @@ export default {
 			control: 'select',
 			options: ['simple', 'box', 'inset'],
 			description: 'Visual style of the list',
+			table: { defaultValue: { summary: 'simple' } },
 		},
 	},
 };

--- a/src/components/navigation/top-title-bar/ndd-top-title-bar.styles.ts
+++ b/src/components/navigation/top-title-bar/ndd-top-title-bar.styles.ts
@@ -90,7 +90,7 @@ export const topTitleBarStyles = css`
 		display: none;
 		width: var(--semantics-dividers-thickness);
 		height: var(--primitives-space-24);
-		background-color: var(--components-top-title-bar-button-bar-divider-color);
+		background-color: var(--components-top-title-bar-divider-color);
 		flex-shrink: 0;
 	}
 

--- a/src/components/status-and-feedback/inline-dialog/ndd-inline-dialog.template.ts
+++ b/src/components/status-and-feedback/inline-dialog/ndd-inline-dialog.template.ts
@@ -25,7 +25,7 @@ export function inlineDialogTemplate(component: NDDInlineDialog) {
 				<slot></slot>
 			</div>
 			<div class="inline-dialog__actions">
-				<ndd-button-group flow="vertical">
+				<ndd-button-group orientation="vertical">
 					<slot name="actions"></slot>
 				</ndd-button-group>
 			</div>


### PR DESCRIPTION
Page:
- Absolute header with scroll wrapper for sticky-header mode
- ResizeObserver sets padding-top only when not scrolled
- Update stories to use top-title-bar with collapse-anchor

Top title bar:
- Rename divider color token to light-dark
- Empty bar is 0px when no visible content

Sheets:
- Flex layout on dialog for correct bottom sheet scrolling
- Responsive bottom sheet styles in navigation-split-view

Button group:
- Rename flow attribute to orientation

Stories:
- Add missing default values across button-bar, button-group, toolbar, rich-text, form-field, list, list-item, icon-cell, title-cell
- Use vertical button group in sheet footer, horizontal in page footer