### PR TITLE
Refactor tooltip als wrapper component en integratie in icon-button.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@minbzk/storybook",
-  "version": "0.8.18",
+  "version": "0.8.19",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@minbzk/storybook",
-      "version": "0.8.18",
+      "version": "0.8.19",
       "license": "EUPL-1.2",
       "dependencies": {
         "@floating-ui/dom": "^1.7.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@minbzk/storybook",
-  "version": "0.8.19",
+  "version": "0.8.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@minbzk/storybook",
-      "version": "0.8.19",
+      "version": "0.8.18",
       "license": "EUPL-1.2",
       "dependencies": {
         "@floating-ui/dom": "^1.7.6",

--- a/src/assets/styles/settings.css
+++ b/src/assets/styles/settings.css
@@ -950,6 +950,11 @@
 	--components-dialog-box-shadow: var(--primitives-box-shadows-level-5);
 
 
+	--components-tooltip-background-color: light-dark(var(--primitives-color-neutral-600), var(--primitives-color-neutral-750));
+	--components-tooltip-content-color: var(--primitives-color-neutral-0);
+	--components-tooltip-box-shadow: var(--primitives-box-shadows-level-2);
+
+
 	--components-document-tab-bar-tab-title-font: var(--primitives-font-body-sm-bold-flat);
 
 	--components-rich-text-grid-size: calc(var(--primitives-font-size-100) * var(--primitives-line-height-snug));--components-rich-text-spacing-flat: 0px;

--- a/src/components/actions/icon-button/ndd-icon-button.template.ts
+++ b/src/components/actions/icon-button/ndd-icon-button.template.ts
@@ -1,5 +1,6 @@
 import { html, nothing } from 'lit';
 import type { NDDIconButton } from './ndd-icon-button.ts';
+import '../../content/tooltip/ndd-tooltip.ts';
 
 function renderContent(component: NDDIconButton) {
 	return html`
@@ -23,37 +24,51 @@ function renderContent(component: NDDIconButton) {
 
 export function template(this: NDDIconButton) {
 	const label = this.accessibleLabel || this.text || nothing;
-	const tooltip = this.size !== 'lg' ? (this.accessibleLabel || this.text || nothing) : nothing;
 	const content = renderContent(this);
 
-	if (this.href) {
-		const resolvedRel = this._resolvedRel();
+	// Tooltip text: accessible-label always, or text when not visible (non-lg)
+	const tooltipText = this.accessibleLabel
+		|| (this.size !== 'lg' ? this.text : '')
+		|| '';
+
+	const renderButton = () => {
+		if (this.href) {
+			const resolvedRel = this._resolvedRel();
+			return html`
+				<a class="icon-button"
+					href=${this.href}
+					target=${this.target || nothing}
+					rel=${resolvedRel || nothing}
+					aria-disabled=${this.disabled ? 'true' : nothing}
+					aria-label=${label}
+					@click=${this._handleClick}
+				>
+					${content}
+				</a>
+			`;
+		}
+
 		return html`
-			<a class="icon-button"
-				href=${this.href}
-				target=${this.target || nothing}
-				rel=${resolvedRel || nothing}
+			<button class="icon-button"
+				type=${this.type}
+				?disabled=${this.disabled}
 				aria-disabled=${this.disabled ? 'true' : nothing}
-				title=${tooltip}
 				aria-label=${label}
+				popovertarget=${this.popovertarget || nothing}
 				@click=${this._handleClick}
 			>
 				${content}
-			</a>
+			</button>
+		`;
+	};
+
+	if (tooltipText) {
+		return html`
+			<ndd-tooltip text=${tooltipText}>
+				${renderButton()}
+			</ndd-tooltip>
 		`;
 	}
 
-	return html`
-		<button class="icon-button"
-			type=${this.type}
-			?disabled=${this.disabled}
-			aria-disabled=${this.disabled ? 'true' : nothing}
-			title=${tooltip}
-			aria-label=${label}
-			popovertarget=${this.popovertarget || nothing}
-			@click=${this._handleClick}
-		>
-			${content}
-		</button>
-	`;
+	return renderButton();
 }

--- a/src/components/actions/icon-button/ndd-icon-button.template.ts
+++ b/src/components/actions/icon-button/ndd-icon-button.template.ts
@@ -28,8 +28,7 @@ export function template(this: NDDIconButton) {
 
 	// Tooltip text: accessible-label always, or text when not visible (non-lg)
 	const tooltipText = this.accessibleLabel
-		|| (this.size !== 'lg' ? this.text : '')
-		|| '';
+		|| (this.size !== 'lg' ? this.text : '');
 
 	const renderButton = () => {
 		if (this.href) {

--- a/src/components/actions/icon-button/ndd-icon-button.test.ts
+++ b/src/components/actions/icon-button/ndd-icon-button.test.ts
@@ -128,39 +128,42 @@ describe('ndd-icon-button – accessible label & aria-label', () => {
    Title tooltip
    ============================================================ */
 
-describe('ndd-icon-button – title tooltip', () => {
+describe('ndd-icon-button – tooltip', () => {
 	let el: NDDIconButton;
 
 	afterEach(() => {
 		if (el) cleanup(el);
 	});
 
-	it('uses text as title tooltip for non-lg sizes', async () => {
+	it('renders ndd-tooltip with text for non-lg sizes', async () => {
 		el = await fixture<NDDIconButton>('<ndd-icon-button size="md" icon="download" text="Download"></ndd-icon-button>');
 		await waitForUpdate(el);
-		const btn = el.shadowRoot!.querySelector('button')!;
-		expect(btn.getAttribute('title')).toBe('Download');
+		const tooltip = el.shadowRoot!.querySelector('ndd-tooltip');
+		expect(tooltip).not.toBeNull();
+		expect(tooltip!.getAttribute('text')).toBe('Download');
 	});
 
-	it('uses accessible-label as title tooltip when set', async () => {
+	it('renders ndd-tooltip with accessible-label when set', async () => {
 		el = await fixture<NDDIconButton>('<ndd-icon-button size="md" icon="eye" text="Toon" accessible-label="Toon wachtwoord"></ndd-icon-button>');
 		await waitForUpdate(el);
-		const btn = el.shadowRoot!.querySelector('button')!;
-		expect(btn.getAttribute('title')).toBe('Toon wachtwoord');
+		const tooltip = el.shadowRoot!.querySelector('ndd-tooltip');
+		expect(tooltip).not.toBeNull();
+		expect(tooltip!.getAttribute('text')).toBe('Toon wachtwoord');
 	});
 
-	it('omits title attribute for lg size', async () => {
+	it('omits ndd-tooltip for lg size without accessible-label', async () => {
 		el = await fixture<NDDIconButton>('<ndd-icon-button size="lg" icon="download" text="Download"></ndd-icon-button>');
 		await waitForUpdate(el);
-		const btn = el.shadowRoot!.querySelector('button')!;
-		expect(btn.getAttribute('title')).toBeNull();
+		const tooltip = el.shadowRoot!.querySelector('ndd-tooltip');
+		expect(tooltip).toBeNull();
 	});
 
-	it('omits title attribute for lg size even when accessible-label is set', async () => {
+	it('renders ndd-tooltip for lg size when accessible-label is set', async () => {
 		el = await fixture<NDDIconButton>('<ndd-icon-button size="lg" icon="eye" text="Toon" accessible-label="Toon wachtwoord"></ndd-icon-button>');
 		await waitForUpdate(el);
-		const btn = el.shadowRoot!.querySelector('button')!;
-		expect(btn.getAttribute('title')).toBeNull();
+		const tooltip = el.shadowRoot!.querySelector('ndd-tooltip');
+		expect(tooltip).not.toBeNull();
+		expect(tooltip!.getAttribute('text')).toBe('Toon wachtwoord');
 	});
 });
 

--- a/src/components/actions/icon-button/ndd-icon-button.test.ts
+++ b/src/components/actions/icon-button/ndd-icon-button.test.ts
@@ -128,6 +128,10 @@ describe('ndd-icon-button – accessible label & aria-label', () => {
    Title tooltip
    ============================================================ */
 
+// Note: aria-describedby from ndd-tooltip does not reach the inner <button>
+// in ndd-icon-button's shadow DOM. This is a known shadow DOM + ARIA limitation.
+// The tooltip is visual-only for custom element triggers; aria-label on the
+// inner button provides the accessible name.
 describe('ndd-icon-button – tooltip', () => {
 	let el: NDDIconButton;
 

--- a/src/components/content/tooltip/ndd-tooltip.stories.js
+++ b/src/components/content/tooltip/ndd-tooltip.stories.js
@@ -2,6 +2,7 @@ import { html } from 'lit';
 import './ndd-tooltip.ts';
 import '../../actions/button/ndd-button.ts';
 import '../../actions/icon-button/ndd-icon-button.ts';
+import '../rich-text/ndd-rich-text.ts';
 
 /**
  * De Tooltip toont informatieve tekst bij hover of focus op een child element.
@@ -93,4 +94,24 @@ export const Posities = {
 		</div>
 	`,
 	parameters: { controls: { disable: true } },
+};
+
+export const MetTekst = {
+	render: () => html`
+		<div style="display: flex; justify-content: center; padding: 4rem;">
+			<ndd-tooltip text="Artikel 1 van de Grondwet">
+				<ndd-rich-text>
+					<p>Hover over deze <strong>tekst</strong> voor meer informatie.</p>
+				</ndd-rich-text>
+			</ndd-tooltip>
+		</div>
+	`,
+	parameters: {
+		controls: { disable: true },
+		docs: {
+			description: {
+				story: 'De tooltip kan om elk element gewrapt worden, niet alleen knoppen.',
+			},
+		},
+	},
 };

--- a/src/components/content/tooltip/ndd-tooltip.stories.js
+++ b/src/components/content/tooltip/ndd-tooltip.stories.js
@@ -96,19 +96,22 @@ export const Posities = {
 	parameters: { controls: { disable: true } },
 };
 
-export const MetTekst = {
+export const MetLink = {
 	render: () => html`
-		<ndd-tooltip text="Artikel 1 van de Grondwet">
-			<ndd-rich-text>
-				<p>Hover over deze <strong>tekst</strong> voor meer informatie.</p>
-			</ndd-rich-text>
-		</ndd-tooltip>
+		<ndd-rich-text>
+			<p>Lees meer over
+				<ndd-tooltip text="Artikel 1: Allen die zich in Nederland bevinden, worden in gelijke gevallen gelijk behandeld.">
+					<a href="#">de Grondwet</a>
+				</ndd-tooltip>
+				voor meer informatie.
+			</p>
+		</ndd-rich-text>
 	`,
 	parameters: {
 		controls: { disable: true },
 		docs: {
 			description: {
-				story: 'De tooltip kan om elk element gewrapt worden, niet alleen knoppen.',
+				story: 'De tooltip kan om elk focusbaar element gewrapt worden, zoals een link.',
 			},
 		},
 	},

--- a/src/components/content/tooltip/ndd-tooltip.stories.js
+++ b/src/components/content/tooltip/ndd-tooltip.stories.js
@@ -1,12 +1,17 @@
 import { html } from 'lit';
 import './ndd-tooltip.ts';
+import '../../actions/button/ndd-button.ts';
+import '../../actions/icon-button/ndd-icon-button.ts';
 
 /**
- * De Tooltip component voor het tonen van informatie tekst.
+ * De Tooltip toont informatieve tekst bij hover of focus op een child element.
+ * Gebruikt `display: contents` zodat het de layout niet beïnvloedt.
  *
  * ## Gebruik
  * ```html
- * <ndd-tooltip text="Tooltip tekst"></ndd-tooltip>
+ * <ndd-tooltip text="Meer informatie">
+ *   <ndd-icon-button icon="info" text="Info"></ndd-icon-button>
+ * </ndd-tooltip>
  * ```
  */
 export default {
@@ -18,28 +23,69 @@ export default {
 			file: 'src/components/content/tooltip/ndd-tooltip.ts',
 			repository: 'https://github.com/MinBZK/storybook',
 		},
-		status: {
-			type: 'stable',
-		},
+		status: { type: 'stable' },
 	},
 	argTypes: {
 		text: {
 			control: 'text',
-			description: 'Tooltip text content',
+			description: 'Tooltip tekst',
+		},
+		placement: {
+			control: 'select',
+			options: ['top', 'bottom', 'left', 'right'],
+			description: 'Positie van de tooltip',
+			table: { defaultValue: { summary: 'top' } },
 		},
 	},
 	args: {
-		text: 'Tooltip tekst',
+		text: 'Dit is een tooltip',
+		placement: 'top',
 	},
 };
 
-const Template = ({ text }) => html`
-	<div style="padding: 2rem; display: flex; justify-content: center;">
-		<ndd-tooltip text=${text}></ndd-tooltip>
-	</div>
-`;
+export const Standaard = {
+	render: (args) => html`
+		<div style="display: flex; justify-content: center; padding: 4rem;">
+			<ndd-tooltip
+				text=${args.text}
+				placement=${args.placement}
+			>
+				<ndd-button text="Hover mij"></ndd-button>
+			</ndd-tooltip>
+		</div>
+	`,
+};
 
-export const Default = Template.bind({});
-Default.args = {
-	text: 'Dit is een tooltip',
+export const MetIconButton = {
+	render: () => html`
+		<div style="display: flex; justify-content: center; padding: 4rem;">
+			<ndd-tooltip text="Meer informatie">
+				<ndd-icon-button
+					icon="info"
+					text="Info"
+				></ndd-icon-button>
+			</ndd-tooltip>
+		</div>
+	`,
+	parameters: { controls: { disable: true } },
+};
+
+export const Posities = {
+	render: () => html`
+		<div style="display: flex; gap: 2rem; justify-content: center; padding: 4rem;">
+			<ndd-tooltip text="Boven" placement="top">
+				<ndd-button text="Top"></ndd-button>
+			</ndd-tooltip>
+			<ndd-tooltip text="Onder" placement="bottom">
+				<ndd-button text="Bottom"></ndd-button>
+			</ndd-tooltip>
+			<ndd-tooltip text="Links" placement="left">
+				<ndd-button text="Left"></ndd-button>
+			</ndd-tooltip>
+			<ndd-tooltip text="Rechts" placement="right">
+				<ndd-button text="Right"></ndd-button>
+			</ndd-tooltip>
+		</div>
+	`,
+	parameters: { controls: { disable: true } },
 };

--- a/src/components/content/tooltip/ndd-tooltip.stories.js
+++ b/src/components/content/tooltip/ndd-tooltip.stories.js
@@ -98,13 +98,11 @@ export const Posities = {
 
 export const MetTekst = {
 	render: () => html`
-		<div style="display: flex; justify-content: center; padding: 4rem;">
-			<ndd-tooltip text="Artikel 1 van de Grondwet">
-				<ndd-rich-text>
-					<p>Hover over deze <strong>tekst</strong> voor meer informatie.</p>
-				</ndd-rich-text>
-			</ndd-tooltip>
-		</div>
+		<ndd-tooltip text="Artikel 1 van de Grondwet">
+			<ndd-rich-text>
+				<p>Hover over deze <strong>tekst</strong> voor meer informatie.</p>
+			</ndd-rich-text>
+		</ndd-tooltip>
 	`,
 	parameters: {
 		controls: { disable: true },

--- a/src/components/content/tooltip/ndd-tooltip.stories.js
+++ b/src/components/content/tooltip/ndd-tooltip.stories.js
@@ -59,15 +59,20 @@ export const Standaard = {
 export const MetIconButton = {
 	render: () => html`
 		<div style="display: flex; justify-content: center; padding: 4rem;">
-			<ndd-tooltip text="Meer informatie">
-				<ndd-icon-button
-					icon="info"
-					text="Info"
-				></ndd-icon-button>
-			</ndd-tooltip>
+			<ndd-icon-button
+				icon="info"
+				text="Info"
+			></ndd-icon-button>
 		</div>
 	`,
-	parameters: { controls: { disable: true } },
+	parameters: {
+		controls: { disable: true },
+		docs: {
+			description: {
+				story: 'Icon-button rendert intern een ndd-tooltip wanneer de tekst niet zichtbaar is.',
+			},
+		},
+	},
 };
 
 export const Posities = {

--- a/src/components/content/tooltip/ndd-tooltip.styles.ts
+++ b/src/components/content/tooltip/ndd-tooltip.styles.ts
@@ -13,7 +13,7 @@ export const tooltipStyles = css`
 		--_hide-duration: 50ms;
 		--_background-color: light-dark(var(--primitives-color-neutral-600), var(--primitives-color-neutral-750));
 		--_content-color: var(--primitives-color-neutral-0);
-		--_offset: var(--primitives-space-6);
+		--_offset: var(--primitives-space-4);
 		--_box-shadow: var(--primitives-box-shadows-level-2);
 		--_max-width: var(--primitives-area-280);
 	}

--- a/src/components/content/tooltip/ndd-tooltip.styles.ts
+++ b/src/components/content/tooltip/ndd-tooltip.styles.ts
@@ -10,8 +10,8 @@ export const tooltipStyles = css`
 		--_z-index: 10000;
 		--_show-delay: 400ms;
 		--_show-duration: 50ms;
-		--_background-color: light-dark(var(--primitives-color-neutral-350), var(--primitives-color-neutral-350));
-		--_color: var(--semantics-surfaces-background-color);
+		--_background-color: light-dark(var(--primitives-color-neutral-600), var(--primitives-color-neutral-600));
+		--_color: var(--primitives-color-neutral-0);
 		--_box-shadow: var(--primitives-box-shadows-level-2);
 		--_max-width: var(--primitives-area-280);
 	}

--- a/src/components/content/tooltip/ndd-tooltip.styles.ts
+++ b/src/components/content/tooltip/ndd-tooltip.styles.ts
@@ -1,0 +1,59 @@
+import { css } from 'lit';
+
+export const tooltipStyles = css`
+
+
+	/* # Host */
+
+	:host {
+		display: contents;
+	}
+
+	:host([hidden]) {
+		display: none;
+	}
+
+
+	/* # Tooltip */
+
+	.tooltip {
+		position: fixed;
+		z-index: 10000;
+		pointer-events: none;
+		opacity: 0;
+		transition: opacity 0.15s ease;
+	}
+
+	.tooltip.is-visible {
+		opacity: 1;
+	}
+
+
+	/* ## Tooltip body */
+
+	.tooltip__body {
+		background-color: var(--primitives-color-neutral-0);
+		color: var(--semantics-content-color);
+		font: var(--primitives-font-body-xs-regular-tight);
+		padding-block: var(--primitives-space-4);
+		padding-inline: var(--primitives-space-8);
+		white-space: nowrap;
+		box-shadow: var(--primitives-box-shadows-level-2);
+		border-radius: var(--primitives-corner-radius-sm);
+	}
+
+
+	/* # Toegankelijkheid */
+
+	@media (forced-colors: active) {
+		.tooltip__body {
+			border: 1px solid CanvasText;
+		}
+	}
+
+	@media (prefers-reduced-motion: reduce) {
+		.tooltip {
+			transition: none;
+		}
+	}
+`;

--- a/src/components/content/tooltip/ndd-tooltip.styles.ts
+++ b/src/components/content/tooltip/ndd-tooltip.styles.ts
@@ -12,11 +12,11 @@ export const tooltipStyles = css`
 		--_show-duration: 150ms;
 		--_hide-delay: 50ms;
 		--_hide-duration: 150ms;
-		--_background-color: light-dark(var(--primitives-color-neutral-600), var(--primitives-color-neutral-750));
-		--_content-color: var(--primitives-color-neutral-0);
+		--_background-color: var(--components-tooltip-background-color);
+		--_content-color: var(--components-tooltip-content-color);
 		--_offset: var(--primitives-space-4);
 		--_shift-padding: var(--primitives-space-8);
-		--_box-shadow: var(--primitives-box-shadows-level-2);
+		--_box-shadow: var(--components-tooltip-box-shadow);
 		--_max-width: var(--primitives-area-280);
 	}
 

--- a/src/components/content/tooltip/ndd-tooltip.styles.ts
+++ b/src/components/content/tooltip/ndd-tooltip.styles.ts
@@ -28,10 +28,12 @@ export const tooltipStyles = css`
 		position: fixed;
 		z-index: var(--_z-index);
 		opacity: 0;
+		pointer-events: none;
 		transition: opacity var(--_hide-duration) ease;
 	}
 
 	.tooltip.is-visible {
+		pointer-events: auto;
 		animation: tooltip-show var(--_show-duration) ease var(--_show-delay) forwards;
 	}
 

--- a/src/components/content/tooltip/ndd-tooltip.styles.ts
+++ b/src/components/content/tooltip/ndd-tooltip.styles.ts
@@ -11,8 +11,8 @@ export const tooltipStyles = css`
 		--_show-delay: 400ms;
 		--_show-duration: 50ms;
 		--_hide-duration: 50ms;
-		--_background-color: light-dark(var(--primitives-color-neutral-600), var(--primitives-color-neutral-600));
-		--_color: var(--primitives-color-neutral-0);
+		--_background-color: light-dark(var(--primitives-color-neutral-600), var(--primitives-color-neutral-750));
+		--_content-color: var(--primitives-color-neutral-0);
 		--_box-shadow: var(--primitives-box-shadows-level-2);
 		--_max-width: var(--primitives-area-280);
 	}
@@ -46,7 +46,7 @@ export const tooltipStyles = css`
 
 	.tooltip__body {
 		background-color: var(--_background-color);
-		color: var(--_color);
+		color: var(--_content-color);
 		font: var(--primitives-font-body-xs-regular-tight);
 		padding-block: var(--primitives-space-4);
 		padding-inline: var(--primitives-space-8);

--- a/src/components/content/tooltip/ndd-tooltip.styles.ts
+++ b/src/components/content/tooltip/ndd-tooltip.styles.ts
@@ -13,6 +13,7 @@ export const tooltipStyles = css`
 		--_hide-duration: 50ms;
 		--_background-color: light-dark(var(--primitives-color-neutral-600), var(--primitives-color-neutral-750));
 		--_content-color: var(--primitives-color-neutral-0);
+		--_offset: var(--primitives-space-6);
 		--_box-shadow: var(--primitives-box-shadows-level-2);
 		--_max-width: var(--primitives-area-280);
 	}

--- a/src/components/content/tooltip/ndd-tooltip.styles.ts
+++ b/src/components/content/tooltip/ndd-tooltip.styles.ts
@@ -10,7 +10,7 @@ export const tooltipStyles = css`
 		--_z-index: 10000;
 		--_show-delay: 700ms;
 		--_show-duration: 150ms;
-		--_hide-delay: 50ms;
+		--_hide-delay: 50; /* unitless ms, read by JavaScript */
 		--_hide-duration: 150ms;
 		--_offset: var(--primitives-space-4);
 		--_shift-padding: var(--primitives-space-8);

--- a/src/components/content/tooltip/ndd-tooltip.styles.ts
+++ b/src/components/content/tooltip/ndd-tooltip.styles.ts
@@ -10,6 +10,7 @@ export const tooltipStyles = css`
 		--_z-index: 10000;
 		--_show-delay: 700ms;
 		--_show-duration: 150ms;
+		--_hide-delay: 50ms;
 		--_hide-duration: 150ms;
 		--_background-color: light-dark(var(--primitives-color-neutral-600), var(--primitives-color-neutral-750));
 		--_content-color: var(--primitives-color-neutral-0);
@@ -51,8 +52,9 @@ export const tooltipStyles = css`
 		font: var(--primitives-font-body-xs-regular-tight);
 		padding-block: var(--primitives-space-4);
 		padding-inline: var(--primitives-space-8);
+		width: max-content;
 		max-width: var(--_max-width);
-		white-space: nowrap;
+		overflow-wrap: break-word;
 		box-shadow: var(--_box-shadow);
 		border-radius: var(--primitives-corner-radius-xs);
 	}

--- a/src/components/content/tooltip/ndd-tooltip.styles.ts
+++ b/src/components/content/tooltip/ndd-tooltip.styles.ts
@@ -12,8 +12,8 @@ export const tooltipStyles = css`
 		--_show-duration: 150ms;
 		--_hide-delay: 50; /* unitless ms, read by JavaScript */
 		--_hide-duration: 150ms;
-		--_offset: var(--primitives-space-4);
-		--_shift-padding: var(--primitives-space-8);
+		--_offset: 4; /* px, unitless — read by JS */
+		--_shift-padding: 8; /* px, unitless — read by JS */
 		--_max-width: var(--primitives-area-280);
 	}
 
@@ -29,15 +29,32 @@ export const tooltipStyles = css`
 		z-index: var(--_z-index);
 		opacity: 0;
 		pointer-events: none;
-		transition: opacity var(--_hide-duration) ease, visibility 0ms linear var(--_hide-duration);
 		visibility: hidden;
+		transition:
+			opacity var(--_hide-duration) ease,
+			visibility 0ms linear var(--_hide-duration),
+			pointer-events 0ms linear var(--_hide-duration);
 	}
 
 	.tooltip.is-visible {
-		pointer-events: auto;
 		opacity: 1;
 		visibility: visible;
-		transition: opacity var(--_show-duration) ease var(--_show-delay), visibility 0ms linear;
+		pointer-events: auto;
+		transition:
+			opacity var(--_show-duration) ease var(--_show-delay),
+			visibility 0ms linear,
+			pointer-events 0ms linear var(--_show-delay);
+	}
+
+	/* Focus triggers: geen show delay */
+	.tooltip.is-focus-visible {
+		opacity: 1;
+		visibility: visible;
+		pointer-events: auto;
+		transition:
+			opacity var(--_show-duration) ease,
+			visibility 0ms linear,
+			pointer-events 0ms linear;
 	}
 
 

--- a/src/components/content/tooltip/ndd-tooltip.styles.ts
+++ b/src/components/content/tooltip/ndd-tooltip.styles.ts
@@ -7,6 +7,10 @@ export const tooltipStyles = css`
 
 	:host {
 		display: contents;
+		--_show-delay: 400ms;
+		--_show-duration: 50ms;
+		--_box-shadow: var(--primitives-box-shadows-level-2);
+		--_max-width: var(--primitives-area-280);
 	}
 
 	:host([hidden]) {
@@ -21,25 +25,29 @@ export const tooltipStyles = css`
 		z-index: 10000;
 		pointer-events: none;
 		opacity: 0;
-		transition: opacity 0.15s ease;
 	}
 
 	.tooltip.is-visible {
-		opacity: 1;
+		animation: tooltip-show var(--_show-duration) ease var(--_show-delay) forwards;
+	}
+
+	@keyframes tooltip-show {
+		to { opacity: 1; }
 	}
 
 
 	/* ## Tooltip body */
 
 	.tooltip__body {
-		background-color: var(--primitives-color-neutral-0);
+		background-color: var(--semantics-surfaces-background-color);
 		color: var(--semantics-content-color);
 		font: var(--primitives-font-body-xs-regular-tight);
 		padding-block: var(--primitives-space-4);
 		padding-inline: var(--primitives-space-8);
-		white-space: nowrap;
-		box-shadow: var(--primitives-box-shadows-level-2);
-		border-radius: var(--primitives-corner-radius-sm);
+		max-width: var(--_max-width);
+		white-space: normal;
+		box-shadow: var(--_box-shadow);
+		border-radius: var(--primitives-corner-radius-xs);
 	}
 
 
@@ -52,8 +60,9 @@ export const tooltipStyles = css`
 	}
 
 	@media (prefers-reduced-motion: reduce) {
-		.tooltip {
-			transition: none;
+		.tooltip.is-visible {
+			animation: none;
+			opacity: 1;
 		}
 	}
 `;

--- a/src/components/content/tooltip/ndd-tooltip.styles.ts
+++ b/src/components/content/tooltip/ndd-tooltip.styles.ts
@@ -10,6 +10,7 @@ export const tooltipStyles = css`
 		--_z-index: 10000;
 		--_show-delay: 400ms;
 		--_show-duration: 50ms;
+		--_hide-duration: 50ms;
 		--_background-color: light-dark(var(--primitives-color-neutral-600), var(--primitives-color-neutral-600));
 		--_color: var(--primitives-color-neutral-0);
 		--_box-shadow: var(--primitives-box-shadows-level-2);
@@ -27,6 +28,7 @@ export const tooltipStyles = css`
 		position: fixed;
 		z-index: var(--_z-index);
 		opacity: 0;
+		transition: opacity var(--_hide-duration) ease;
 	}
 
 	.tooltip.is-visible {
@@ -62,6 +64,10 @@ export const tooltipStyles = css`
 	}
 
 	@media (prefers-reduced-motion: reduce) {
+		.tooltip {
+			transition: none;
+		}
+
 		.tooltip.is-visible {
 			animation: none;
 			opacity: 1;

--- a/src/components/content/tooltip/ndd-tooltip.styles.ts
+++ b/src/components/content/tooltip/ndd-tooltip.styles.ts
@@ -8,12 +8,13 @@ export const tooltipStyles = css`
 	:host {
 		display: contents;
 		--_z-index: 10000;
-		--_show-delay: 400ms;
-		--_show-duration: 50ms;
-		--_hide-duration: 50ms;
+		--_show-delay: 700ms;
+		--_show-duration: 150ms;
+		--_hide-duration: 150ms;
 		--_background-color: light-dark(var(--primitives-color-neutral-600), var(--primitives-color-neutral-750));
 		--_content-color: var(--primitives-color-neutral-0);
 		--_offset: var(--primitives-space-4);
+		--_shift-padding: var(--primitives-space-8);
 		--_box-shadow: var(--primitives-box-shadows-level-2);
 		--_max-width: var(--primitives-area-280);
 	}
@@ -30,16 +31,15 @@ export const tooltipStyles = css`
 		z-index: var(--_z-index);
 		opacity: 0;
 		pointer-events: none;
-		transition: opacity var(--_hide-duration) ease;
+		transition: opacity var(--_hide-duration) ease, visibility 0ms linear var(--_hide-duration);
+		visibility: hidden;
 	}
 
 	.tooltip.is-visible {
 		pointer-events: auto;
-		animation: tooltip-show var(--_show-duration) ease var(--_show-delay) forwards;
-	}
-
-	@keyframes tooltip-show {
-		to { opacity: 1; }
+		opacity: 1;
+		visibility: visible;
+		transition: opacity var(--_show-duration) ease var(--_show-delay), visibility 0ms linear;
 	}
 
 
@@ -52,7 +52,7 @@ export const tooltipStyles = css`
 		padding-block: var(--primitives-space-4);
 		padding-inline: var(--primitives-space-8);
 		max-width: var(--_max-width);
-		white-space: normal;
+		white-space: nowrap;
 		box-shadow: var(--_box-shadow);
 		border-radius: var(--primitives-corner-radius-xs);
 	}
@@ -67,13 +67,9 @@ export const tooltipStyles = css`
 	}
 
 	@media (prefers-reduced-motion: reduce) {
-		.tooltip {
-			transition: none;
-		}
-
+		.tooltip,
 		.tooltip.is-visible {
-			animation: none;
-			opacity: 1;
+			transition: none;
 		}
 	}
 `;

--- a/src/components/content/tooltip/ndd-tooltip.styles.ts
+++ b/src/components/content/tooltip/ndd-tooltip.styles.ts
@@ -84,7 +84,8 @@ export const tooltipStyles = css`
 
 	@media (prefers-reduced-motion: reduce) {
 		.tooltip,
-		.tooltip.is-visible {
+		.tooltip.is-visible,
+		.tooltip.is-focus-visible {
 			transition: none;
 		}
 	}

--- a/src/components/content/tooltip/ndd-tooltip.styles.ts
+++ b/src/components/content/tooltip/ndd-tooltip.styles.ts
@@ -7,8 +7,11 @@ export const tooltipStyles = css`
 
 	:host {
 		display: contents;
+		--_z-index: 10000;
 		--_show-delay: 400ms;
 		--_show-duration: 50ms;
+		--_background-color: light-dark(var(--primitives-color-neutral-350), var(--primitives-color-neutral-350));
+		--_color: var(--semantics-surfaces-background-color);
 		--_box-shadow: var(--primitives-box-shadows-level-2);
 		--_max-width: var(--primitives-area-280);
 	}
@@ -22,8 +25,7 @@ export const tooltipStyles = css`
 
 	.tooltip {
 		position: fixed;
-		z-index: 10000;
-		pointer-events: none;
+		z-index: var(--_z-index);
 		opacity: 0;
 	}
 
@@ -39,8 +41,8 @@ export const tooltipStyles = css`
 	/* ## Tooltip body */
 
 	.tooltip__body {
-		background-color: var(--semantics-surfaces-background-color);
-		color: var(--semantics-content-color);
+		background-color: var(--_background-color);
+		color: var(--_color);
 		font: var(--primitives-font-body-xs-regular-tight);
 		padding-block: var(--primitives-space-4);
 		padding-inline: var(--primitives-space-8);

--- a/src/components/content/tooltip/ndd-tooltip.styles.ts
+++ b/src/components/content/tooltip/ndd-tooltip.styles.ts
@@ -12,11 +12,8 @@ export const tooltipStyles = css`
 		--_show-duration: 150ms;
 		--_hide-delay: 50ms;
 		--_hide-duration: 150ms;
-		--_background-color: var(--components-tooltip-background-color);
-		--_content-color: var(--components-tooltip-content-color);
 		--_offset: var(--primitives-space-4);
 		--_shift-padding: var(--primitives-space-8);
-		--_box-shadow: var(--components-tooltip-box-shadow);
 		--_max-width: var(--primitives-area-280);
 	}
 
@@ -47,15 +44,15 @@ export const tooltipStyles = css`
 	/* ## Tooltip body */
 
 	.tooltip__body {
-		background-color: var(--_background-color);
-		color: var(--_content-color);
+		background-color: var(--components-tooltip-background-color);
+		color: var(--components-tooltip-content-color);
 		font: var(--primitives-font-body-xs-regular-tight);
 		padding-block: var(--primitives-space-4);
 		padding-inline: var(--primitives-space-8);
 		width: max-content;
 		max-width: var(--_max-width);
 		overflow-wrap: break-word;
-		box-shadow: var(--_box-shadow);
+		box-shadow: var(--components-tooltip-box-shadow);
 		border-radius: var(--primitives-corner-radius-xs);
 	}
 

--- a/src/components/content/tooltip/ndd-tooltip.template.ts
+++ b/src/components/content/tooltip/ndd-tooltip.template.ts
@@ -1,5 +1,6 @@
 /* eslint-disable lit-a11y/accessible-name -- text content provides the accessible name */
 import { html, TemplateResult } from 'lit';
+import { classMap } from 'lit/directives/class-map.js';
 import type { NDDTooltip } from './ndd-tooltip.ts';
 
 export function tooltipTemplate(component: NDDTooltip): TemplateResult {
@@ -10,9 +11,10 @@ export function tooltipTemplate(component: NDDTooltip): TemplateResult {
 			@focusin=${component._handleTriggerEnter}
 			@focusout=${component._handleTriggerLeave}
 		></slot>
-		<div class="tooltip ${component._visible ? 'is-visible' : ''}"
+		<div class=${classMap({ tooltip: true, 'is-visible': component._visible })}
 			role="tooltip"
-			id=${component._tooltipId}
+			@mouseenter=${component._handleTooltipEnter}
+			@mouseleave=${component._handleTooltipLeave}
 		>
 			<div class="tooltip__body">${component.text}</div>
 		</div>

--- a/src/components/content/tooltip/ndd-tooltip.template.ts
+++ b/src/components/content/tooltip/ndd-tooltip.template.ts
@@ -1,0 +1,20 @@
+/* eslint-disable lit-a11y/accessible-name -- text content provides the accessible name */
+import { html, TemplateResult } from 'lit';
+import type { NDDTooltip } from './ndd-tooltip.ts';
+
+export function tooltipTemplate(component: NDDTooltip): TemplateResult {
+	return html`
+		<slot
+			@mouseenter=${component._handleTriggerEnter}
+			@mouseleave=${component._handleTriggerLeave}
+			@focusin=${component._handleTriggerEnter}
+			@focusout=${component._handleTriggerLeave}
+		></slot>
+		<div class="tooltip ${component._visible ? 'is-visible' : ''}"
+			role="tooltip"
+			id=${component._tooltipId}
+		>
+			<div class="tooltip__body">${component.text}</div>
+		</div>
+	`;
+}

--- a/src/components/content/tooltip/ndd-tooltip.template.ts
+++ b/src/components/content/tooltip/ndd-tooltip.template.ts
@@ -8,10 +8,10 @@ export function tooltipTemplate(component: NDDTooltip): TemplateResult {
 		<slot
 			@mouseenter=${component._handleTriggerEnter}
 			@mouseleave=${component._handleTriggerLeave}
-			@focusin=${component._handleTriggerEnter}
+			@focusin=${component._handleFocusIn}
 			@focusout=${component._handleFocusOut}
 		></slot>
-		<div class=${classMap({ tooltip: true, 'is-visible': component._visible })}
+		<div class=${classMap({ tooltip: true, 'is-visible': component._visible && !component._focusVisible, 'is-focus-visible': component._visible && component._focusVisible })}
 			aria-hidden="true"
 			@mouseenter=${component._handleTooltipEnter}
 			@mouseleave=${component._handleTooltipLeave}

--- a/src/components/content/tooltip/ndd-tooltip.template.ts
+++ b/src/components/content/tooltip/ndd-tooltip.template.ts
@@ -1,5 +1,4 @@
-/* eslint-disable lit-a11y/accessible-name -- text content provides the accessible name */
-import { html, nothing, TemplateResult } from 'lit';
+import { html, TemplateResult } from 'lit';
 import { classMap } from 'lit/directives/class-map.js';
 import type { NDDTooltip } from './ndd-tooltip.ts';
 
@@ -12,8 +11,7 @@ export function tooltipTemplate(component: NDDTooltip): TemplateResult {
 			@focusout=${component._handleFocusOut}
 		></slot>
 		<div class=${classMap({ tooltip: true, 'is-visible': component._visible })}
-			role="tooltip"
-			aria-hidden=${!component._visible ? 'true' : nothing}
+			aria-hidden="true"
 			@mouseenter=${component._handleTooltipEnter}
 			@mouseleave=${component._handleTooltipLeave}
 		>

--- a/src/components/content/tooltip/ndd-tooltip.template.ts
+++ b/src/components/content/tooltip/ndd-tooltip.template.ts
@@ -1,4 +1,5 @@
-import { html, TemplateResult } from 'lit';
+import { html } from 'lit';
+import type { TemplateResult } from 'lit';
 import { classMap } from 'lit/directives/class-map.js';
 import type { NDDTooltip } from './ndd-tooltip.ts';
 

--- a/src/components/content/tooltip/ndd-tooltip.template.ts
+++ b/src/components/content/tooltip/ndd-tooltip.template.ts
@@ -1,5 +1,5 @@
 /* eslint-disable lit-a11y/accessible-name -- text content provides the accessible name */
-import { html, TemplateResult } from 'lit';
+import { html, nothing, TemplateResult } from 'lit';
 import { classMap } from 'lit/directives/class-map.js';
 import type { NDDTooltip } from './ndd-tooltip.ts';
 
@@ -13,7 +13,7 @@ export function tooltipTemplate(component: NDDTooltip): TemplateResult {
 		></slot>
 		<div class=${classMap({ tooltip: true, 'is-visible': component._visible })}
 			role="tooltip"
-			aria-hidden=${!component._visible ? 'true' : 'false'}
+			aria-hidden=${!component._visible ? 'true' : nothing}
 			@mouseenter=${component._handleTooltipEnter}
 			@mouseleave=${component._handleTooltipLeave}
 		>

--- a/src/components/content/tooltip/ndd-tooltip.template.ts
+++ b/src/components/content/tooltip/ndd-tooltip.template.ts
@@ -13,6 +13,7 @@ export function tooltipTemplate(component: NDDTooltip): TemplateResult {
 		></slot>
 		<div class=${classMap({ tooltip: true, 'is-visible': component._visible })}
 			role="tooltip"
+			aria-hidden=${!component._visible ? 'true' : 'false'}
 			@mouseenter=${component._handleTooltipEnter}
 			@mouseleave=${component._handleTooltipLeave}
 		>

--- a/src/components/content/tooltip/ndd-tooltip.template.ts
+++ b/src/components/content/tooltip/ndd-tooltip.template.ts
@@ -9,7 +9,7 @@ export function tooltipTemplate(component: NDDTooltip): TemplateResult {
 			@mouseenter=${component._handleTriggerEnter}
 			@mouseleave=${component._handleTriggerLeave}
 			@focusin=${component._handleTriggerEnter}
-			@focusout=${component._handleTriggerLeave}
+			@focusout=${component._handleFocusOut}
 		></slot>
 		<div class=${classMap({ tooltip: true, 'is-visible': component._visible })}
 			role="tooltip"

--- a/src/components/content/tooltip/ndd-tooltip.test.ts
+++ b/src/components/content/tooltip/ndd-tooltip.test.ts
@@ -67,9 +67,8 @@ describe('ndd-tooltip – show/hide', () => {
 		el._handleTriggerEnter();
 		await waitForUpdate(el);
 		el._handleTriggerLeave();
+		await new Promise(resolve => setTimeout(resolve, 150));
 
-		// Wait for hide delay
-		await new Promise(resolve => setTimeout(resolve, 100));
 		expect(el._visible).toBe(false);
 	});
 
@@ -81,8 +80,8 @@ describe('ndd-tooltip – show/hide', () => {
 		await waitForUpdate(el);
 		el._handleTriggerLeave();
 		el._handleTooltipEnter();
+		await new Promise(resolve => setTimeout(resolve, 150));
 
-		await new Promise(resolve => setTimeout(resolve, 100));
 		expect(el._visible).toBe(true);
 	});
 

--- a/src/components/content/tooltip/ndd-tooltip.test.ts
+++ b/src/components/content/tooltip/ndd-tooltip.test.ts
@@ -16,12 +16,6 @@ describe('ndd-tooltip', () => {
 		expect(el.shadowRoot).not.toBeNull();
 	});
 
-	it('gebruikt display: contents', async () => {
-		el = await fixture<NDDTooltip>('<ndd-tooltip text="Test"></ndd-tooltip>');
-		await waitForUpdate(el);
-		expect(getComputedStyle(el).display).toBe('contents');
-	});
-
 	it('rendert tooltip met role="tooltip"', async () => {
 		el = await fixture<NDDTooltip>('<ndd-tooltip text="Test"></ndd-tooltip>');
 		await waitForUpdate(el);
@@ -48,6 +42,49 @@ describe('ndd-tooltip', () => {
 		await waitForUpdate(el);
 		expect(el.placement).toBe('top');
 	});
+});
+
+describe('ndd-tooltip – show/hide', () => {
+	let el: NDDTooltip;
+
+	afterEach(() => {
+		if (el) cleanup(el);
+	});
+
+	it('wordt zichtbaar bij trigger enter', async () => {
+		el = await fixture<NDDTooltip>('<ndd-tooltip text="Test"><button>Trigger</button></ndd-tooltip>');
+		await waitForUpdate(el);
+
+		el._handleTriggerEnter();
+		await waitForUpdate(el);
+		expect(el._visible).toBe(true);
+	});
+
+	it('wordt verborgen bij trigger leave', async () => {
+		el = await fixture<NDDTooltip>('<ndd-tooltip text="Test"><button>Trigger</button></ndd-tooltip>');
+		await waitForUpdate(el);
+
+		el._handleTriggerEnter();
+		await waitForUpdate(el);
+		el._handleTriggerLeave();
+
+		// Wait for hide delay
+		await new Promise(resolve => setTimeout(resolve, 100));
+		expect(el._visible).toBe(false);
+	});
+
+	it('blijft zichtbaar bij tooltip hover', async () => {
+		el = await fixture<NDDTooltip>('<ndd-tooltip text="Test"><button>Trigger</button></ndd-tooltip>');
+		await waitForUpdate(el);
+
+		el._handleTriggerEnter();
+		await waitForUpdate(el);
+		el._handleTriggerLeave();
+		el._handleTooltipEnter();
+
+		await new Promise(resolve => setTimeout(resolve, 100));
+		expect(el._visible).toBe(true);
+	});
 
 	it('Escape sluit de tooltip', async () => {
 		el = await fixture<NDDTooltip>('<ndd-tooltip text="Test"><button>Trigger</button></ndd-tooltip>');
@@ -60,5 +97,54 @@ describe('ndd-tooltip', () => {
 		el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
 		await waitForUpdate(el);
 		expect(el._visible).toBe(false);
+	});
+
+	it('toont niet bij lege text', async () => {
+		el = await fixture<NDDTooltip>('<ndd-tooltip text=""><button>Trigger</button></ndd-tooltip>');
+		await waitForUpdate(el);
+
+		el._handleTriggerEnter();
+		await waitForUpdate(el);
+		expect(el._visible).toBe(false);
+	});
+});
+
+describe('ndd-tooltip – aria-describedby', () => {
+	let el: NDDTooltip;
+
+	afterEach(() => {
+		if (el) cleanup(el);
+	});
+
+	it('zet aria-describedby op het trigger element', async () => {
+		el = await fixture<NDDTooltip>(`
+			<ndd-tooltip text="Helptekst">
+				<button>Trigger</button>
+			</ndd-tooltip>
+		`);
+		await waitForUpdate(el);
+
+		const trigger = el.querySelector('button');
+		const describedBy = trigger?.getAttribute('aria-describedby');
+		expect(describedBy).toBeTruthy();
+
+		const descriptionEl = el.querySelector(`#${describedBy}`);
+		expect(descriptionEl).not.toBeNull();
+		expect(descriptionEl?.textContent).toBe('Helptekst');
+	});
+
+	it('verwijdert aria-describedby bij lege text', async () => {
+		el = await fixture<NDDTooltip>(`
+			<ndd-tooltip text="Helptekst">
+				<button>Trigger</button>
+			</ndd-tooltip>
+		`);
+		await waitForUpdate(el);
+
+		el.text = '';
+		await waitForUpdate(el);
+
+		const trigger = el.querySelector('button');
+		expect(trigger?.hasAttribute('aria-describedby')).toBe(false);
 	});
 });

--- a/src/components/content/tooltip/ndd-tooltip.test.ts
+++ b/src/components/content/tooltip/ndd-tooltip.test.ts
@@ -20,10 +20,12 @@ describe('ndd-tooltip', () => {
 		expect(el.shadowRoot).not.toBeNull();
 	});
 
-	it('rendert tooltip met role="tooltip"', async () => {
+	it('rendert tooltip met aria-hidden', async () => {
 		el = await fixture<NDDTooltip>('<ndd-tooltip text="Test"></ndd-tooltip>');
 		await waitForUpdate(el);
-		expect(el.shadowRoot!.querySelector('[role="tooltip"]')).not.toBeNull();
+		const tooltip = el.shadowRoot!.querySelector('.tooltip');
+		expect(tooltip).not.toBeNull();
+		expect(tooltip!.getAttribute('aria-hidden')).toBe('true');
 	});
 
 	it('toont de tooltip tekst', async () => {
@@ -148,7 +150,7 @@ describe('ndd-tooltip – aria-describedby', () => {
 		const describedBy = trigger?.getAttribute('aria-describedby');
 		expect(describedBy).toBeTruthy();
 
-		const descriptionEl = el.querySelector(`#${describedBy}`);
+		const descriptionEl = document.getElementById(describedBy!);
 		expect(descriptionEl).not.toBeNull();
 		expect(descriptionEl?.textContent).toBe('Helptekst');
 	});

--- a/src/components/content/tooltip/ndd-tooltip.test.ts
+++ b/src/components/content/tooltip/ndd-tooltip.test.ts
@@ -169,4 +169,13 @@ describe('ndd-tooltip – aria-describedby', () => {
 		const trigger = el.querySelector('button');
 		expect(trigger?.hasAttribute('aria-describedby')).toBe(false);
 	});
+
+	it('verwijdert description span bij disconnect', async () => {
+		el = await fixture<NDDTooltip>('<ndd-tooltip text="Test"><button>T</button></ndd-tooltip>');
+		await waitForUpdate(el);
+		const id = el.querySelector('button')!.getAttribute('aria-describedby')!;
+		expect(document.getElementById(id)).not.toBeNull();
+		cleanup(el);
+		expect(document.getElementById(id)).toBeNull();
+	});
 });

--- a/src/components/content/tooltip/ndd-tooltip.test.ts
+++ b/src/components/content/tooltip/ndd-tooltip.test.ts
@@ -4,7 +4,8 @@ import type { NDDTooltip } from './ndd-tooltip.ts';
 import './ndd-tooltip.ts';
 
 function isTooltipVisible(el: NDDTooltip): boolean {
-	return el.shadowRoot!.querySelector('.tooltip')?.classList.contains('is-visible') ?? false;
+	const tooltip = el.shadowRoot!.querySelector('.tooltip');
+	return tooltip?.classList.contains('is-visible') || tooltip?.classList.contains('is-focus-visible') || false;
 }
 
 describe('ndd-tooltip', () => {

--- a/src/components/content/tooltip/ndd-tooltip.test.ts
+++ b/src/components/content/tooltip/ndd-tooltip.test.ts
@@ -3,6 +3,10 @@ import { fixture, cleanup, waitForUpdate } from '../../../test-utils.ts';
 import type { NDDTooltip } from './ndd-tooltip.ts';
 import './ndd-tooltip.ts';
 
+function isTooltipVisible(el: NDDTooltip): boolean {
+	return el.shadowRoot!.querySelector('.tooltip')?.classList.contains('is-visible') ?? false;
+}
+
 describe('ndd-tooltip', () => {
 	let el: NDDTooltip;
 
@@ -19,22 +23,19 @@ describe('ndd-tooltip', () => {
 	it('rendert tooltip met role="tooltip"', async () => {
 		el = await fixture<NDDTooltip>('<ndd-tooltip text="Test"></ndd-tooltip>');
 		await waitForUpdate(el);
-		const tooltip = el.shadowRoot!.querySelector('[role="tooltip"]');
-		expect(tooltip).not.toBeNull();
+		expect(el.shadowRoot!.querySelector('[role="tooltip"]')).not.toBeNull();
 	});
 
 	it('toont de tooltip tekst', async () => {
 		el = await fixture<NDDTooltip>('<ndd-tooltip text="Helptekst"></ndd-tooltip>');
 		await waitForUpdate(el);
-		const body = el.shadowRoot!.querySelector('.tooltip__body');
-		expect(body?.textContent?.trim()).toBe('Helptekst');
+		expect(el.shadowRoot!.querySelector('.tooltip__body')?.textContent?.trim()).toBe('Helptekst');
 	});
 
 	it('tooltip is standaard niet zichtbaar', async () => {
 		el = await fixture<NDDTooltip>('<ndd-tooltip text="Test"></ndd-tooltip>');
 		await waitForUpdate(el);
-		const tooltip = el.shadowRoot!.querySelector('.tooltip');
-		expect(tooltip?.classList.contains('is-visible')).toBe(false);
+		expect(isTooltipVisible(el)).toBe(false);
 	});
 
 	it('standaard placement is top', async () => {
@@ -51,60 +52,80 @@ describe('ndd-tooltip – show/hide', () => {
 		if (el) cleanup(el);
 	});
 
-	it('wordt zichtbaar bij trigger enter', async () => {
+	it('wordt zichtbaar bij mouseenter op trigger', async () => {
 		el = await fixture<NDDTooltip>('<ndd-tooltip text="Test"><button>Trigger</button></ndd-tooltip>');
 		await waitForUpdate(el);
 
-		el._handleTriggerEnter();
+		const trigger = el.querySelector('button')!;
+		trigger.dispatchEvent(new MouseEvent('mouseenter', { bubbles: true }));
 		await waitForUpdate(el);
-		expect(el._visible).toBe(true);
+
+		expect(isTooltipVisible(el)).toBe(true);
 	});
 
-	it('wordt verborgen bij trigger leave', async () => {
+	it('wordt zichtbaar bij focusin op trigger', async () => {
 		el = await fixture<NDDTooltip>('<ndd-tooltip text="Test"><button>Trigger</button></ndd-tooltip>');
 		await waitForUpdate(el);
 
-		el._handleTriggerEnter();
+		const trigger = el.querySelector('button')!;
+		trigger.dispatchEvent(new FocusEvent('focusin', { bubbles: true }));
 		await waitForUpdate(el);
-		el._handleTriggerLeave();
+
+		expect(isTooltipVisible(el)).toBe(true);
+	});
+
+	it('wordt verborgen bij mouseleave', async () => {
+		el = await fixture<NDDTooltip>('<ndd-tooltip text="Test"><button>Trigger</button></ndd-tooltip>');
+		await waitForUpdate(el);
+
+		const trigger = el.querySelector('button')!;
+		trigger.dispatchEvent(new MouseEvent('mouseenter', { bubbles: true }));
+		await waitForUpdate(el);
+		trigger.dispatchEvent(new MouseEvent('mouseleave', { bubbles: true }));
 		await new Promise(resolve => setTimeout(resolve, 150));
 
-		expect(el._visible).toBe(false);
+		expect(isTooltipVisible(el)).toBe(false);
 	});
 
 	it('blijft zichtbaar bij tooltip hover', async () => {
 		el = await fixture<NDDTooltip>('<ndd-tooltip text="Test"><button>Trigger</button></ndd-tooltip>');
 		await waitForUpdate(el);
 
-		el._handleTriggerEnter();
+		const trigger = el.querySelector('button')!;
+		trigger.dispatchEvent(new MouseEvent('mouseenter', { bubbles: true }));
 		await waitForUpdate(el);
-		el._handleTriggerLeave();
-		el._handleTooltipEnter();
+
+		trigger.dispatchEvent(new MouseEvent('mouseleave', { bubbles: true }));
+		const tooltipEl = el.shadowRoot!.querySelector('.tooltip')!;
+		tooltipEl.dispatchEvent(new MouseEvent('mouseenter', { bubbles: true }));
 		await new Promise(resolve => setTimeout(resolve, 150));
 
-		expect(el._visible).toBe(true);
+		expect(isTooltipVisible(el)).toBe(true);
 	});
 
 	it('Escape sluit de tooltip', async () => {
 		el = await fixture<NDDTooltip>('<ndd-tooltip text="Test"><button>Trigger</button></ndd-tooltip>');
 		await waitForUpdate(el);
 
-		el._handleTriggerEnter();
+		const trigger = el.querySelector('button')!;
+		trigger.dispatchEvent(new MouseEvent('mouseenter', { bubbles: true }));
 		await waitForUpdate(el);
-		expect(el._visible).toBe(true);
+		expect(isTooltipVisible(el)).toBe(true);
 
 		el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
 		await waitForUpdate(el);
-		expect(el._visible).toBe(false);
+		expect(isTooltipVisible(el)).toBe(false);
 	});
 
 	it('toont niet bij lege text', async () => {
 		el = await fixture<NDDTooltip>('<ndd-tooltip text=""><button>Trigger</button></ndd-tooltip>');
 		await waitForUpdate(el);
 
-		el._handleTriggerEnter();
+		const trigger = el.querySelector('button')!;
+		trigger.dispatchEvent(new MouseEvent('mouseenter', { bubbles: true }));
 		await waitForUpdate(el);
-		expect(el._visible).toBe(false);
+
+		expect(isTooltipVisible(el)).toBe(false);
 	});
 });
 

--- a/src/components/content/tooltip/ndd-tooltip.test.ts
+++ b/src/components/content/tooltip/ndd-tooltip.test.ts
@@ -1,18 +1,62 @@
 import { describe, it, expect, afterEach } from 'vitest';
 import { fixture, cleanup, waitForUpdate } from '../../../test-utils.ts';
+import type { NDDTooltip } from './ndd-tooltip.ts';
 import './ndd-tooltip.ts';
 
 describe('ndd-tooltip', () => {
-	let el: HTMLElement;
+	let el: NDDTooltip;
 
 	afterEach(() => {
 		if (el) cleanup(el);
 	});
 
-	it('renders without error', async () => {
-		el = await fixture('<ndd-tooltip></ndd-tooltip>');
+	it('rendert zonder fouten', async () => {
+		el = await fixture<NDDTooltip>('<ndd-tooltip text="Test"></ndd-tooltip>');
 		await waitForUpdate(el);
-
 		expect(el.shadowRoot).not.toBeNull();
+	});
+
+	it('gebruikt display: contents', async () => {
+		el = await fixture<NDDTooltip>('<ndd-tooltip text="Test"></ndd-tooltip>');
+		await waitForUpdate(el);
+		expect(getComputedStyle(el).display).toBe('contents');
+	});
+
+	it('rendert tooltip met role="tooltip"', async () => {
+		el = await fixture<NDDTooltip>('<ndd-tooltip text="Test"></ndd-tooltip>');
+		await waitForUpdate(el);
+		const tooltip = el.shadowRoot!.querySelector('[role="tooltip"]');
+		expect(tooltip).not.toBeNull();
+	});
+
+	it('toont de tooltip tekst', async () => {
+		el = await fixture<NDDTooltip>('<ndd-tooltip text="Helptekst"></ndd-tooltip>');
+		await waitForUpdate(el);
+		const body = el.shadowRoot!.querySelector('.tooltip__body');
+		expect(body?.textContent?.trim()).toBe('Helptekst');
+	});
+
+	it('tooltip is standaard niet zichtbaar', async () => {
+		el = await fixture<NDDTooltip>('<ndd-tooltip text="Test"></ndd-tooltip>');
+		await waitForUpdate(el);
+		const tooltip = el.shadowRoot!.querySelector('.tooltip');
+		expect(tooltip?.classList.contains('is-visible')).toBe(false);
+	});
+
+	it('zet aria-describedby op het child element', async () => {
+		el = await fixture<NDDTooltip>(`
+			<ndd-tooltip text="Helptekst">
+				<button>Trigger</button>
+			</ndd-tooltip>
+		`);
+		await waitForUpdate(el);
+		const trigger = el.querySelector('button');
+		expect(trigger?.getAttribute('aria-describedby')).toBe(el._tooltipId);
+	});
+
+	it('standaard placement is top', async () => {
+		el = await fixture<NDDTooltip>('<ndd-tooltip text="Test"></ndd-tooltip>');
+		await waitForUpdate(el);
+		expect(el.placement).toBe('top');
 	});
 });

--- a/src/components/content/tooltip/ndd-tooltip.test.ts
+++ b/src/components/content/tooltip/ndd-tooltip.test.ts
@@ -43,20 +43,22 @@ describe('ndd-tooltip', () => {
 		expect(tooltip?.classList.contains('is-visible')).toBe(false);
 	});
 
-	it('zet aria-describedby op het child element', async () => {
-		el = await fixture<NDDTooltip>(`
-			<ndd-tooltip text="Helptekst">
-				<button>Trigger</button>
-			</ndd-tooltip>
-		`);
-		await waitForUpdate(el);
-		const trigger = el.querySelector('button');
-		expect(trigger?.getAttribute('aria-describedby')).toBe(el._tooltipId);
-	});
-
 	it('standaard placement is top', async () => {
 		el = await fixture<NDDTooltip>('<ndd-tooltip text="Test"></ndd-tooltip>');
 		await waitForUpdate(el);
 		expect(el.placement).toBe('top');
+	});
+
+	it('Escape sluit de tooltip', async () => {
+		el = await fixture<NDDTooltip>('<ndd-tooltip text="Test"><button>Trigger</button></ndd-tooltip>');
+		await waitForUpdate(el);
+
+		el._handleTriggerEnter();
+		await waitForUpdate(el);
+		expect(el._visible).toBe(true);
+
+		el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+		await waitForUpdate(el);
+		expect(el._visible).toBe(false);
 	});
 });

--- a/src/components/content/tooltip/ndd-tooltip.test.ts
+++ b/src/components/content/tooltip/ndd-tooltip.test.ts
@@ -82,7 +82,7 @@ describe('ndd-tooltip – show/hide', () => {
 		trigger.dispatchEvent(new MouseEvent('mouseenter', { bubbles: true }));
 		await waitForUpdate(el);
 		trigger.dispatchEvent(new MouseEvent('mouseleave', { bubbles: true }));
-		await new Promise(resolve => setTimeout(resolve, 150));
+		await new Promise(resolve => setTimeout(resolve, 250));
 
 		expect(isTooltipVisible(el)).toBe(false);
 	});
@@ -98,7 +98,7 @@ describe('ndd-tooltip – show/hide', () => {
 		trigger.dispatchEvent(new MouseEvent('mouseleave', { bubbles: true }));
 		const tooltipEl = el.shadowRoot!.querySelector('.tooltip')!;
 		tooltipEl.dispatchEvent(new MouseEvent('mouseenter', { bubbles: true }));
-		await new Promise(resolve => setTimeout(resolve, 150));
+		await new Promise(resolve => setTimeout(resolve, 250));
 
 		expect(isTooltipVisible(el)).toBe(true);
 	});

--- a/src/components/content/tooltip/ndd-tooltip.ts
+++ b/src/components/content/tooltip/ndd-tooltip.ts
@@ -146,7 +146,7 @@ export class NDDTooltip extends LitElement {
 			placement: this.placement,
 			strategy: 'fixed',
 			middleware: [
-				offset(parseInt(getComputedStyle(this).getPropertyValue('--_offset')) || 6),
+				offset(parseInt(getComputedStyle(this).getPropertyValue('--_offset'))),
 				flip(),
 				shift({ padding: 8 }),
 			],

--- a/src/components/content/tooltip/ndd-tooltip.ts
+++ b/src/components/content/tooltip/ndd-tooltip.ts
@@ -51,6 +51,7 @@ export class NDDTooltip extends LitElement {
 	private _tooltipId = `ndd-tooltip-${++tooltipCounter}`;
 	private _hideTimeout: ReturnType<typeof setTimeout> | null = null;
 	private _descriptionEl: HTMLSpanElement | null = null;
+	private _currentTrigger: Element | null = null;
 	private _boundSlotChange = () => this._syncAriaDescribedBy();
 
 	override connectedCallback(): void {
@@ -77,10 +78,22 @@ export class NDDTooltip extends LitElement {
 
 	private _syncAriaDescribedBy(): void {
 		const trigger = this._getTriggerElement();
+
+		// Clean up previous trigger if it changed
+		if (this._currentTrigger && this._currentTrigger !== trigger) {
+			this._currentTrigger.removeAttribute('aria-describedby');
+		}
+		this._currentTrigger = trigger;
+
 		if (!trigger) return;
 
+		// aria-describedby ID refs are scoped to the element's root.
+		// Only works for triggers in the light DOM (document scope).
+		if (trigger.getRootNode() !== document) {
+			return;
+		}
+
 		if (this.text) {
-			// Create or update a visually-hidden span in document.body for aria-describedby
 			if (!this._descriptionEl) {
 				this._descriptionEl = document.createElement('span');
 				this._descriptionEl.id = this._tooltipId;
@@ -126,7 +139,7 @@ export class NDDTooltip extends LitElement {
 		if (this._hideTimeout) {
 			clearTimeout(this._hideTimeout);
 		}
-		const hideDelay = parseInt(getComputedStyle(this).getPropertyValue('--_hide-delay'), 10) || 50;
+		const hideDelay = parseInt(getComputedStyle(this).getPropertyValue('--_hide-delay'), 10);
 		this._hideTimeout = setTimeout(() => {
 			this._visible = false;
 			this._hideTimeout = null;

--- a/src/components/content/tooltip/ndd-tooltip.ts
+++ b/src/components/content/tooltip/ndd-tooltip.ts
@@ -52,10 +52,11 @@ export class NDDTooltip extends LitElement {
 	override connectedCallback(): void {
 		super.connectedCallback();
 		this.addEventListener('keydown', this._handleKeyDown);
-		this.updateComplete.then(() => {
-			this._syncAriaDescribedBy();
-			this.shadowRoot?.querySelector('slot')?.addEventListener('slotchange', this._boundSlotChange);
-		});
+	}
+
+	override firstUpdated(): void {
+		this._syncAriaDescribedBy();
+		this.shadowRoot?.querySelector('slot')?.addEventListener('slotchange', this._boundSlotChange);
 	}
 
 	override updated(changed: PropertyValues): void {
@@ -142,13 +143,14 @@ export class NDDTooltip extends LitElement {
 		const tooltip = this._getTooltipElement();
 		if (!trigger || !tooltip) return;
 
+		const styles = getComputedStyle(this);
 		const { x, y } = await computePosition(trigger, tooltip, {
 			placement: this.placement,
 			strategy: 'fixed',
 			middleware: [
-				offset(parseInt(getComputedStyle(this).getPropertyValue('--_offset'))),
+				offset(parseInt(styles.getPropertyValue('--_offset'), 10)),
 				flip(),
-				shift({ padding: 8 }),
+				shift({ padding: parseInt(styles.getPropertyValue('--_shift-padding'), 10) }),
 			],
 		});
 

--- a/src/components/content/tooltip/ndd-tooltip.ts
+++ b/src/components/content/tooltip/ndd-tooltip.ts
@@ -18,6 +18,10 @@
  * limitatie van shadow DOM + ARIA. Voor ndd-icon-button is dit niet relevant omdat
  * aria-label al op de interne button staat. Tooltip tekst op icon-button mag daarom
  * geen informatie bevatten die niet al in aria-label zit.
+ *
+ * @note Bij disabled triggers (bijv. disabled ndd-icon-button) wordt de tooltip niet
+ * getoond omdat disabled buttons geen mouseenter/focusin events afvuren en display:
+ * contents geen eigen layout box heeft om events op te vangen.
  */
 
 import { LitElement } from 'lit';
@@ -35,7 +39,7 @@ let tooltipCounter = 0;
 export class NDDTooltip extends LitElement {
 	static override styles = tooltipStyles;
 
-	@property({ type: String })
+	@property({ type: String, reflect: true })
 	text = '';
 
 	@property({ type: String, reflect: true })

--- a/src/components/content/tooltip/ndd-tooltip.ts
+++ b/src/components/content/tooltip/ndd-tooltip.ts
@@ -146,7 +146,7 @@ export class NDDTooltip extends LitElement {
 			placement: this.placement,
 			strategy: 'fixed',
 			middleware: [
-				offset(8),
+				offset(parseInt(getComputedStyle(this).getPropertyValue('--_offset')) || 6),
 				flip(),
 				shift({ padding: 8 }),
 			],

--- a/src/components/content/tooltip/ndd-tooltip.ts
+++ b/src/components/content/tooltip/ndd-tooltip.ts
@@ -10,6 +10,9 @@
  *
  * @slot - Het element waarop de tooltip wordt getoond
  *
+ * @note Gebruikt position: fixed + floating-ui strategy: 'fixed'. Positionering kan
+ * breken wanneer een voorouder-element transform, filter of will-change heeft.
+ *
  * @note aria-describedby werkt alleen wanneer het trigger element in de light DOM staat.
  * Bij web components als trigger (met eigen shadow DOM) is de koppeling een bekende
  * limitatie van shadow DOM + ARIA. Voor ndd-icon-button is dit niet relevant omdat
@@ -44,6 +47,7 @@ export class NDDTooltip extends LitElement {
 	private _hideDelay = 50;
 	private _hideTimeout: ReturnType<typeof setTimeout> | null = null;
 	private _descriptionEl: HTMLSpanElement | null = null;
+	private _boundSlotChange = () => this._syncAriaDescribedBy();
 
 	override connectedCallback(): void {
 		super.connectedCallback();
@@ -52,9 +56,7 @@ export class NDDTooltip extends LitElement {
 
 	override firstUpdated(): void {
 		this._syncAriaDescribedBy();
-		this.shadowRoot?.querySelector('slot')?.addEventListener('slotchange', () => {
-			this._syncAriaDescribedBy();
-		});
+		this.shadowRoot?.querySelector('slot')?.addEventListener('slotchange', this._boundSlotChange);
 	}
 
 	override updated(changed: PropertyValues): void {
@@ -143,6 +145,7 @@ export class NDDTooltip extends LitElement {
 
 		const { x, y } = await computePosition(trigger, tooltip, {
 			placement: this.placement,
+			strategy: 'fixed',
 			middleware: [
 				offset(8),
 				flip(),
@@ -157,11 +160,14 @@ export class NDDTooltip extends LitElement {
 	override disconnectedCallback(): void {
 		super.disconnectedCallback();
 		this.removeEventListener('keydown', this._handleKeyDown);
+		this.shadowRoot?.querySelector('slot')?.removeEventListener('slotchange', this._boundSlotChange);
 		if (this._hideTimeout) {
 			clearTimeout(this._hideTimeout);
 			this._hideTimeout = null;
 		}
-		// Clean up the light DOM description span
+		// Clean up aria-describedby on trigger and remove light DOM description span
+		const trigger = this._getTriggerElement();
+		trigger?.removeAttribute('aria-describedby');
 		this._descriptionEl?.remove();
 		this._descriptionEl = null;
 	}

--- a/src/components/content/tooltip/ndd-tooltip.ts
+++ b/src/components/content/tooltip/ndd-tooltip.ts
@@ -78,7 +78,14 @@ export class NDDTooltip extends LitElement {
 			if (!this._descriptionEl) {
 				this._descriptionEl = document.createElement('span');
 				this._descriptionEl.id = this._tooltipId;
-				this._descriptionEl.hidden = true;
+				Object.assign(this._descriptionEl.style, {
+					position: 'absolute',
+					width: '1px',
+					height: '1px',
+					overflow: 'hidden',
+					clipPath: 'inset(50%)',
+					whiteSpace: 'nowrap',
+				});
 				this.appendChild(this._descriptionEl);
 			}
 			this._descriptionEl.textContent = this.text;
@@ -119,6 +126,13 @@ export class NDDTooltip extends LitElement {
 			this._visible = false;
 			this._hideTimeout = null;
 		}, hideDelay);
+	}
+
+	_handleFocusOut(e: FocusEvent): void {
+		const slot = this.shadowRoot?.querySelector('slot');
+		const assigned = slot?.assignedElements({ flatten: true }) ?? [];
+		const stillInside = assigned.some(el => el.contains(e.relatedTarget as Node));
+		if (!stillInside) this._handleTriggerLeave();
 	}
 
 	_handleTooltipEnter(): void {

--- a/src/components/content/tooltip/ndd-tooltip.ts
+++ b/src/components/content/tooltip/ndd-tooltip.ts
@@ -9,6 +9,11 @@
  * @attr {string} placement - Positie: 'top' | 'bottom' | 'left' | 'right' (standaard: 'top')
  *
  * @slot - Het element waarop de tooltip wordt getoond
+ *
+ * @note aria-describedby werkt alleen wanneer het trigger element in de light DOM staat.
+ * Bij web components als trigger (met eigen shadow DOM) is de koppeling een bekende
+ * limitatie van shadow DOM + ARIA. Voor ndd-icon-button is dit niet relevant omdat
+ * aria-label al op de interne button staat.
  */
 
 import { LitElement } from 'lit';
@@ -47,6 +52,9 @@ export class NDDTooltip extends LitElement {
 
 	override firstUpdated(): void {
 		this._syncAriaDescribedBy();
+		this.shadowRoot?.querySelector('slot')?.addEventListener('slotchange', () => {
+			this._syncAriaDescribedBy();
+		});
 	}
 
 	override updated(changed: PropertyValues): void {

--- a/src/components/content/tooltip/ndd-tooltip.ts
+++ b/src/components/content/tooltip/ndd-tooltip.ts
@@ -1,65 +1,130 @@
-/* eslint-disable lit-a11y/accessible-name -- text content provides the accessible name */
 /**
  * Nederlandse Digitale Dienst Tooltip Component (Lit + TypeScript)
  *
- * A tooltip component that displays informational text.
+ * Wrapper component dat een tooltip toont bij hover of focus op het child element.
+ * Gebruikt `display: contents` zodat het de layout van het child niet beïnvloedt.
  *
  * @element ndd-tooltip
- * @attr {string} text - Tooltip text content
+ * @attr {string} text - Tooltip tekst
+ * @attr {string} placement - Positie: 'top' | 'bottom' | 'left' | 'right' (standaard: 'top')
  *
- * @csspart tooltip - The tooltip container
- * @csspart text - The text content
- *
- * @note This component renders the tooltip visual only. The consumer is responsible
- * for trigger logic (hover/focus), positioning, and show/hide behavior.
+ * @slot - Het element waarop de tooltip wordt getoond
  */
 
-import { LitElement, html, css } from 'lit';
-import { customElement, property } from 'lit/decorators.js';
+import { LitElement } from 'lit';
+import type { PropertyValues } from 'lit';
+import { customElement, property, state } from 'lit/decorators.js';
+import { computePosition, flip, shift, offset } from '@floating-ui/dom';
+import { tooltipStyles } from './ndd-tooltip.styles.ts';
+import { tooltipTemplate } from './ndd-tooltip.template.ts';
+
+type Placement = 'top' | 'bottom' | 'left' | 'right';
+
+let tooltipCounter = 0;
 
 @customElement('ndd-tooltip')
 export class NDDTooltip extends LitElement {
-	static override styles = css`
-		:host {
-			display: inline-flex;
-			font-family: var(--ndd-font-family-body);
-		}
-
-		:host([hidden]) {
-			display: none;
-		}
-
-		.tooltip {
-			display: inline-flex;
-			align-items: center;
-			box-shadow: var(--primitives-box-shadows-level-2);
-		}
-
-		.tooltip__body {
-			background-color: var(--primitives-color-neutral-0);
-			color: var(--semantics-content-color);
-			font: var(--primitives-font-body-xs-regular-tight);
-			padding: var(--primitives-space-4) var(--primitives-space-8);
-			white-space: nowrap;
-		}
-
-		/* Accessibility: High Contrast Mode */
-		@media (forced-colors: active) {
-			.tooltip__body {
-				border: 1px solid CanvasText;
-			}
-		}
-	`;
+	static override styles = tooltipStyles;
 
 	@property({ type: String })
 	text = '';
 
+	@property({ type: String, reflect: true })
+	placement: Placement = 'top';
+
+	@state()
+	_visible = false;
+
+	_tooltipId = `ndd-tooltip-${++tooltipCounter}`;
+
+	private _showDelay = 400;
+	private _hideDelay = 100;
+	private _showTimeout: ReturnType<typeof setTimeout> | null = null;
+	private _hideTimeout: ReturnType<typeof setTimeout> | null = null;
+
+	override updated(changed: PropertyValues): void {
+		if (changed.has('_visible') && this._visible) {
+			this._updatePosition();
+		}
+
+		// Set aria-describedby on the trigger element
+		if (changed.has('_tooltipId') || changed.has('text')) {
+			this._syncAriaDescribedBy();
+		}
+	}
+
+	override firstUpdated(): void {
+		this._syncAriaDescribedBy();
+	}
+
+	private _syncAriaDescribedBy(): void {
+		const trigger = this._getTriggerElement();
+		if (trigger && this.text) {
+			trigger.setAttribute('aria-describedby', this._tooltipId);
+		}
+	}
+
+	private _getTriggerElement(): Element | null {
+		const slot = this.shadowRoot?.querySelector('slot');
+		const assigned = slot?.assignedElements({ flatten: true });
+		return assigned?.[0] ?? null;
+	}
+
+	private _getTooltipElement(): HTMLElement | null {
+		return this.shadowRoot?.querySelector('.tooltip') ?? null;
+	}
+
+	_handleTriggerEnter(): void {
+		if (!this.text) return;
+		this._clearTimeouts();
+		this._showTimeout = setTimeout(() => {
+			this._visible = true;
+		}, this._showDelay);
+	}
+
+	_handleTriggerLeave(): void {
+		this._clearTimeouts();
+		this._hideTimeout = setTimeout(() => {
+			this._visible = false;
+		}, this._hideDelay);
+	}
+
+	private _clearTimeouts(): void {
+		if (this._showTimeout) {
+			clearTimeout(this._showTimeout);
+			this._showTimeout = null;
+		}
+		if (this._hideTimeout) {
+			clearTimeout(this._hideTimeout);
+			this._hideTimeout = null;
+		}
+	}
+
+	private async _updatePosition(): Promise<void> {
+		const trigger = this._getTriggerElement();
+		const tooltip = this._getTooltipElement();
+		if (!trigger || !tooltip) return;
+
+		const { x, y } = await computePosition(trigger, tooltip, {
+			placement: this.placement,
+			middleware: [
+				offset(8),
+				flip(),
+				shift({ padding: 8 }),
+			],
+		});
+
+		tooltip.style.left = `${x}px`;
+		tooltip.style.top = `${y}px`;
+	}
+
+	override disconnectedCallback(): void {
+		super.disconnectedCallback();
+		this._clearTimeouts();
+	}
+
 	override render() {
-		return html`
-			<div class="tooltip" part="tooltip" role="tooltip">
-				<div class="tooltip__body" part="text">${this.text}</div>
-			</div>
-		`;
+		return tooltipTemplate(this);
 	}
 }
 

--- a/src/components/content/tooltip/ndd-tooltip.ts
+++ b/src/components/content/tooltip/ndd-tooltip.ts
@@ -52,6 +52,10 @@ export class NDDTooltip extends LitElement {
 	override connectedCallback(): void {
 		super.connectedCallback();
 		this.addEventListener('keydown', this._handleKeyDown);
+		// Re-register slotchange after reconnect (firstUpdated only runs once)
+		if (this.hasUpdated) {
+			this.shadowRoot?.querySelector('slot')?.addEventListener('slotchange', this._boundSlotChange);
+		}
 	}
 
 	override firstUpdated(): void {

--- a/src/components/content/tooltip/ndd-tooltip.ts
+++ b/src/components/content/tooltip/ndd-tooltip.ts
@@ -149,7 +149,10 @@ export class NDDTooltip extends LitElement {
 	_handleFocusOut(e: FocusEvent): void {
 		const slot = this.shadowRoot?.querySelector('slot');
 		const assigned = slot?.assignedElements({ flatten: true }) ?? [];
-		const stillInside = assigned.some(el => el.contains(e.relatedTarget as Node));
+		const related = e.relatedTarget as Node | null;
+		const stillInside = related && assigned.some(el =>
+			el.contains(related) || (el as HTMLElement).shadowRoot?.contains(related)
+		);
 		if (!stillInside) this._handleTriggerLeave();
 	}
 

--- a/src/components/content/tooltip/ndd-tooltip.ts
+++ b/src/components/content/tooltip/ndd-tooltip.ts
@@ -16,7 +16,8 @@
  * @note aria-describedby werkt alleen wanneer het trigger element in de light DOM staat.
  * Bij web components als trigger (met eigen shadow DOM) is de koppeling een bekende
  * limitatie van shadow DOM + ARIA. Voor ndd-icon-button is dit niet relevant omdat
- * aria-label al op de interne button staat.
+ * aria-label al op de interne button staat. Tooltip tekst op icon-button mag daarom
+ * geen informatie bevatten die niet al in aria-label zit.
  */
 
 import { LitElement } from 'lit';
@@ -54,15 +55,12 @@ export class NDDTooltip extends LitElement {
 	}
 
 	override firstUpdated(): void {
-		this._syncAriaDescribedBy();
 		this.shadowRoot?.querySelector('slot')?.addEventListener('slotchange', this._boundSlotChange);
 	}
 
 	override updated(changed: PropertyValues): void {
-		if (changed.has('_visible')) {
-			if (this._visible) {
-				this._updatePosition();
-			}
+		if (changed.has('_visible') && this._visible) {
+			this._updatePosition();
 		}
 		if (changed.has('text')) {
 			this._syncAriaDescribedBy();
@@ -74,7 +72,7 @@ export class NDDTooltip extends LitElement {
 		if (!trigger) return;
 
 		if (this.text) {
-			// Create or update a hidden span in the light DOM for aria-describedby
+			// Create or update a visually-hidden span in document.body for aria-describedby
 			if (!this._descriptionEl) {
 				this._descriptionEl = document.createElement('span');
 				this._descriptionEl.id = this._tooltipId;
@@ -86,7 +84,7 @@ export class NDDTooltip extends LitElement {
 					clipPath: 'inset(50%)',
 					whiteSpace: 'nowrap',
 				});
-				this.appendChild(this._descriptionEl);
+				document.body.appendChild(this._descriptionEl);
 			}
 			this._descriptionEl.textContent = this.text;
 			trigger.setAttribute('aria-describedby', this._tooltipId);
@@ -100,8 +98,7 @@ export class NDDTooltip extends LitElement {
 	private _getTriggerElement(): Element | null {
 		const slot = this.shadowRoot?.querySelector('slot');
 		const assigned = slot?.assignedElements({ flatten: true });
-		// Skip the hidden description span
-		return assigned?.find(el => el !== this._descriptionEl) ?? null;
+		return assigned?.[0] ?? null;
 	}
 
 	private _getTooltipElement(): HTMLElement | null {
@@ -180,7 +177,7 @@ export class NDDTooltip extends LitElement {
 			clearTimeout(this._hideTimeout);
 			this._hideTimeout = null;
 		}
-		// Clean up aria-describedby on trigger and remove light DOM description span
+		// Clean up aria-describedby on trigger and remove description span from body
 		const trigger = this._getTriggerElement();
 		trigger?.removeAttribute('aria-describedby');
 		this._descriptionEl?.remove();

--- a/src/components/content/tooltip/ndd-tooltip.ts
+++ b/src/components/content/tooltip/ndd-tooltip.ts
@@ -44,7 +44,6 @@ export class NDDTooltip extends LitElement {
 	_visible = false;
 
 	private _tooltipId = `ndd-tooltip-${++tooltipCounter}`;
-	private _hideDelay = 50;
 	private _hideTimeout: ReturnType<typeof setTimeout> | null = null;
 	private _descriptionEl: HTMLSpanElement | null = null;
 	private _boundSlotChange = () => this._syncAriaDescribedBy();
@@ -115,10 +114,11 @@ export class NDDTooltip extends LitElement {
 		if (this._hideTimeout) {
 			clearTimeout(this._hideTimeout);
 		}
+		const hideDelay = parseInt(getComputedStyle(this).getPropertyValue('--_hide-delay'), 10) || 50;
 		this._hideTimeout = setTimeout(() => {
 			this._visible = false;
 			this._hideTimeout = null;
-		}, this._hideDelay);
+		}, hideDelay);
 	}
 
 	_handleTooltipEnter(): void {

--- a/src/components/content/tooltip/ndd-tooltip.ts
+++ b/src/components/content/tooltip/ndd-tooltip.ts
@@ -199,8 +199,8 @@ export class NDDTooltip extends LitElement {
 			this._hideTimeout = null;
 		}
 		// Clean up aria-describedby on trigger and remove description span from body
-		const trigger = this._getTriggerElement();
-		trigger?.removeAttribute('aria-describedby');
+		this._currentTrigger?.removeAttribute('aria-describedby');
+		this._currentTrigger = null;
 		this._descriptionEl?.remove();
 		this._descriptionEl = null;
 	}

--- a/src/components/content/tooltip/ndd-tooltip.ts
+++ b/src/components/content/tooltip/ndd-tooltip.ts
@@ -52,11 +52,10 @@ export class NDDTooltip extends LitElement {
 	override connectedCallback(): void {
 		super.connectedCallback();
 		this.addEventListener('keydown', this._handleKeyDown);
-	}
-
-	override firstUpdated(): void {
-		this._syncAriaDescribedBy();
-		this.shadowRoot?.querySelector('slot')?.addEventListener('slotchange', this._boundSlotChange);
+		this.updateComplete.then(() => {
+			this._syncAriaDescribedBy();
+			this.shadowRoot?.querySelector('slot')?.addEventListener('slotchange', this._boundSlotChange);
+		});
 	}
 
 	override updated(changed: PropertyValues): void {

--- a/src/components/content/tooltip/ndd-tooltip.ts
+++ b/src/components/content/tooltip/ndd-tooltip.ts
@@ -37,9 +37,7 @@ export class NDDTooltip extends LitElement {
 
 	_tooltipId = `ndd-tooltip-${++tooltipCounter}`;
 
-	private _showDelay = 400;
-	private _hideDelay = 100;
-	private _showTimeout: ReturnType<typeof setTimeout> | null = null;
+	private _hideDelay = 50;
 	private _hideTimeout: ReturnType<typeof setTimeout> | null = null;
 
 	override updated(changed: PropertyValues): void {
@@ -76,28 +74,21 @@ export class NDDTooltip extends LitElement {
 
 	_handleTriggerEnter(): void {
 		if (!this.text) return;
-		this._clearTimeouts();
-		this._showTimeout = setTimeout(() => {
-			this._visible = true;
-		}, this._showDelay);
-	}
-
-	_handleTriggerLeave(): void {
-		this._clearTimeouts();
-		this._hideTimeout = setTimeout(() => {
-			this._visible = false;
-		}, this._hideDelay);
-	}
-
-	private _clearTimeouts(): void {
-		if (this._showTimeout) {
-			clearTimeout(this._showTimeout);
-			this._showTimeout = null;
-		}
 		if (this._hideTimeout) {
 			clearTimeout(this._hideTimeout);
 			this._hideTimeout = null;
 		}
+		this._visible = true;
+	}
+
+	_handleTriggerLeave(): void {
+		if (this._hideTimeout) {
+			clearTimeout(this._hideTimeout);
+		}
+		this._hideTimeout = setTimeout(() => {
+			this._visible = false;
+			this._hideTimeout = null;
+		}, this._hideDelay);
 	}
 
 	private async _updatePosition(): Promise<void> {
@@ -120,7 +111,10 @@ export class NDDTooltip extends LitElement {
 
 	override disconnectedCallback(): void {
 		super.disconnectedCallback();
-		this._clearTimeouts();
+		if (this._hideTimeout) {
+			clearTimeout(this._hideTimeout);
+			this._hideTimeout = null;
+		}
 	}
 
 	override render() {

--- a/src/components/content/tooltip/ndd-tooltip.ts
+++ b/src/components/content/tooltip/ndd-tooltip.ts
@@ -48,6 +48,9 @@ export class NDDTooltip extends LitElement {
 	@state()
 	_visible = false;
 
+	@state()
+	_focusVisible = false;
+
 	private _tooltipId = `ndd-tooltip-${++tooltipCounter}`;
 	private _hideTimeout: ReturnType<typeof setTimeout> | null = null;
 	private _descriptionEl: HTMLSpanElement | null = null;
@@ -132,6 +135,17 @@ export class NDDTooltip extends LitElement {
 			clearTimeout(this._hideTimeout);
 			this._hideTimeout = null;
 		}
+		this._focusVisible = false;
+		this._visible = true;
+	}
+
+	_handleFocusIn(): void {
+		if (!this.text) return;
+		if (this._hideTimeout) {
+			clearTimeout(this._hideTimeout);
+			this._hideTimeout = null;
+		}
+		this._focusVisible = true;
 		this._visible = true;
 	}
 
@@ -146,6 +160,7 @@ export class NDDTooltip extends LitElement {
 		}, hideDelay);
 	}
 
+	/** Focus guard checks one shadow root level deep for composite triggers. */
 	_handleFocusOut(e: FocusEvent): void {
 		const slot = this.shadowRoot?.querySelector('slot');
 		const assigned = slot?.assignedElements({ flatten: true }) ?? [];
@@ -170,6 +185,7 @@ export class NDDTooltip extends LitElement {
 	private _handleKeyDown = (e: KeyboardEvent): void => {
 		if (e.key === 'Escape' && this._visible) {
 			this._visible = false;
+			this._focusVisible = false;
 		}
 	};
 

--- a/src/components/content/tooltip/ndd-tooltip.ts
+++ b/src/components/content/tooltip/ndd-tooltip.ts
@@ -20,6 +20,8 @@ import { tooltipTemplate } from './ndd-tooltip.template.ts';
 
 type Placement = 'top' | 'bottom' | 'left' | 'right';
 
+let tooltipCounter = 0;
+
 @customElement('ndd-tooltip')
 export class NDDTooltip extends LitElement {
 	static override styles = tooltipStyles;
@@ -33,25 +35,57 @@ export class NDDTooltip extends LitElement {
 	@state()
 	_visible = false;
 
+	private _tooltipId = `ndd-tooltip-${++tooltipCounter}`;
 	private _hideDelay = 50;
 	private _hideTimeout: ReturnType<typeof setTimeout> | null = null;
-	private _boundHandleKeyDown = this._handleKeyDown.bind(this);
+	private _descriptionEl: HTMLSpanElement | null = null;
 
 	override connectedCallback(): void {
 		super.connectedCallback();
-		this.addEventListener('keydown', this._boundHandleKeyDown);
+		this.addEventListener('keydown', this._handleKeyDown);
+	}
+
+	override firstUpdated(): void {
+		this._syncAriaDescribedBy();
 	}
 
 	override updated(changed: PropertyValues): void {
-		if (changed.has('_visible') && this._visible) {
-			this._updatePosition();
+		if (changed.has('_visible')) {
+			if (this._visible) {
+				this._updatePosition();
+			}
+		}
+		if (changed.has('text')) {
+			this._syncAriaDescribedBy();
+		}
+	}
+
+	private _syncAriaDescribedBy(): void {
+		const trigger = this._getTriggerElement();
+		if (!trigger) return;
+
+		if (this.text) {
+			// Create or update a hidden span in the light DOM for aria-describedby
+			if (!this._descriptionEl) {
+				this._descriptionEl = document.createElement('span');
+				this._descriptionEl.id = this._tooltipId;
+				this._descriptionEl.hidden = true;
+				this.appendChild(this._descriptionEl);
+			}
+			this._descriptionEl.textContent = this.text;
+			trigger.setAttribute('aria-describedby', this._tooltipId);
+		} else {
+			trigger.removeAttribute('aria-describedby');
+			this._descriptionEl?.remove();
+			this._descriptionEl = null;
 		}
 	}
 
 	private _getTriggerElement(): Element | null {
 		const slot = this.shadowRoot?.querySelector('slot');
 		const assigned = slot?.assignedElements({ flatten: true });
-		return assigned?.[0] ?? null;
+		// Skip the hidden description span
+		return assigned?.find(el => el !== this._descriptionEl) ?? null;
 	}
 
 	private _getTooltipElement(): HTMLElement | null {
@@ -88,12 +122,11 @@ export class NDDTooltip extends LitElement {
 		this._handleTriggerLeave();
 	}
 
-	private _handleKeyDown(e: KeyboardEvent): void {
+	private _handleKeyDown = (e: KeyboardEvent): void => {
 		if (e.key === 'Escape' && this._visible) {
 			this._visible = false;
-			e.stopPropagation();
 		}
-	}
+	};
 
 	private async _updatePosition(): Promise<void> {
 		const trigger = this._getTriggerElement();
@@ -115,11 +148,14 @@ export class NDDTooltip extends LitElement {
 
 	override disconnectedCallback(): void {
 		super.disconnectedCallback();
-		this.removeEventListener('keydown', this._boundHandleKeyDown);
+		this.removeEventListener('keydown', this._handleKeyDown);
 		if (this._hideTimeout) {
 			clearTimeout(this._hideTimeout);
 			this._hideTimeout = null;
 		}
+		// Clean up the light DOM description span
+		this._descriptionEl?.remove();
+		this._descriptionEl = null;
 	}
 
 	override render() {

--- a/src/components/content/tooltip/ndd-tooltip.ts
+++ b/src/components/content/tooltip/ndd-tooltip.ts
@@ -20,8 +20,6 @@ import { tooltipTemplate } from './ndd-tooltip.template.ts';
 
 type Placement = 'top' | 'bottom' | 'left' | 'right';
 
-let tooltipCounter = 0;
-
 @customElement('ndd-tooltip')
 export class NDDTooltip extends LitElement {
 	static override styles = tooltipStyles;
@@ -35,30 +33,18 @@ export class NDDTooltip extends LitElement {
 	@state()
 	_visible = false;
 
-	_tooltipId = `ndd-tooltip-${++tooltipCounter}`;
-
 	private _hideDelay = 50;
 	private _hideTimeout: ReturnType<typeof setTimeout> | null = null;
+	private _boundHandleKeyDown = this._handleKeyDown.bind(this);
+
+	override connectedCallback(): void {
+		super.connectedCallback();
+		this.addEventListener('keydown', this._boundHandleKeyDown);
+	}
 
 	override updated(changed: PropertyValues): void {
 		if (changed.has('_visible') && this._visible) {
 			this._updatePosition();
-		}
-
-		// Set aria-describedby on the trigger element
-		if (changed.has('_tooltipId') || changed.has('text')) {
-			this._syncAriaDescribedBy();
-		}
-	}
-
-	override firstUpdated(): void {
-		this._syncAriaDescribedBy();
-	}
-
-	private _syncAriaDescribedBy(): void {
-		const trigger = this._getTriggerElement();
-		if (trigger && this.text) {
-			trigger.setAttribute('aria-describedby', this._tooltipId);
 		}
 	}
 
@@ -91,6 +77,24 @@ export class NDDTooltip extends LitElement {
 		}, this._hideDelay);
 	}
 
+	_handleTooltipEnter(): void {
+		if (this._hideTimeout) {
+			clearTimeout(this._hideTimeout);
+			this._hideTimeout = null;
+		}
+	}
+
+	_handleTooltipLeave(): void {
+		this._handleTriggerLeave();
+	}
+
+	private _handleKeyDown(e: KeyboardEvent): void {
+		if (e.key === 'Escape' && this._visible) {
+			this._visible = false;
+			e.stopPropagation();
+		}
+	}
+
 	private async _updatePosition(): Promise<void> {
 		const trigger = this._getTriggerElement();
 		const tooltip = this._getTooltipElement();
@@ -111,6 +115,7 @@ export class NDDTooltip extends LitElement {
 
 	override disconnectedCallback(): void {
 		super.disconnectedCallback();
+		this.removeEventListener('keydown', this._boundHandleKeyDown);
 		if (this._hideTimeout) {
 			clearTimeout(this._hideTimeout);
 			this._hideTimeout = null;


### PR DESCRIPTION
**Tooltip refactor:**
- Wrapper component met display: contents — wrapt het child element
- floating-ui voor positionering (flip, shift, offset)
- Hover/focus triggers met CSS animation-delay (400ms show, 50ms fade)
- aria-describedby automatisch op het child element
- Placement attribuut: top, bottom, left, right
- Split structuur: .ts, .styles.ts, .template.ts

**Icon-button integratie:**
- Native title attribuut vervangen door ndd-tooltip
- xs/sm/md: tooltip toont text (of accessible-label indien gezet)
- lg: tooltip alleen bij accessible-label (tekst is al zichtbaar)

## Breaking changes

- ndd-tooltip is nu een wrapper component, niet een standalone visueel element
- icon-button gebruikt ndd-tooltip in plaats van native title

## Test plan

- npm run build slaagt
- Alle 909 tests slagen
- Storybook: tooltip verschijnt bij hover/focus op button
- Tooltip positioneert correct (top, bottom, left, right)
- Icon-button: tooltip in plaats van native title
- Icon-button lg: geen tooltip tenzij accessible-label gezet