### PR TITLE
Chore/component housekeeping

### DIFF
--- a/src/assets/styles/settings.css
+++ b/src/assets/styles/settings.css
@@ -833,6 +833,7 @@
 	--components-list-item-is-dragging-opacity: var(--primitives-opacity-dragging);
 
 
+	--components-menu-box-shadow: var(--primitives-box-shadows-level-5);
 	--components-menu-item-is-highlighted-background-color: light-dark(var(--primitives-color-accent-750), var(--primitives-color-accent-650));
 	--components-menu-item-is-highlighted-content-color: light-dark(var(--primitives-color-accent-0), var(--primitives-color-accent-0));
 

--- a/src/components/actions/button/ndd-button.styles.ts
+++ b/src/components/actions/button/ndd-button.styles.ts
@@ -5,6 +5,7 @@ export const styles = css`
 
 	:host {
 		display: inline-block;
+		-webkit-tap-highlight-color: transparent;
 	}
 
 	:host([full-width]) {

--- a/src/components/actions/icon-button/ndd-icon-button.styles.ts
+++ b/src/components/actions/icon-button/ndd-icon-button.styles.ts
@@ -5,6 +5,7 @@ export const styles = css`
 
 	:host {
 		display: inline-block;
+		-webkit-tap-highlight-color: transparent;
 	}
 
 	:host([hidden]) {

--- a/src/components/actions/split-button/ndd-split-button.styles.ts
+++ b/src/components/actions/split-button/ndd-split-button.styles.ts
@@ -5,6 +5,7 @@ export const styles = css`
 
 	:host {
 		display: inline-flex;
+		-webkit-tap-highlight-color: transparent;
 	}
 
 	:host([hidden]) {

--- a/src/components/content/tooltip/ndd-tooltip.test.ts
+++ b/src/components/content/tooltip/ndd-tooltip.test.ts
@@ -41,10 +41,10 @@ describe('ndd-tooltip', () => {
 		expect(isTooltipVisible(el)).toBe(false);
 	});
 
-	it('standaard placement is top', async () => {
+	it('standaard placement is bottom', async () => {
 		el = await fixture<NDDTooltip>('<ndd-tooltip text="Test"></ndd-tooltip>');
 		await waitForUpdate(el);
-		expect(el.placement).toBe('top');
+		expect(el.placement).toBe('bottom');
 	});
 });
 

--- a/src/components/content/tooltip/ndd-tooltip.ts
+++ b/src/components/content/tooltip/ndd-tooltip.ts
@@ -6,7 +6,7 @@
  *
  * @element ndd-tooltip
  * @attr {string} text - Tooltip tekst
- * @attr {string} placement - Positie: 'top' | 'bottom' | 'left' | 'right' (standaard: 'top')
+ * @attr {string} placement - Positie: 'top' | 'bottom' | 'left' | 'right' (standaard: 'bottom'; op touch devices automatisch 'top')
  *
  * @slot - Het element waarop de tooltip wordt getoond
  *
@@ -43,7 +43,13 @@ export class NDDTooltip extends LitElement {
 	text = '';
 
 	@property({ type: String, reflect: true })
-	placement: Placement = 'top';
+	placement: Placement = 'bottom';
+
+	private get _effectivePlacement(): Placement {
+		if (this._focusVisible) return this.placement;
+		const isTouch = matchMedia('(pointer: coarse)').matches;
+		return isTouch ? 'top' : this.placement;
+	}
 
 	@state()
 	_visible = false;
@@ -196,7 +202,7 @@ export class NDDTooltip extends LitElement {
 
 		const styles = getComputedStyle(this);
 		const { x, y } = await computePosition(trigger, tooltip, {
-			placement: this.placement,
+			placement: this._effectivePlacement,
 			strategy: 'fixed',
 			middleware: [
 				offset(parseInt(styles.getPropertyValue('--_offset'), 10)),

--- a/src/components/content/tooltip/ndd-tooltip.ts
+++ b/src/components/content/tooltip/ndd-tooltip.ts
@@ -34,6 +34,7 @@ import { tooltipTemplate } from './ndd-tooltip.template.ts';
 type Placement = 'top' | 'bottom' | 'left' | 'right';
 
 let tooltipCounter = 0;
+const coarsePointerQuery = matchMedia('(pointer: coarse)');
 
 @customElement('ndd-tooltip')
 export class NDDTooltip extends LitElement {
@@ -47,8 +48,7 @@ export class NDDTooltip extends LitElement {
 
 	private get _effectivePlacement(): Placement {
 		if (this._focusVisible) return this.placement;
-		const isTouch = matchMedia('(pointer: coarse)').matches;
-		return isTouch ? 'top' : this.placement;
+		return coarsePointerQuery.matches ? 'top' : this.placement;
 	}
 
 	@state()

--- a/src/components/inputs/checkbox/ndd-checkbox.styles.ts
+++ b/src/components/inputs/checkbox/ndd-checkbox.styles.ts
@@ -11,6 +11,7 @@ export const checkboxStyles = css`
 		position: relative;
 		width: var(--semantics-controls-xs-min-size);
 		height: var(--semantics-controls-xs-min-size);
+		-webkit-tap-highlight-color: transparent;
 	}
 
 	:host([hidden]) {

--- a/src/components/inputs/combo-box/ndd-combo-box.styles.ts
+++ b/src/components/inputs/combo-box/ndd-combo-box.styles.ts
@@ -7,6 +7,7 @@ export const comboBoxStyles = css`
 
 	:host {
 		display: block;
+		-webkit-tap-highlight-color: transparent;
 	}
 
 	:host([hidden]) {

--- a/src/components/inputs/combo-box/ndd-combo-box.ts
+++ b/src/components/inputs/combo-box/ndd-combo-box.ts
@@ -4,7 +4,7 @@
  * A text input with autocomplete dropdown via ndd-menu.
  * Add a slotted ndd-menu with ndd-menu-item children to provide options.
  *
- * The component automatically sets no-auto-focus on the slotted ndd-menu
+ * The slotted ndd-menu keeps its default focus behavior (menu container receives focus)
  * so that typing keeps focus on the input. The picker button moves focus
  * to the menu explicitly on activation.
  *
@@ -155,9 +155,7 @@ export class NDDComboBox extends LitElement {
 		menu.placement = 'bottom-start';
 		menu.maxItems = this.maxItems;
 		menu.variant = 'listbox';
-		// Always prevent auto-focus so typing keeps focus on the input.
-		// The picker button moves focus explicitly when activated.
-		menu.noAutoFocus = true;
+		// Focus stays on the input — default menu behavior (no auto-focus-item).
 		menu.addEventListener('toggle', this._handleMenuToggle);
 		menu.addEventListener('select', this._handleMenuSelect);
 		menu.addEventListener('keydown', this._handleMenuKeydown);
@@ -222,7 +220,6 @@ export class NDDComboBox extends LitElement {
 			return;
 		}
 		this._updateMenuWidth();
-		this._menu.noAutoFocus = true;
 		(this._menu as HTMLElement).showPopover();
 	}
 

--- a/src/components/inputs/dropdown/ndd-dropdown.styles.ts
+++ b/src/components/inputs/dropdown/ndd-dropdown.styles.ts
@@ -7,6 +7,7 @@ export const dropdownStyles = css`
 		display: block;
 		--_md-icon-size: var(--primitives-space-24);
 		--_sm-icon-size: var(--primitives-space-20);
+		-webkit-tap-highlight-color: transparent;
 	}
 
 	:host([hidden]) {

--- a/src/components/inputs/number-field/ndd-number-field.styles.ts
+++ b/src/components/inputs/number-field/ndd-number-field.styles.ts
@@ -8,6 +8,7 @@ export const numberFieldStyles = css`
 	:host {
 		display: inline-block;
 		--_width: auto;
+		-webkit-tap-highlight-color: transparent;
 	}
 
 	:host([hidden]) {

--- a/src/components/inputs/password-field/ndd-password-field.styles.ts
+++ b/src/components/inputs/password-field/ndd-password-field.styles.ts
@@ -8,6 +8,7 @@ export const passwordFieldStyles = css`
 	:host {
 		display: block;
 		--_background-color: var(--semantics-input-fields-background-color);
+		-webkit-tap-highlight-color: transparent;
 	}
 
 	:host([hidden]) {

--- a/src/components/inputs/radio-button/ndd-radio-button.styles.ts
+++ b/src/components/inputs/radio-button/ndd-radio-button.styles.ts
@@ -11,6 +11,7 @@ export const radioButtonStyles = css`
 		position: relative;
 		width: var(--semantics-controls-xs-min-size);
 		height: var(--semantics-controls-xs-min-size);
+		-webkit-tap-highlight-color: transparent;
 	}
 
 	:host([hidden]) {

--- a/src/components/inputs/search-field/ndd-search-field.styles.ts
+++ b/src/components/inputs/search-field/ndd-search-field.styles.ts
@@ -6,6 +6,7 @@ export const searchFieldStyles = css`
 	:host {
 		display: block;
 		--_background-color: var(--semantics-input-fields-background-color);
+		-webkit-tap-highlight-color: transparent;
 	}
 
 	:host([hidden]) {

--- a/src/components/inputs/segmented-control/ndd-segmented-control.styles.ts
+++ b/src/components/inputs/segmented-control/ndd-segmented-control.styles.ts
@@ -8,6 +8,7 @@ export const segmentedControlStyles = css`
 		grid-auto-columns: 1fr;
 		grid-auto-flow: column;
 		background-color: var(--semantics-buttons-neutral-tinted-background-color);
+		-webkit-tap-highlight-color: transparent;
 	}
 
 	:host([hidden]) {
@@ -57,6 +58,7 @@ export const segmentedControlItemStyles = css`
 		--_segmented-control-sm-inset-size: var(--primitives-space-3);
 		--_segmented-control-sm-gap-size: var(--primitives-space-2);
 		--_segmented-control-sm-item-icon-size: var(--primitives-space-20);
+		-webkit-tap-highlight-color: transparent;
 	}
 
 	:host([hidden]) {

--- a/src/components/inputs/segmented-control/ndd-segmented-control.styles.ts
+++ b/src/components/inputs/segmented-control/ndd-segmented-control.styles.ts
@@ -174,38 +174,39 @@ export const segmentedControlItemStyles = css`
 
 	/* # Indicator */
 
-	.segmented-control__item-indicator {
+	.segmented-control__item-label::before {
+		content: '';
 		position: absolute;
 		inset: 0;
 		pointer-events: none;
 		background-color: transparent;
 	}
 
-	:host([size='md']) .segmented-control__item-indicator,
-	:host(:not([size])) .segmented-control__item-indicator {
+	:host([size='md']) .segmented-control__item-label::before,
+	:host(:not([size])) .segmented-control__item-label::before {
 		inset-block: var(--_segmented-control-md-inset-size);
 		inset-inline: calc(var(--_segmented-control-md-gap-size) / 2);
 		border-radius: calc(var(--semantics-controls-md-corner-radius) - (var(--_segmented-control-md-inset-size) / 2));
 	}
 
-	:host([size='sm']) .segmented-control__item-indicator {
+	:host([size='sm']) .segmented-control__item-label::before {
 		inset-block: var(--_segmented-control-sm-inset-size);
 		inset-inline: calc(var(--_segmented-control-sm-gap-size) / 2);
 		border-radius: calc(var(--semantics-controls-sm-corner-radius) - (var(--_segmented-control-sm-inset-size) / 2));
 	}
 
-	:host([selected]) .segmented-control__item-indicator {
+	:host([selected]) .segmented-control__item-label::before {
 		background-color: var(--semantics-buttons-neutral-tinted-is-selected-background-color);
 	}
 
-	:host(:not([selected])) .segmented-control__item-input:hover ~ .segmented-control__item-indicator {
+	:host(:not([selected])) .segmented-control__item-label:hover::before {
 		background-color: var(--semantics-buttons-neutral-tinted-is-hovered-background-color);
 	}
 
 
 	/* # Focus */
 
-	.segmented-control__item-input:focus-visible ~ .segmented-control__item-indicator {
+	.segmented-control__item-label:has(:focus-visible)::before {
 		box-shadow: 0 0 0 var(--semantics-focus-ring-center-thickness) var(--semantics-focus-ring-center-color);
 		outline: var(--semantics-focus-ring-edge-thickness) double var(--semantics-focus-ring-edge-color);
 	}

--- a/src/components/inputs/segmented-control/ndd-segmented-control.template.ts
+++ b/src/components/inputs/segmented-control/ndd-segmented-control.template.ts
@@ -1,5 +1,6 @@
 import { html, nothing, TemplateResult } from 'lit';
 import type { NDDSegmentedControl, NDDSegmentedControlItem } from './ndd-segmented-control.js';
+import '../../content/tooltip/ndd-tooltip.js';
 
 export function segmentedControlTemplate(component: NDDSegmentedControl): TemplateResult {
 	return html`<slot @slotchange=${component._onSlotChange}></slot>`;
@@ -9,10 +10,8 @@ export function segmentedControlItemTemplate(component: NDDSegmentedControlItem)
 	const isIcon = component.variant === 'icon';
 	const labelText = component.text || nothing;
 
-	return html`
-		<label class="segmented-control__item-label"
-			title=${isIcon ? labelText : nothing}
-		>
+	const label = html`
+		<label class="segmented-control__item-label">
 			<input class="segmented-control__item-input"
 				type=${component.inputType}
 				name=${component.groupName || nothing}
@@ -34,6 +33,10 @@ export function segmentedControlItemTemplate(component: NDDSegmentedControlItem)
 			>
 				${component.text}
 			</span>
-		</label>
-	`;
+		</label>`;
+
+	if (isIcon && labelText) {
+		return html`<ndd-tooltip text=${labelText}>${label}</ndd-tooltip>`;
+	}
+	return label;
 }

--- a/src/components/inputs/segmented-control/ndd-segmented-control.template.ts
+++ b/src/components/inputs/segmented-control/ndd-segmented-control.template.ts
@@ -34,7 +34,6 @@ export function segmentedControlItemTemplate(component: NDDSegmentedControlItem)
 			>
 				${component.text}
 			</span>
-			<div class="segmented-control__item-indicator"></div>
 		</label>
 	`;
 }

--- a/src/components/inputs/segmented-control/ndd-segmented-control.test.ts
+++ b/src/components/inputs/segmented-control/ndd-segmented-control.test.ts
@@ -400,3 +400,34 @@ describe('ndd-segmented-control – accessibility', () => {
 		expect(el.getAttribute('aria-label')).toBe('Weergave');
 	});
 });
+
+
+/* ============================================================
+   Tooltip
+   ============================================================ */
+
+describe('ndd-segmented-control-item – tooltip', () => {
+	let el: NDDSegmentedControlItem;
+
+	afterEach(() => {
+		if (el) cleanup(el);
+	});
+
+	it('wraps in ndd-tooltip when variant is icon', async () => {
+		el = await fixture<NDDSegmentedControlItem>(`
+			<ndd-segmented-control-item variant="icon" text="Zoom in" icon="zoom-in"></ndd-segmented-control-item>
+		`);
+		await waitForUpdate(el);
+		const tooltip = el.shadowRoot!.querySelector('ndd-tooltip');
+		expect(tooltip).not.toBeNull();
+		expect(tooltip!.getAttribute('text')).toBe('Zoom in');
+	});
+
+	it('does not wrap in ndd-tooltip when variant is text', async () => {
+		el = await fixture<NDDSegmentedControlItem>(`
+			<ndd-segmented-control-item variant="text" text="Label"></ndd-segmented-control-item>
+		`);
+		await waitForUpdate(el);
+		expect(el.shadowRoot!.querySelector('ndd-tooltip')).toBeNull();
+	});
+});

--- a/src/components/inputs/stepper/ndd-stepper.styles.ts
+++ b/src/components/inputs/stepper/ndd-stepper.styles.ts
@@ -5,6 +5,7 @@ export const stepperStyles = css`
 
 	:host {
 		display: inline-flex;
+		-webkit-tap-highlight-color: transparent;
 	}
 
 	:host([hidden]) {

--- a/src/components/inputs/switch/ndd-switch.styles.ts
+++ b/src/components/inputs/switch/ndd-switch.styles.ts
@@ -15,6 +15,7 @@ export const switchStyles = css`
 		--_switch-xs-thumb-size: calc(var(--_switch-xs-height) - var(--_switch-padding) * 2 - var(--components-switch-thumb-border-thickness) * 2);
 		--_switch-sm-thumb-size: calc(var(--_switch-sm-height) - var(--_switch-padding) * 2 - var(--components-switch-thumb-border-thickness) * 2);
 		--_transition-duration: 150ms;
+		-webkit-tap-highlight-color: transparent;
 	}
 
 	:host([hidden]) {

--- a/src/components/inputs/text-field/ndd-text-field.styles.ts
+++ b/src/components/inputs/text-field/ndd-text-field.styles.ts
@@ -7,6 +7,7 @@ export const textFieldStyles = css`
 	:host {
 		display: block;
 		--_background-color: var(--semantics-input-fields-background-color);
+		-webkit-tap-highlight-color: transparent;
 	}
 
 	:host([hidden]) {

--- a/src/components/inputs/toggle-button/ndd-toggle-button.styles.ts
+++ b/src/components/inputs/toggle-button/ndd-toggle-button.styles.ts
@@ -7,6 +7,7 @@ export const toggleButtonStyles = css`
 
 	:host {
 		display: inline-block;
+		-webkit-tap-highlight-color: transparent;
 	}
 
 	:host([hidden]) {

--- a/src/components/inputs/toggle-button/ndd-toggle-button.template.ts
+++ b/src/components/inputs/toggle-button/ndd-toggle-button.template.ts
@@ -1,9 +1,12 @@
 import { html, nothing, TemplateResult } from 'lit';
 import type { NDDToggleButton } from './ndd-toggle-button.js';
+import '../../content/tooltip/ndd-tooltip.js';
 
 
 export function toggleButtonTemplate(component: NDDToggleButton): TemplateResult {
 	const label = component.accessibleLabel || nothing;
+	const iconOnly = !!component.icon && !component.text;
+	const tooltipText = iconOnly ? (component.accessibleLabel || component.text) : '';
 
 	const icon = component.icon
 		? html`<ndd-icon class="toggle-button__icon" name=${component.icon}></ndd-icon>`
@@ -13,8 +16,10 @@ export function toggleButtonTemplate(component: NDDToggleButton): TemplateResult
 		? html`<span class="toggle-button__text">${component.text}</span>`
 		: nothing;
 
+	let result: TemplateResult;
+
 	if (component.type === 'checkbox' || component.type === 'radio') {
-		return html`
+		result = html`
 			<label class="toggle-button">
 				<input
 					class="toggle-button__input"
@@ -30,19 +35,24 @@ export function toggleButtonTemplate(component: NDDToggleButton): TemplateResult
 				${textContent}
 			</label>
 		`;
+	} else {
+		result = html`
+			<button
+				class="toggle-button"
+				type="button"
+				aria-pressed=${component.selected}
+				?disabled=${component.disabled}
+				aria-label=${label}
+				@click=${component._handleButtonClick}
+			>
+				${icon}
+				${textContent}
+			</button>
+		`;
 	}
 
-	return html`
-		<button
-			class="toggle-button"
-			type="button"
-			aria-pressed=${component.selected}
-			?disabled=${component.disabled}
-			aria-label=${label}
-			@click=${component._handleButtonClick}
-		>
-			${icon}
-			${textContent}
-		</button>
-	`;
+	if (tooltipText) {
+		return html`<ndd-tooltip text=${tooltipText}>${result}</ndd-tooltip>`;
+	}
+	return result;
 }

--- a/src/components/inputs/toggle-button/ndd-toggle-button.test.ts
+++ b/src/components/inputs/toggle-button/ndd-toggle-button.test.ts
@@ -382,3 +382,30 @@ describe('ndd-toggle-button – accessibility', () => {
 		expect(button.hasAttribute('aria-label')).toBe(false);
 	});
 });
+
+
+/* ============================================================
+   Tooltip
+   ============================================================ */
+
+describe('ndd-toggle-button – tooltip', () => {
+	let el: NDDToggleButton;
+
+	afterEach(() => {
+		if (el) cleanup(el);
+	});
+
+	it('wraps in ndd-tooltip when icon-only', async () => {
+		el = await fixture<NDDToggleButton>('<ndd-toggle-button icon="star" accessible-label="Favoriet"></ndd-toggle-button>');
+		await waitForUpdate(el);
+		const tooltip = el.shadowRoot!.querySelector('ndd-tooltip');
+		expect(tooltip).not.toBeNull();
+		expect(tooltip!.getAttribute('text')).toBe('Favoriet');
+	});
+
+	it('does not wrap in ndd-tooltip when text is present', async () => {
+		el = await fixture<NDDToggleButton>('<ndd-toggle-button icon="star" text="Favoriet"></ndd-toggle-button>');
+		await waitForUpdate(el);
+		expect(el.shadowRoot!.querySelector('ndd-tooltip')).toBeNull();
+	});
+});

--- a/src/components/inputs/token/ndd-token.styles.ts
+++ b/src/components/inputs/token/ndd-token.styles.ts
@@ -7,6 +7,7 @@ export const tokenStyles = css`
 
 	:host {
 		display: inline-block;
+		-webkit-tap-highlight-color: transparent;
 	}
 
 	:host([hidden]) {

--- a/src/components/layout/sheet/ndd-sheet.styles.ts
+++ b/src/components/layout/sheet/ndd-sheet.styles.ts
@@ -71,6 +71,10 @@ export const sheetStyles = css`
 	}
 
 	.sheet:focus-visible {
+		outline: none;
+	}
+
+	.sheet.is-keyboard-focus:focus {
 		box-shadow: 0 0 0 var(--semantics-focus-ring-center-thickness) var(--semantics-focus-ring-center-color), var(--components-sheet-box-shadow);
 		outline: var(--semantics-focus-ring-edge-thickness) double var(--semantics-focus-ring-edge-color);
 	}

--- a/src/components/layout/sheet/ndd-sheet.test.ts
+++ b/src/components/layout/sheet/ndd-sheet.test.ts
@@ -271,65 +271,27 @@ describe('ndd-sheet – focus management', () => {
 		}
 	});
 
-	it('focuses the first heading in light DOM when show() is called', async () => {
+	it('focuses the dialog when show() is called', async () => {
 		el = await fixture<NDDSheet>(`
 			<ndd-sheet>
-				<h2 id="heading">Sheet titel</h2>
-			</ndd-sheet>
-		`);
-		await waitForUpdate(el);
-		el.show();
-		const heading = el.querySelector<HTMLElement>('#heading')!;
-		expect(document.activeElement === heading || el.shadowRoot!.activeElement === heading).toBe(true);
-	});
-
-	it('adds tabindex="-1" to heading on show() when not already set', async () => {
-		el = await fixture<NDDSheet>(`
-			<ndd-sheet>
-				<h2 id="heading">Sheet titel</h2>
-			</ndd-sheet>
-		`);
-		await waitForUpdate(el);
-		el.show();
-		const heading = el.querySelector<HTMLElement>('#heading')!;
-		expect(heading.getAttribute('tabindex')).toBe('-1');
-	});
-
-	it('removes tabindex from heading on blur when it was added by show()', async () => {
-		el = await fixture<NDDSheet>(`
-			<ndd-sheet>
-				<h2 id="heading">Sheet titel</h2>
-			</ndd-sheet>
-		`);
-		await waitForUpdate(el);
-		el.show();
-		const heading = el.querySelector<HTMLElement>('#heading')!;
-		heading.dispatchEvent(new Event('blur'));
-		expect(heading.hasAttribute('tabindex')).toBe(false);
-	});
-
-	it('preserves pre-existing tabindex on heading after blur', async () => {
-		el = await fixture<NDDSheet>(`
-			<ndd-sheet>
-				<h2 id="heading" tabindex="0">Sheet titel</h2>
-			</ndd-sheet>
-		`);
-		await waitForUpdate(el);
-		el.show();
-		const heading = el.querySelector<HTMLElement>('#heading')!;
-		heading.dispatchEvent(new Event('blur'));
-		expect(heading.getAttribute('tabindex')).toBe('0');
-	});
-
-	it('falls back to focusing the dialog when no heading is present', async () => {
-		el = await fixture<NDDSheet>(`
-			<ndd-sheet>
-				<p>Geen heading</p>
+				<h2>Sheet titel</h2>
 			</ndd-sheet>
 		`);
 		await waitForUpdate(el);
 		el.show();
 		const dialog = el.shadowRoot!.querySelector('dialog')!;
 		expect(document.activeElement === dialog || el.shadowRoot!.activeElement === dialog).toBe(true);
+	});
+
+	it('respects autofocus attribute on slotted content', async () => {
+		el = await fixture<NDDSheet>(`
+			<ndd-sheet>
+				<button autofocus>Focus me</button>
+			</ndd-sheet>
+		`);
+		await waitForUpdate(el);
+		el.show();
+		const button = el.querySelector<HTMLElement>('button')!;
+		expect(document.activeElement === button).toBe(true);
 	});
 });

--- a/src/components/layout/sheet/ndd-sheet.ts
+++ b/src/components/layout/sheet/ndd-sheet.ts
@@ -27,6 +27,7 @@ import { LitElement } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { sheetStyles } from './ndd-sheet.styles.ts';
 import { sheetTemplate } from './ndd-sheet.template.ts';
+import { isKeyboardMode } from '../../../utilities/keyboard-mode.js';
 
 type Placement = 'left' | 'right' | 'bottom';
 
@@ -86,30 +87,11 @@ export class NDDSheet extends LitElement {
 		// 1. autofocus element present — let the browser handle it natively
 		if (this.querySelector('[autofocus]')) return;
 
-		// 2. Focus the first heading — check shadow roots of known components first,
-		// then fall back to light DOM headings
-		const heading = (
-			this.querySelector('ndd-top-title-bar')?.shadowRoot?.querySelector('h1, h2, h3, h4, h5, h6') as HTMLElement | null
-		) ?? (
-			this.querySelector('h1, h2, h3, h4, h5, h6') as HTMLElement | null
-		);
-
-		if (heading) {
-			// Only add tabindex if the consumer hasn't already set one
-			const hadTabindex = heading.hasAttribute('tabindex');
-			if (!hadTabindex) heading.setAttribute('tabindex', '-1');
-			heading.focus();
-			// Only remove tabindex on blur if we added it ourselves
-			if (!hadTabindex) {
-				heading.addEventListener('blur', () => {
-					heading.removeAttribute('tabindex');
-				}, { once: true });
-			}
-			return;
-		}
-
-		// 3. Fallback — focus the dialog itself
-		this._dialog?.focus();
+		// 2. Focus the dialog — show focus ring only when opened via keyboard
+		const dialog = this._dialog;
+		if (!dialog) return;
+		dialog.classList.toggle('is-keyboard-focus', isKeyboardMode());
+		dialog.focus();
 	}
 
 	hide(): void {

--- a/src/components/lists-and-menus/list-item/ndd-list-item.styles.ts
+++ b/src/components/lists-and-menus/list-item/ndd-list-item.styles.ts
@@ -8,6 +8,7 @@ export const styles = css`
 		width: 100%;
 		--_z-index-content: 1;
 		--_z-index-indicator: calc(var(--_z-index-content) - 1);
+		-webkit-tap-highlight-color: transparent;
 	}
 
 	:host([hidden]) {

--- a/src/components/lists-and-menus/list-item/ndd-list-item.styles.ts
+++ b/src/components/lists-and-menus/list-item/ndd-list-item.styles.ts
@@ -144,6 +144,7 @@ export const styles = css`
 	/* # Divider */
 
 	.list-item__divider {
+		display: var(--context-list-divider-display, block);
 		position: absolute;
 		inset-block-end: 0;
 		inset-inline: 0;

--- a/src/components/lists-and-menus/list-item/ndd-list-item.styles.ts
+++ b/src/components/lists-and-menus/list-item/ndd-list-item.styles.ts
@@ -158,7 +158,8 @@ export const styles = css`
 
 	/* # Indicator */
 
-	.list-item__indicator {
+	.list-item::before {
+		content: '';
 		display: none;
 		position: absolute;
 		inset-block: 0;
@@ -167,17 +168,17 @@ export const styles = css`
 		z-index: var(--_z-index-indicator);
 	}
 
-	:host([selected]) .list-item__indicator {
+	:host([selected]) .list-item::before {
 		display: block;
 		background-color: var(--components-list-item-is-selected-background-color);
 	}
 
-	.list-item__action:hover .list-item__indicator {
+	.list-item:has(.list-item__action:hover)::before {
 		display: block;
 		background-color: var(--components-list-item-is-hovered-background-color);
 	}
 
-	:host([selected]) .list-item__action:hover .list-item__indicator {
+	:host([selected]) .list-item:has(.list-item__action:hover)::before {
 		background-color: var(--components-list-item-is-selected-background-color);
 	}
 `;

--- a/src/components/lists-and-menus/list-item/ndd-list-item.template.ts
+++ b/src/components/lists-and-menus/list-item/ndd-list-item.template.ts
@@ -3,7 +3,6 @@ import { ifDefined } from 'lit/directives/if-defined.js';
 import { classMap } from 'lit/directives/class-map.js';
 
 const areas = (showStart: boolean, showEnd: boolean) => html`
-	<div class="list-item__indicator"></div>
 	<div class=${classMap({ 'list-item__start-area': true, 'is-visible': showStart })}>
 		<slot name="start">
 			<ndd-spacer-cell size="12"></ndd-spacer-cell>

--- a/src/components/lists-and-menus/list/ndd-list.stories.js
+++ b/src/components/lists-and-menus/list/ndd-list.stories.js
@@ -19,15 +19,21 @@ export default {
 			description: 'Visual style of the list',
 			table: { defaultValue: { summary: 'simple' } },
 		},
+		'no-dividers': {
+			control: 'boolean',
+			description: 'Hides dividers between list items',
+			table: { type: { summary: 'boolean' }, defaultValue: { summary: 'false' } },
+		},
 	},
 };
 
 export const Default = {
 	args: {
 		variant: 'simple',
+		'no-dividers': false,
 	},
 	render: (args) => html`
-		<ndd-list variant=${args.variant}>
+		<ndd-list variant=${args.variant} ?no-dividers=${args['no-dividers']}>
 			<ndd-list-item>
 				<ndd-text-cell text="Item 1" />
 			</ndd-list-item>

--- a/src/components/lists-and-menus/list/ndd-list.styles.ts
+++ b/src/components/lists-and-menus/list/ndd-list.styles.ts
@@ -40,10 +40,21 @@ export const styles = css`
 	}
 
 
+	/* # No dividers */
+
+	:host([no-dividers]) {
+		--context-list-divider-display: none;
+	}
+
+
 	/* # Variant: simple */
 
 	:host([variant='simple']) .list__items {
 		border-top: var(--semantics-dividers-thickness) solid var(--semantics-dividers-color);
+	}
+
+	:host([variant='simple'][no-dividers]) .list__items {
+		border-top: none;
 	}
 
 

--- a/src/components/lists-and-menus/list/ndd-list.test.ts
+++ b/src/components/lists-and-menus/list/ndd-list.test.ts
@@ -39,6 +39,18 @@ describe('ndd-list', () => {
 		expect(header?.textContent).toBe('Header content');
 	});
 
+	it('reflects no-dividers attribute', async () => {
+		el = await fixture('<ndd-list no-dividers></ndd-list>');
+		await waitForUpdate(el);
+		expect(el.hasAttribute('no-dividers')).toBe(true);
+	});
+
+	it('sets --context-list-divider-display when no-dividers is set', async () => {
+		el = await fixture('<ndd-list no-dividers></ndd-list>');
+		await waitForUpdate(el);
+		expect(getComputedStyle(el).getPropertyValue('--context-list-divider-display').trim()).toBe('none');
+	});
+
 	it('renders footer slot', async () => {
 		el = await fixture(`
 			<ndd-list>

--- a/src/components/lists-and-menus/list/ndd-list.ts
+++ b/src/components/lists-and-menus/list/ndd-list.ts
@@ -35,6 +35,10 @@ export class NDDList extends LitElement {
 	@property({ type: Boolean, reflect: true })
 	reorderable = false;
 
+	/** Hides dividers between list items. */
+	@property({ type: Boolean, reflect: true, attribute: 'no-dividers' })
+	noDividers = false;
+
 	/** Override one or more translation keys. Unset keys fall back to the Dutch default. */
 	@property({ type: Object })
 	translations: Partial<NDDListTranslations> = {};

--- a/src/components/lists-and-menus/menu/ndd-menu.styles.ts
+++ b/src/components/lists-and-menus/menu/ndd-menu.styles.ts
@@ -51,6 +51,11 @@ export const menuStyles = css`
 		outline: none;
 	}
 
+	.menu.is-keyboard-focus:focus {
+		box-shadow: 0 0 0 var(--semantics-focus-ring-center-thickness) var(--semantics-focus-ring-center-color), var(--components-menu-box-shadow);
+		outline: var(--semantics-focus-ring-edge-thickness) double var(--semantics-focus-ring-edge-color);
+	}
+
 
 	/* # Empty text */
 

--- a/src/components/lists-and-menus/menu/ndd-menu.styles.ts
+++ b/src/components/lists-and-menus/menu/ndd-menu.styles.ts
@@ -51,11 +51,6 @@ export const menuStyles = css`
 		outline: none;
 	}
 
-	.menu.is-keyboard-focus:focus {
-		box-shadow: 0 0 0 var(--semantics-focus-ring-center-thickness) var(--semantics-focus-ring-center-color), var(--components-menu-box-shadow);
-		outline: var(--semantics-focus-ring-edge-thickness) double var(--semantics-focus-ring-edge-color);
-	}
-
 
 	/* # Empty text */
 

--- a/src/components/lists-and-menus/menu/ndd-menu.styles.ts
+++ b/src/components/lists-and-menus/menu/ndd-menu.styles.ts
@@ -37,7 +37,7 @@ export const menuStyles = css`
 		padding: var(--_menu-padding);
 		background: var(--semantics-surfaces-background-color);
 		border-radius: var(--semantics-overlays-corner-radius);
-		box-shadow: var(--primitives-box-shadows-level-5);
+		box-shadow: var(--components-menu-box-shadow);
 		box-sizing: border-box;
 		width: var(--_menu-width);
 		max-height: min(
@@ -52,7 +52,7 @@ export const menuStyles = css`
 	}
 
 	.menu.is-keyboard-focus:focus {
-		box-shadow: 0 0 0 var(--semantics-focus-ring-center-thickness) var(--semantics-focus-ring-center-color), var(--primitives-box-shadows-level-5);
+		box-shadow: 0 0 0 var(--semantics-focus-ring-center-thickness) var(--semantics-focus-ring-center-color), var(--components-menu-box-shadow);
 		outline: var(--semantics-focus-ring-edge-thickness) double var(--semantics-focus-ring-edge-color);
 	}
 

--- a/src/components/lists-and-menus/menu/ndd-menu.styles.ts
+++ b/src/components/lists-and-menus/menu/ndd-menu.styles.ts
@@ -47,6 +47,15 @@ export const menuStyles = css`
 		overflow-y: auto;
 	}
 
+	.menu:focus-visible {
+		outline: none;
+	}
+
+	.menu.is-keyboard-focus:focus {
+		box-shadow: 0 0 0 var(--semantics-focus-ring-center-thickness) var(--semantics-focus-ring-center-color), var(--primitives-box-shadows-level-5);
+		outline: var(--semantics-focus-ring-edge-thickness) double var(--semantics-focus-ring-edge-color);
+	}
+
 
 	/* # Empty text */
 

--- a/src/components/lists-and-menus/menu/ndd-menu.styles.ts
+++ b/src/components/lists-and-menus/menu/ndd-menu.styles.ts
@@ -21,6 +21,7 @@ export const menuStyles = css`
 			--_menu-item-size: var(--semantics-controls-sm-min-size);
 			--_menu-padding: var(--primitives-space-6);
 		}
+		-webkit-tap-highlight-color: transparent;
 	}
 
 	:host(:not(:popover-open)) {
@@ -63,6 +64,7 @@ export const menuItemStyles = css`
 	:host {
 		display: block;
 		font-family: var(--ndd-font-family-body);
+		-webkit-tap-highlight-color: transparent;
 	}
 
 	:host([hidden]) {

--- a/src/components/lists-and-menus/menu/ndd-menu.ts
+++ b/src/components/lists-and-menus/menu/ndd-menu.ts
@@ -9,6 +9,7 @@ import '../../lists-and-menus/cells/icon-cell/ndd-icon-cell.js';
 import '../../lists-and-menus/cells/spacer-cell/ndd-spacer-cell.js';
 import '../../lists-and-menus/cells/text-cell/ndd-text-cell.js';
 import '../../content/icon/ndd-icon.js';
+import { isKeyboardMode } from '../../../utilities/keyboard-mode.js';
 
 
 // # ndd-menu-divider
@@ -144,7 +145,6 @@ const defaultFilterFn = (query: string, item: NDDMenuItem): boolean => {
  * @attr {string}  anchor         - ID of the anchor element.
  * @attr {string}  placement      - Floating UI placement. Default: 'bottom-start'.
  * @attr {string}  empty-text     - Text shown when all items are hidden or no items exist.
- * @attr {boolean} no-auto-focus  - When set, the first item is not focused on open.
  * @attr {string}  width          - Explicit width. Sets --_menu-width internally.
  * @attr {number}  max-items      - Maximum number of visible items before scrolling.
  *                                  Sets --_menu-max-items internally. Default: 0 (no limit).
@@ -176,9 +176,6 @@ export class NDDMenu extends LitElement {
 	@property({ type: String, attribute: 'empty-text' })
 	emptyText = '';
 
-	/** When set, the first item is not focused automatically on open. */
-	@property({ type: Boolean, attribute: 'no-auto-focus' })
-	noAutoFocus = false;
 
 	/** Explicit width. Sets --_menu-width internally. */
 	@property({ type: String, reflect: true })
@@ -316,10 +313,14 @@ export class NDDMenu extends LitElement {
 		return items.findIndex(item => item.hasAttribute('data-focused'));
 	}
 
-	private _setHighlight(target: NDDMenuItem | null): void {
+	private _clearHighlight(): void {
 		Array.from(this.querySelectorAll('ndd-menu-item')).forEach(item => {
 			item.removeAttribute('highlighted');
 		});
+	}
+
+	private _setHighlight(target: NDDMenuItem | null): void {
+		this._clearHighlight();
 		const resolved = target ?? this._getVisibleItems()[0] ?? null;
 		resolved?.setAttribute('highlighted', '');
 	}
@@ -536,7 +537,7 @@ export class NDDMenu extends LitElement {
 		}
 
 		this._updateDividerVisibility();
-		this._setHighlight(null);
+		this._clearHighlight();
 		this._updateEmptyState();
 		Array.from(this.querySelectorAll('ndd-menu-item')).forEach(item => {
 			(item as NDDMenuItem).menuVariant = this.variant;
@@ -544,12 +545,11 @@ export class NDDMenu extends LitElement {
 
 		await this.reposition();
 
-		if (!this.noAutoFocus) {
-			await this.updateComplete;
-			const items = this._getVisibleItems();
-			if (items.length > 0) {
-				items[0].shadowRoot?.querySelector('button')?.focus();
-			}
+		await this.updateComplete;
+		if (this.variant !== 'listbox') {
+			const menu = this.shadowRoot?.querySelector<HTMLElement>('.menu');
+			menu?.classList.toggle('is-keyboard-focus', isKeyboardMode());
+			menu?.focus();
 		}
 	};
 

--- a/src/components/lists-and-menus/menu/ndd-menu.ts
+++ b/src/components/lists-and-menus/menu/ndd-menu.ts
@@ -554,14 +554,14 @@ export class NDDMenu extends LitElement {
 
 		await this.updateComplete;
 		if (this.variant !== 'listbox') {
-			if (isKeyboardMode()) {
-				const items = this._getVisibleItems();
-				if (items.length > 0) {
-					this._setHighlight(items[0]);
-					items[0].shadowRoot?.querySelector('button')?.focus();
-				}
+			const keyboard = isKeyboardMode();
+			const items = this._getVisibleItems();
+			if (keyboard && items.length > 0) {
+				this._setHighlight(items[0]);
+				items[0].shadowRoot?.querySelector('button')?.focus();
 			} else {
 				const menu = this.shadowRoot?.querySelector<HTMLElement>('.menu');
+				menu?.classList.toggle('is-keyboard-focus', keyboard);
 				menu?.focus();
 			}
 		}

--- a/src/components/lists-and-menus/menu/ndd-menu.ts
+++ b/src/components/lists-and-menus/menu/ndd-menu.ts
@@ -209,6 +209,7 @@ export class NDDMenu extends LitElement {
 	private _isEmpty = false;
 
 	private _isOpen = false;
+	private _closedAt = 0;
 
 	// — i18n ——————————————————————————————————————————————————————————————————
 
@@ -263,7 +264,7 @@ export class NDDMenu extends LitElement {
 		if (!path.includes(anchorEl)) return;
 		if (this._isOpen) {
 			(this as HTMLElement).hidePopover();
-		} else {
+		} else if (Date.now() - this._closedAt > 50) {
 			(this as HTMLElement).showPopover();
 		}
 	};
@@ -529,7 +530,10 @@ export class NDDMenu extends LitElement {
 		const toggleEvent = event as ToggleEvent;
 		this._isOpen = toggleEvent.newState === 'open';
 
-		if (toggleEvent.newState !== 'open') return;
+		if (toggleEvent.newState !== 'open') {
+			this._closedAt = Date.now();
+			return;
+		}
 
 		this._updateDividerVisibility();
 		this._setHighlight(null);

--- a/src/components/lists-and-menus/menu/ndd-menu.ts
+++ b/src/components/lists-and-menus/menu/ndd-menu.ts
@@ -554,13 +554,16 @@ export class NDDMenu extends LitElement {
 
 		await this.updateComplete;
 		if (this.variant !== 'listbox') {
-			const keyboard = isKeyboardMode();
-			if (keyboard) {
-				this._setHighlight(null);
+			if (isKeyboardMode()) {
+				const items = this._getVisibleItems();
+				if (items.length > 0) {
+					this._setHighlight(items[0]);
+					items[0].shadowRoot?.querySelector('button')?.focus();
+				}
+			} else {
+				const menu = this.shadowRoot?.querySelector<HTMLElement>('.menu');
+				menu?.focus();
 			}
-			const menu = this.shadowRoot?.querySelector<HTMLElement>('.menu');
-			menu?.classList.toggle('is-keyboard-focus', keyboard);
-			menu?.focus();
 		}
 	};
 

--- a/src/components/lists-and-menus/menu/ndd-menu.ts
+++ b/src/components/lists-and-menus/menu/ndd-menu.ts
@@ -554,8 +554,12 @@ export class NDDMenu extends LitElement {
 
 		await this.updateComplete;
 		if (this.variant !== 'listbox') {
+			const keyboard = isKeyboardMode();
+			if (keyboard) {
+				this._setHighlight(null);
+			}
 			const menu = this.shadowRoot?.querySelector<HTMLElement>('.menu');
-			menu?.classList.toggle('is-keyboard-focus', isKeyboardMode());
+			menu?.classList.toggle('is-keyboard-focus', keyboard);
 			menu?.focus();
 		}
 	};

--- a/src/components/lists-and-menus/menu/ndd-menu.ts
+++ b/src/components/lists-and-menus/menu/ndd-menu.ts
@@ -272,6 +272,10 @@ export class NDDMenu extends LitElement {
 		this._setHighlight(item);
 	};
 
+	private _handleMouseleave = (): void => {
+		if (this.variant !== 'listbox') this._clearHighlight();
+	};
+
 	private _handleMenuItemFocused = (event: Event): void => {
 		const item = (event.target as Element).closest('ndd-menu-item') as NDDMenuItem | null;
 		if (!item || item.disabled || item.hasAttribute('hidden')) return;
@@ -288,6 +292,7 @@ export class NDDMenu extends LitElement {
 		this.addEventListener('toggle', this._handleToggle);
 		this.addEventListener('keydown', this._handleKeydown);
 		this.addEventListener('mouseenter', this._handleMenuItemMouseenter, true);
+		this.addEventListener('mouseleave', this._handleMouseleave);
 		this.addEventListener('menu-item-focused', this._handleMenuItemFocused);
 		document.addEventListener('click', this._handleDocumentClick);
 	}
@@ -297,6 +302,7 @@ export class NDDMenu extends LitElement {
 		this.removeEventListener('toggle', this._handleToggle);
 		this.removeEventListener('keydown', this._handleKeydown);
 		this.removeEventListener('mouseenter', this._handleMenuItemMouseenter, true);
+		this.removeEventListener('mouseleave', this._handleMouseleave);
 		this.removeEventListener('menu-item-focused', this._handleMenuItemFocused);
 		document.removeEventListener('click', this._handleDocumentClick);
 	}

--- a/src/components/lists-and-menus/menu/ndd-menu.ts
+++ b/src/components/lists-and-menus/menu/ndd-menu.ts
@@ -10,6 +10,7 @@ import '../../lists-and-menus/cells/spacer-cell/ndd-spacer-cell.js';
 import '../../lists-and-menus/cells/text-cell/ndd-text-cell.js';
 import '../../content/icon/ndd-icon.js';
 import { isKeyboardMode } from '../../../utilities/keyboard-mode.js';
+import { POPOVER_REOPEN_GUARD_MS } from '../../../utilities/popover-guard.js';
 
 
 // # ndd-menu-divider
@@ -261,7 +262,7 @@ export class NDDMenu extends LitElement {
 		if (!path.includes(anchorEl)) return;
 		if (this._isOpen) {
 			(this as HTMLElement).hidePopover();
-		} else if (Date.now() - this._closedAt > 50) {
+		} else if (Date.now() - this._closedAt > POPOVER_REOPEN_GUARD_MS) {
 			(this as HTMLElement).showPopover();
 		}
 	};

--- a/src/components/lists-and-menus/menu/ndd-menu.ts
+++ b/src/components/lists-and-menus/menu/ndd-menu.ts
@@ -99,6 +99,11 @@ export class NDDMenuItem extends LitElement {
 		this.addEventListener('focusout', () => this.removeAttribute('data-focused'));
 	}
 
+	override focus(options?: FocusOptions): void {
+		const focusable = this.shadowRoot?.querySelector<HTMLElement>('button, a');
+		focusable?.focus(options);
+	}
+
 	_handleClick(): void {
 		if (this.disabled) return;
 		this.dispatchEvent(new CustomEvent('select', {
@@ -429,7 +434,7 @@ export class NDDMenu extends LitElement {
 
 		items.forEach(item => item.removeAttribute('highlighted'));
 		items[targetIndex].setAttribute('highlighted', '');
-		items[targetIndex].shadowRoot?.querySelector('button')?.focus();
+		items[targetIndex].focus();
 	}
 
 	/**
@@ -505,23 +510,23 @@ export class NDDMenu extends LitElement {
 			case 'ArrowDown': {
 				event.preventDefault();
 				const next = index === -1 ? 0 : index < items.length - 1 ? index + 1 : 0;
-				items[next].shadowRoot?.querySelector('button')?.focus();
+				items[next].focus();
 				break;
 			}
 			case 'ArrowUp': {
 				event.preventDefault();
 				const prev = index === -1 ? items.length - 1 : index > 0 ? index - 1 : items.length - 1;
-				items[prev].shadowRoot?.querySelector('button')?.focus();
+				items[prev].focus();
 				break;
 			}
 			case 'Home': {
 				event.preventDefault();
-				items[0].shadowRoot?.querySelector('button')?.focus();
+				items[0].focus();
 				break;
 			}
 			case 'End': {
 				event.preventDefault();
-				items[items.length - 1].shadowRoot?.querySelector('button')?.focus();
+				items[items.length - 1].focus();
 				break;
 			}
 			case 'Escape': {
@@ -558,7 +563,7 @@ export class NDDMenu extends LitElement {
 			const items = this._getVisibleItems();
 			if (keyboard && items.length > 0) {
 				this._setHighlight(items[0]);
-				items[0].shadowRoot?.querySelector('button')?.focus();
+				items[0].focus();
 			} else {
 				const menu = this.shadowRoot?.querySelector<HTMLElement>('.menu');
 				menu?.classList.toggle('is-keyboard-focus', keyboard);

--- a/src/components/navigation/document-tab-bar/ndd-document-tab-bar.i18n.ts
+++ b/src/components/navigation/document-tab-bar/ndd-document-tab-bar.i18n.ts
@@ -1,6 +1,6 @@
 export const nddDocumentTabBarTranslations = {
 	'components.document-tab-bar.dismiss-action': 'Sluit',
-	'components.document-tab-bar.overflow-action': 'Meer',
+	'components.document-tab-bar.overflow-action': 'Toon meer tabbladen',
 	'components.document-tab-bar.drag-dropped-text': 'Tabblad verplaatst naar positie {position}.',
 	'components.document-tab-bar.drag-no-change-text': 'Tabblad verplaatst. Positie ongewijzigd.',
 	'components.document-tab-bar.drag-cancelled-text': 'Slepen geannuleerd.',

--- a/src/components/navigation/document-tab-bar/ndd-document-tab-bar.styles.ts
+++ b/src/components/navigation/document-tab-bar/ndd-document-tab-bar.styles.ts
@@ -277,7 +277,6 @@ export const documentTabBarItemStyles = css`
 
 	.document-tab-bar__item-normal {
 		display: contents;
-		padding-right: var(--primitives-space-6);
 
 		@container document-tab-bar (max-width: 200px) {
 			display: none;
@@ -289,7 +288,6 @@ export const documentTabBarItemStyles = css`
 
 		@container document-tab-bar (max-width: 200px) {
 			display: contents;
-			padding-right: var(--primitives-space-6);
 		}
 	}
 
@@ -297,7 +295,7 @@ export const documentTabBarItemStyles = css`
 	/* # Item label */
 
 	.document-tab-bar__item-text {
-		padding-right: var(--primitives-space-6);
+		padding-inline-end: var(--primitives-space-6);
 		font: var(--components-document-tab-bar-tab-title-font);
 		color: var(--semantics-buttons-neutral-tinted-content-color);
 		overflow: hidden;
@@ -310,7 +308,7 @@ export const documentTabBarItemStyles = css`
 	}
 
 	.document-tab-bar__item-short-text {
-		padding-right: var(--primitives-space-6);
+		padding-inline-end: var(--primitives-space-6);
 		font: var(--components-document-tab-bar-tab-title-font);
 		color: var(--semantics-buttons-neutral-tinted-content-color);
 		overflow: hidden;
@@ -326,7 +324,7 @@ export const documentTabBarItemStyles = css`
 	/* # Item supporting label */
 
 	.document-tab-bar__item-supporting-text {
-		padding-right: var(--primitives-space-6);
+		padding-inline-end: var(--primitives-space-6);
 		font: var(--primitives-font-body-xs-regular-flat);
 		color: var(--semantics-content-secondary-color);
 		overflow: hidden;
@@ -339,7 +337,7 @@ export const documentTabBarItemStyles = css`
 	}
 
 	.document-tab-bar__item-short-supporting-text {
-		padding-right: var(--primitives-space-6);
+		padding-inline-end: var(--primitives-space-6);
 		font: var(--primitives-font-body-xs-regular-flat);
 		color: var(--semantics-content-secondary-color);
 		overflow: hidden;

--- a/src/components/navigation/document-tab-bar/ndd-document-tab-bar.styles.ts
+++ b/src/components/navigation/document-tab-bar/ndd-document-tab-bar.styles.ts
@@ -163,6 +163,15 @@ export const documentTabBarStyles = css`
 		white-space: nowrap;
 	}
 
+	.document-tab-bar__drag-clone.is-selected .document-tab-bar__item-tab {
+		background-color: var(--semantics-buttons-neutral-tinted-is-selected-background-color);
+	}
+
+	.document-tab-bar__drag-clone.is-selected .document-tab-bar__item-text,
+	.document-tab-bar__drag-clone.is-selected .document-tab-bar__item-supporting-text {
+		color: var(--semantics-buttons-neutral-tinted-is-selected-content-color);
+	}
+
 	.document-tab-bar__drag-clone .document-tab-bar__item-supporting-text {
 		font: var(--primitives-font-body-xs-regular-flat);
 		color: var(--semantics-content-secondary-color);
@@ -198,6 +207,7 @@ export const documentTabBarItemStyles = css`
 		min-width: 0;
 		container-name: document-tab-bar;
 		container-type: inline-size;
+		touch-action: pan-y;
 		-webkit-tap-highlight-color: transparent;
 	}
 

--- a/src/components/navigation/document-tab-bar/ndd-document-tab-bar.styles.ts
+++ b/src/components/navigation/document-tab-bar/ndd-document-tab-bar.styles.ts
@@ -16,6 +16,7 @@ export const documentTabBarStyles = css`
 		--_short-text-threshold: 200px;
 		--_item-min-width: 100px;
 		--_overflow-button-reserve: 52px; /* Used for overflowButtonReserve. Overflow button width + spacing */
+		-webkit-tap-highlight-color: transparent;
 	}
 
 	:host([hidden]) {
@@ -197,6 +198,7 @@ export const documentTabBarItemStyles = css`
 		min-width: 0;
 		container-name: document-tab-bar;
 		container-type: inline-size;
+		-webkit-tap-highlight-color: transparent;
 	}
 
 	:host([hidden]) {

--- a/src/components/navigation/document-tab-bar/ndd-document-tab-bar.styles.ts
+++ b/src/components/navigation/document-tab-bar/ndd-document-tab-bar.styles.ts
@@ -242,7 +242,7 @@ export const documentTabBarItemStyles = css`
 		border-radius: var(--semantics-controls-md-corner-radius);
 		padding-block: var(--primitives-space-6);
 		padding-inline-start: var(--primitives-space-10);
-		padding-inline-end: calc(var(--semantics-controls-sm-min-size) + var(--primitives-space-6) * 2);
+		padding-inline-end: calc(var(--semantics-controls-sm-min-size) + var(--primitives-space-6));
 		background-color: var(--semantics-buttons-neutral-tinted-background-color);
 		box-sizing: border-box;
 		overflow: hidden;
@@ -273,24 +273,36 @@ export const documentTabBarItemStyles = css`
 	}
 
 
+	/* # Item text wrappers */
+
+	.document-tab-bar__item-normal {
+		display: contents;
+		padding-right: var(--primitives-space-6);
+
+		@container document-tab-bar (max-width: 200px) {
+			display: none;
+		}
+	}
+
+	.document-tab-bar__item-short {
+		display: none;
+
+		@container document-tab-bar (max-width: 200px) {
+			display: contents;
+			padding-right: var(--primitives-space-6);
+		}
+	}
+
+
 	/* # Item label */
 
 	.document-tab-bar__item-text {
+		padding-right: var(--primitives-space-6);
 		font: var(--components-document-tab-bar-tab-title-font);
 		color: var(--semantics-buttons-neutral-tinted-content-color);
 		overflow: hidden;
 		text-overflow: ellipsis;
 		white-space: nowrap;
-
-		@container document-tab-bar (max-width: 200px) {
-			clip: rect(0 0 0 0);
-			clip-path: inset(50%);
-			height: 1px;
-			overflow: hidden;
-			position: absolute;
-			white-space: nowrap;
-			width: 1px;
-		}
 	}
 
 	:host([selected]) .document-tab-bar__item-text {
@@ -298,15 +310,12 @@ export const documentTabBarItemStyles = css`
 	}
 
 	.document-tab-bar__item-short-text {
+		padding-right: var(--primitives-space-6);
 		font: var(--components-document-tab-bar-tab-title-font);
 		color: var(--semantics-buttons-neutral-tinted-content-color);
 		overflow: hidden;
 		text-overflow: ellipsis;
 		white-space: nowrap;
-
-		@container document-tab-bar (min-width: 201px) {
-			display: none;
-		}
 	}
 
 	:host([selected]) .document-tab-bar__item-short-text {
@@ -317,21 +326,12 @@ export const documentTabBarItemStyles = css`
 	/* # Item supporting label */
 
 	.document-tab-bar__item-supporting-text {
+		padding-right: var(--primitives-space-6);
 		font: var(--primitives-font-body-xs-regular-flat);
 		color: var(--semantics-content-secondary-color);
 		overflow: hidden;
 		text-overflow: ellipsis;
 		white-space: nowrap;
-
-		@container document-tab-bar (max-width: 200px) {
-			clip: rect(0 0 0 0);
-			clip-path: inset(50%);
-			height: 1px;
-			overflow: hidden;
-			position: absolute;
-			white-space: nowrap;
-			width: 1px;
-		}
 	}
 
 	:host([selected]) .document-tab-bar__item-supporting-text {
@@ -339,15 +339,12 @@ export const documentTabBarItemStyles = css`
 	}
 
 	.document-tab-bar__item-short-supporting-text {
+		padding-right: var(--primitives-space-6);
 		font: var(--primitives-font-body-xs-regular-flat);
 		color: var(--semantics-content-secondary-color);
 		overflow: hidden;
 		text-overflow: ellipsis;
 		white-space: nowrap;
-
-		@container document-tab-bar (min-width: 201px) {
-			display: none;
-		}
 	}
 
 	:host([selected]) .document-tab-bar__item-short-supporting-text {

--- a/src/components/navigation/document-tab-bar/ndd-document-tab-bar.template.ts
+++ b/src/components/navigation/document-tab-bar/ndd-document-tab-bar.template.ts
@@ -3,6 +3,7 @@ import { classMap } from 'lit/directives/class-map.js';
 import type { NDDDocumentTabBar, NDDDocumentTabBarItem } from './ndd-document-tab-bar.ts';
 import './../../actions/icon-button/ndd-icon-button.ts';
 import './../../content/icon/ndd-icon.ts';
+import './../../content/tooltip/ndd-tooltip.ts';
 
 export function documentTabBarTemplate(component: NDDDocumentTabBar): TemplateResult {
 	const hasOverflow = component._overflowCount > 0;
@@ -61,21 +62,25 @@ export function documentTabBarItemTemplate(component: NDDDocumentTabBarItem): Te
 	const isLink = Boolean(safeHref);
 	const tabindex = component.selected || component._isFallbackFocusable ? '0' : '-1';
 
+	const tooltipText = component.supportingText
+		? `${component.text} · ${component.supportingText}`
+		: component.text;
+
 	const tabContent = html`
-		<span class="document-tab-bar__item-text">${component.text}</span>
-		<span class="document-tab-bar__item-short-text"
-			aria-hidden="true"
-			title=${component.text}
-		>${shortTextValue}</span>
-		${component.supportingText
-			? html`<span class="document-tab-bar__item-supporting-text">${component.supportingText}</span>`
-			: nothing}
-		${shortSupportingTextValue
-			? html`<span class="document-tab-bar__item-short-supporting-text"
-				aria-hidden="true"
-				title=${component.supportingText || nothing}
-			>${shortSupportingTextValue}</span>`
-			: nothing}
+		<span class="document-tab-bar__item-normal">
+			<span class="document-tab-bar__item-text">${component.text}</span>
+			${component.supportingText
+				? html`<span class="document-tab-bar__item-supporting-text">${component.supportingText}</span>`
+				: nothing}
+		</span>
+		<span class="document-tab-bar__item-short">
+			<ndd-tooltip text=${tooltipText}>
+				<span class="document-tab-bar__item-short-text">${shortTextValue}</span>
+				${shortSupportingTextValue
+					? html`<span class="document-tab-bar__item-short-supporting-text">${shortSupportingTextValue}</span>`
+					: nothing}
+			</ndd-tooltip>
+		</span>
 	`;
 
 	const tab = isLink

--- a/src/components/navigation/document-tab-bar/ndd-document-tab-bar.template.ts
+++ b/src/components/navigation/document-tab-bar/ndd-document-tab-bar.template.ts
@@ -67,7 +67,7 @@ export function documentTabBarItemTemplate(component: NDDDocumentTabBarItem): Te
 		: component.text;
 
 	const tabContent = html`
-		<span class="document-tab-bar__item-normal">
+		<span class="document-tab-bar__item-normal" aria-hidden="true">
 			<span class="document-tab-bar__item-text">${component.text}</span>
 			${component.supportingText
 				? html`<span class="document-tab-bar__item-supporting-text">${component.supportingText}</span>`
@@ -89,6 +89,7 @@ export function documentTabBarItemTemplate(component: NDDDocumentTabBarItem): Te
 				role=${isNavigation ? nothing : 'tab'}
 				aria-current=${isNavigation && component.selected ? 'page' : nothing}
 				aria-selected=${!isNavigation ? (component.selected ? 'true' : 'false') : nothing}
+				aria-label=${tooltipText}
 				tabindex=${tabindex}
 				@click=${component._handleClick}
 			>${tabContent}</a>`
@@ -96,6 +97,7 @@ export function documentTabBarItemTemplate(component: NDDDocumentTabBarItem): Te
 				type="button"
 				role="tab"
 				aria-selected=${component.selected ? 'true' : 'false'}
+				aria-label=${tooltipText}
 				tabindex=${tabindex}
 				@click=${component._handleClick}
 			>${tabContent}</button>`;

--- a/src/components/navigation/document-tab-bar/ndd-document-tab-bar.ts
+++ b/src/components/navigation/document-tab-bar/ndd-document-tab-bar.ts
@@ -42,6 +42,7 @@ import { documentTabBarTemplate, documentTabBarItemTemplate } from './ndd-docume
 import { nddDocumentTabBarTranslations } from './ndd-document-tab-bar.i18n.ts';
 import type { NDDDocumentTabBarTranslations } from './ndd-document-tab-bar.i18n.ts';
 import './../../lists-and-menus/menu/ndd-menu.ts';
+import { POPOVER_REOPEN_GUARD_MS } from '../../../utilities/popover-guard.js';
 
 // Pointer movement threshold in px before drag mode activates.
 // Distinguishes a click (select) from a drag (reorder).
@@ -725,7 +726,7 @@ export class NDDDocumentTabBar extends LitElement {
 		this._updateMenu();
 		if (this._menuOpen) {
 			(this._menu as any).hidePopover?.();
-		} else if (Date.now() - this._menuClosedAt > 50) {
+		} else if (Date.now() - this._menuClosedAt > POPOVER_REOPEN_GUARD_MS) {
 			(this._menu as any).showPopover?.();
 		}
 	}

--- a/src/components/navigation/document-tab-bar/ndd-document-tab-bar.ts
+++ b/src/components/navigation/document-tab-bar/ndd-document-tab-bar.ts
@@ -160,6 +160,7 @@ export class NDDDocumentTabBar extends LitElement {
 	_menuOpen = false;
 
 	private _menu: Element | null = null;
+	private _menuClosedAt = 0;
 	private _resizeObserver: ResizeObserver | null = null;
 	private _hasCustomLabel = false;
 	private _mergedTranslations = { ...nddDocumentTabBarTranslations };
@@ -458,7 +459,7 @@ export class NDDDocumentTabBar extends LitElement {
 		cloneInner.appendChild(cloneTab);
 
 		this._clone = document.createElement('div');
-		this._clone.className = 'document-tab-bar__drag-clone';
+		this._clone.className = `document-tab-bar__drag-clone${item.selected ? ' is-selected' : ''}`;
 		this._clone.style.setProperty('--_drag-clone-left', `${clientX - this._tabBarRect.left - this._cloneOffsetX}px`);
 		this._clone.style.setProperty('--_drag-clone-top', `${rect.top - this._tabBarRect.top}px`);
 		this._clone.style.setProperty('--_drag-clone-width', `${rect.width}px`);
@@ -695,7 +696,9 @@ export class NDDDocumentTabBar extends LitElement {
 		menu.setAttribute('placement', 'bottom-end');
 		menu.id = `${this._id}-menu`;
 		menu.addEventListener('toggle', (event: Event) => {
-			this._menuOpen = (event as ToggleEvent).newState === 'open';
+			const open = (event as ToggleEvent).newState === 'open';
+			this._menuOpen = open;
+			if (!open) this._menuClosedAt = Date.now();
 		});
 		// TODO: appending to document.body and accessing ndd-menu internals via any-cast
 		// is a known limitation. Fix: define a typed public API on ndd-menu (anchorElement,
@@ -722,7 +725,7 @@ export class NDDDocumentTabBar extends LitElement {
 		this._updateMenu();
 		if (this._menuOpen) {
 			(this._menu as any).hidePopover?.();
-		} else {
+		} else if (Date.now() - this._menuClosedAt > 50) {
 			(this._menu as any).showPopover?.();
 		}
 	}

--- a/src/components/navigation/menu-bar/ndd-menu-bar.styles.ts
+++ b/src/components/navigation/menu-bar/ndd-menu-bar.styles.ts
@@ -10,6 +10,7 @@ export const menuBarItemStyles = css`
 		width: fit-content;
 		font-family: var(--ndd-font-family-body);
 		--_color: var(--components-menu-bar-menu-item-color);
+		-webkit-tap-highlight-color: transparent;
 	}
 
 	:host([hidden]) {

--- a/src/components/navigation/pagination/ndd-pagination.styles.ts
+++ b/src/components/navigation/pagination/ndd-pagination.styles.ts
@@ -8,6 +8,7 @@ export const paginationStyles = css`
 	:host {
 		display: block;
 		container-type: inline-size;
+		-webkit-tap-highlight-color: transparent;
 	}
 
 	:host([hidden]) {

--- a/src/components/navigation/pagination/ndd-pagination.styles.ts
+++ b/src/components/navigation/pagination/ndd-pagination.styles.ts
@@ -75,7 +75,8 @@ export const paginationStyles = css`
 
 	/* ## Page button indicator */
 
-	.pagination__page-button-indicator {
+	.pagination__page-button::before {
+		content: '';
 		position: absolute;
 		inset: var(--primitives-space-4);
 		border-radius: calc(var(--semantics-controls-md-corner-radius) - var(--primitives-space-4) / 2);
@@ -83,15 +84,15 @@ export const paginationStyles = css`
 		pointer-events: none;
 	}
 
-	.pagination__page-button:hover:not(.is-current) .pagination__page-button-indicator {
+	.pagination__page-button:hover:not(.is-current)::before {
 		background-color: var(--semantics-buttons-neutral-tinted-is-hovered-background-color);
 	}
 
-	.pagination__page-button.is-current .pagination__page-button-indicator {
+	.pagination__page-button.is-current::before {
 		background-color: var(--semantics-buttons-neutral-tinted-is-selected-background-color);
 	}
 
-	.pagination__page-button:focus-visible .pagination__page-button-indicator {
+	.pagination__page-button:focus-visible::before {
 		box-shadow: 0 0 0 var(--semantics-focus-ring-center-thickness) var(--semantics-focus-ring-center-color);
 		outline: var(--semantics-focus-ring-edge-thickness) double var(--semantics-focus-ring-edge-color);
 	}
@@ -211,11 +212,11 @@ export const paginationStyles = css`
 			color: HighlightText;
 		}
 
-		.pagination__page-button.is-current .pagination__page-button-indicator {
+		.pagination__page-button.is-current::before {
 			background-color: Highlight;
 		}
 
-		.pagination__page-button:focus-visible .pagination__page-button-indicator {
+		.pagination__page-button:focus-visible::before {
 			outline: 2px solid CanvasText;
 		}
 	}

--- a/src/components/navigation/pagination/ndd-pagination.template.ts
+++ b/src/components/navigation/pagination/ndd-pagination.template.ts
@@ -25,7 +25,6 @@ export function paginationTemplate(component: NDDPagination): TemplateResult {
 					aria-disabled=${isDisabled ? 'true' : nothing}
 					@click=${(e: Event) => { e.preventDefault(); component._goToPage(page); }}
 				>
-					<span class="pagination__page-button-indicator"></span>
 					<span class="pagination__page-button-text">${page}</span>
 				</a>
 			`;
@@ -39,7 +38,6 @@ export function paginationTemplate(component: NDDPagination): TemplateResult {
 				?disabled=${isDisabled}
 				@click=${() => component._goToPage(page)}
 			>
-				<span class="pagination__page-button-indicator"></span>
 				<span class="pagination__page-button-text">${page}</span>
 			</button>
 		`;

--- a/src/components/navigation/tab-bar/ndd-tab-bar.styles.ts
+++ b/src/components/navigation/tab-bar/ndd-tab-bar.styles.ts
@@ -132,7 +132,8 @@ export const tabBarItemStyles = css`
 
 	/* # Indicator */
 
-	.tab-bar__item-indicator {
+	.tab-bar__item::before {
+		content: '';
 		position: absolute;
 		inset: var(--primitives-space-4) var(--primitives-space-2);
 		border-radius: var(--primitives-corner-radius-sm);
@@ -141,11 +142,11 @@ export const tabBarItemStyles = css`
 		pointer-events: none;
 	}
 
-	.tab-bar__item:hover .tab-bar__item-indicator {
+	.tab-bar__item:hover::before {
 		background-color: var(--semantics-buttons-neutral-tinted-is-hovered-background-color);
 	}
 
-	:host([selected]) .tab-bar__item-indicator {
+	:host([selected]) .tab-bar__item::before {
 		background-color: var(--semantics-buttons-neutral-tinted-is-selected-background-color);
 
 		@media (forced-colors: active) {
@@ -156,7 +157,7 @@ export const tabBarItemStyles = css`
 
 	/* # Focus */
 
-	.tab-bar__item:focus-visible .tab-bar__item-indicator {
+	.tab-bar__item:focus-visible::before {
 		box-shadow: 0 0 0 var(--semantics-focus-ring-center-thickness) var(--semantics-focus-ring-center-color);
 		outline: var(--semantics-focus-ring-edge-thickness) double var(--semantics-focus-ring-edge-color);
 	}

--- a/src/components/navigation/tab-bar/ndd-tab-bar.styles.ts
+++ b/src/components/navigation/tab-bar/ndd-tab-bar.styles.ts
@@ -10,6 +10,7 @@ export const tabBarStyles = css`
 	:host {
 		display: inline-block;
 		position: relative;
+		-webkit-tap-highlight-color: transparent;
 	}
 
 	:host([hidden]) {
@@ -62,6 +63,7 @@ export const tabBarItemStyles = css`
 	:host {
 		display: inline-block;
 		position: relative;
+		-webkit-tap-highlight-color: transparent;
 	}
 
 	:host([hidden]) {

--- a/src/components/navigation/tab-bar/ndd-tab-bar.template.ts
+++ b/src/components/navigation/tab-bar/ndd-tab-bar.template.ts
@@ -1,5 +1,6 @@
 import { html, nothing, TemplateResult } from 'lit';
 import type { NDDTabBar, NDDTabBarItem } from './ndd-tab-bar.ts';
+import '../../content/tooltip/ndd-tooltip.js';
 
 export function tabBarTemplate(component: NDDTabBar): TemplateResult {
 	const label = component.accessibleLabel || 'Tabs';
@@ -46,30 +47,35 @@ export function tabBarItemTemplate(component: NDDTabBarItem): TemplateResult {
 		</span>
 	`;
 
+	let result: TemplateResult;
+
 	if (isLink) {
-		return html`
+		result = html`
 			<a class="tab-bar__item"
 				href=${safeHref!}
 				role=${isNavigation ? nothing : 'tab'}
 				aria-current=${isNavigation && component.selected ? 'page' : nothing}
 				aria-selected=${!isNavigation ? (component.selected ? 'true' : 'false') : nothing}
 				aria-label=${iconLabel}
-				title=${iconLabel}
 				tabindex=${tabindex}
 				@click=${component._handleClick}
 			>${content}</a>
 		`;
+	} else {
+		result = html`
+			<button class="tab-bar__item"
+				type="button"
+				role="tab"
+				aria-selected=${component.selected ? 'true' : 'false'}
+				aria-label=${iconLabel}
+				tabindex=${tabindex}
+				@click=${component._handleClick}
+			>${content}</button>
+		`;
 	}
 
-	return html`
-		<button class="tab-bar__item"
-			type="button"
-			role="tab"
-			aria-selected=${component.selected ? 'true' : 'false'}
-			aria-label=${iconLabel}
-			title=${iconLabel}
-			tabindex=${tabindex}
-			@click=${component._handleClick}
-		>${content}</button>
-	`;
+	if (isIconVariant && component.text) {
+		return html`<ndd-tooltip text=${component.text}>${result}</ndd-tooltip>`;
+	}
+	return result;
 }

--- a/src/components/navigation/tab-bar/ndd-tab-bar.template.ts
+++ b/src/components/navigation/tab-bar/ndd-tab-bar.template.ts
@@ -38,7 +38,6 @@ export function tabBarItemTemplate(component: NDDTabBarItem): TemplateResult {
 	const iconLabel = isIconVariant ? component.text || nothing : nothing;
 
 	const content = html`
-		<span class="tab-bar__item-indicator"></span>
 		<span class="tab-bar__item-icon" aria-hidden="true">
 			<slot name="icon" @slotchange=${component._onIconSlotChange}></slot>
 		</span>

--- a/src/components/navigation/tab-bar/ndd-tab-bar.test.ts
+++ b/src/components/navigation/tab-bar/ndd-tab-bar.test.ts
@@ -164,14 +164,16 @@ describe('ndd-tab-bar-item – icon variant accessibility', () => {
 		expect(el.shadowRoot!.querySelector('[role="tab"]')!.getAttribute('aria-label')).toBe('Home');
 	});
 
-	it('sets title from text attribute when variant is icon', async () => {
+	it('wraps in ndd-tooltip when variant is icon', async () => {
 		el = await fixture<NDDTabBarItem>(`
 			<ndd-tab-bar-item variant="icon" text="Home">
 				<svg slot="icon"></svg>
 			</ndd-tab-bar-item>
 		`);
 		await waitForUpdate(el);
-		expect(el.shadowRoot!.querySelector('[role="tab"]')!.getAttribute('title')).toBe('Home');
+		const tooltip = el.shadowRoot!.querySelector('ndd-tooltip');
+		expect(tooltip).not.toBeNull();
+		expect(tooltip!.getAttribute('text')).toBe('Home');
 	});
 
 	it('does not set aria-label when variant is icon-and-text', async () => {
@@ -184,14 +186,14 @@ describe('ndd-tab-bar-item – icon variant accessibility', () => {
 		expect(el.shadowRoot!.querySelector('[role="tab"]')!.getAttribute('aria-label')).toBeNull();
 	});
 
-	it('does not set title when variant is text', async () => {
+	it('does not wrap in ndd-tooltip when variant is text', async () => {
 		el = await fixture<NDDTabBarItem>(`
 			<ndd-tab-bar-item variant="text" text="Home">
 				<svg slot="icon"></svg>
 			</ndd-tab-bar-item>
 		`);
 		await waitForUpdate(el);
-		expect(el.shadowRoot!.querySelector('[role="tab"]')!.getAttribute('title')).toBeNull();
+		expect(el.shadowRoot!.querySelector('ndd-tooltip')).toBeNull();
 	});
 });
 

--- a/src/components/navigation/top-title-bar/ndd-top-title-bar.styles.ts
+++ b/src/components/navigation/top-title-bar/ndd-top-title-bar.styles.ts
@@ -127,11 +127,6 @@ export const topTitleBarStyles = css`
 		white-space: nowrap;
 	}
 
-	.top-title-bar__title:focus-visible {
-		box-shadow: none;
-		outline: none;
-	}
-
 	.top-title-bar__title:has(+ .top-title-bar__subtitle) {
 		font: var(--primitives-font-body-md-bold-flat);
 	}

--- a/src/components/status-and-feedback/modal-dialog/ndd-modal-dialog.styles.ts
+++ b/src/components/status-and-feedback/modal-dialog/ndd-modal-dialog.styles.ts
@@ -1,4 +1,7 @@
-import { css } from 'lit';
+import { css, unsafeCSS } from 'lit';
+import { breakpoints } from '../../../assets/styles/breakpoints.ts';
+
+const mdMin = unsafeCSS(breakpoints.mdMin);
 
 /* # ndd-modal-dialog styles */
 
@@ -33,7 +36,7 @@ export const modalDialogStyles = css`
 
 		padding: var(--primitives-space-16);
 
-		@media (min-width: 641px) {
+		@media (min-width: ${mdMin}) {
 			padding: var(--primitives-space-24);
 		}
 	}

--- a/src/components/status-and-feedback/modal-dialog/ndd-modal-dialog.styles.ts
+++ b/src/components/status-and-feedback/modal-dialog/ndd-modal-dialog.styles.ts
@@ -45,6 +45,10 @@ export const modalDialogStyles = css`
 	}
 
 	.modal-dialog:focus-visible {
+		outline: none;
+	}
+
+	.modal-dialog.is-keyboard-focus:focus {
 		box-shadow: var(--components-dialog-box-shadow), 0 0 0 var(--semantics-focus-ring-center-thickness) var(--semantics-focus-ring-center-color);
 		outline: var(--semantics-focus-ring-edge-thickness) double var(--semantics-focus-ring-edge-color);
 	}

--- a/src/components/status-and-feedback/modal-dialog/ndd-modal-dialog.styles.ts
+++ b/src/components/status-and-feedback/modal-dialog/ndd-modal-dialog.styles.ts
@@ -22,7 +22,6 @@ export const modalDialogStyles = css`
 
 	.modal-dialog {
 		border: none;
-		padding: var(--primitives-space-24) var(--primitives-space-16);
 		max-width: var(--primitives-area-480);
 		width: calc(100% - var(--primitives-space-16) * 2);
 		max-height: var(--_max-height);
@@ -31,6 +30,14 @@ export const modalDialogStyles = css`
 		border-radius: var(--semantics-overlays-corner-radius);
 		box-shadow: var(--components-dialog-box-shadow);
 		box-sizing: border-box;
+
+		@media (max-width: 640px) {
+			padding: var(--primitives-space-16);
+		}
+
+		@media (min-width: 641px) {
+			padding: var(--primitives-space-24);
+		}
 	}
 
 	.modal-dialog:not([open]) {

--- a/src/components/status-and-feedback/modal-dialog/ndd-modal-dialog.styles.ts
+++ b/src/components/status-and-feedback/modal-dialog/ndd-modal-dialog.styles.ts
@@ -31,9 +31,7 @@ export const modalDialogStyles = css`
 		box-shadow: var(--components-dialog-box-shadow);
 		box-sizing: border-box;
 
-		@media (max-width: 640px) {
-			padding: var(--primitives-space-16);
-		}
+		padding: var(--primitives-space-16);
 
 		@media (min-width: 641px) {
 			padding: var(--primitives-space-24);

--- a/src/components/status-and-feedback/modal-dialog/ndd-modal-dialog.template.ts
+++ b/src/components/status-and-feedback/modal-dialog/ndd-modal-dialog.template.ts
@@ -6,6 +6,7 @@ export function modalDialogTemplate(component: NDDModalDialog) {
 	return html`
 		<dialog class="modal-dialog"
 			role=${component.variant === 'alert' ? 'alertdialog' : nothing}
+			aria-label=${component.accessibleLabel || component.text || nothing}
 			aria-modal="true"
 			@click=${component._handleBackdropClick}
 			@cancel=${component._handleCancel}

--- a/src/components/status-and-feedback/modal-dialog/ndd-modal-dialog.test.ts
+++ b/src/components/status-and-feedback/modal-dialog/ndd-modal-dialog.test.ts
@@ -109,6 +109,18 @@ describe('ndd-modal-dialog', () => {
 		expect(inner?.getAttribute('icon-name')).toBe('check-mark-circle');
 	});
 
+	it('sets aria-label from accessible-label', async () => {
+		el = await fixture('<ndd-modal-dialog accessible-label="Bevestig actie" text="Weet u het zeker?"></ndd-modal-dialog>');
+		await waitForUpdate(el);
+		expect(el.shadowRoot!.querySelector('dialog')!.getAttribute('aria-label')).toBe('Bevestig actie');
+	});
+
+	it('falls back to text for aria-label when no accessible-label', async () => {
+		el = await fixture('<ndd-modal-dialog text="Bevestiging vereist"></ndd-modal-dialog>');
+		await waitForUpdate(el);
+		expect(el.shadowRoot!.querySelector('dialog')!.getAttribute('aria-label')).toBe('Bevestiging vereist');
+	});
+
 	it('focuses the dialog on show()', async () => {
 		el = await fixture('<ndd-modal-dialog text="Bevestiging vereist"></ndd-modal-dialog>');
 		await waitForUpdate(el);

--- a/src/components/status-and-feedback/modal-dialog/ndd-modal-dialog.test.ts
+++ b/src/components/status-and-feedback/modal-dialog/ndd-modal-dialog.test.ts
@@ -109,13 +109,12 @@ describe('ndd-modal-dialog', () => {
 		expect(inner?.getAttribute('icon-name')).toBe('check-mark-circle');
 	});
 
-	it('focuses the dialog__text heading on show()', async () => {
+	it('focuses the dialog on show()', async () => {
 		el = await fixture('<ndd-modal-dialog text="Bevestiging vereist"></ndd-modal-dialog>');
 		await waitForUpdate(el);
 		(el as NDDModalDialog).show();
-		const inner = el.shadowRoot!.querySelector('ndd-inline-dialog');
-		const heading = inner?.shadowRoot?.querySelector('h2.inline-dialog__text') as HTMLElement;
-		expect(document.activeElement === heading || inner?.shadowRoot?.activeElement === heading).toBe(true);
+		const dialog = el.shadowRoot!.querySelector('dialog')!;
+		expect(document.activeElement === dialog || el.shadowRoot!.activeElement === dialog).toBe(true);
 	});
 
 	it('inner ndd-inline-dialog receives heading-level="2"', async () => {
@@ -125,13 +124,12 @@ describe('ndd-modal-dialog', () => {
 		expect(inner?.getAttribute('heading-level')).toBe('2');
 	});
 
-	it('adds tabindex="-1" to dialog__text heading on show()', async () => {
-		el = await fixture('<ndd-modal-dialog text="Bevestiging vereist"></ndd-modal-dialog>');
+	it('respects autofocus attribute on slotted content', async () => {
+		el = await fixture('<ndd-modal-dialog><button slot="actions" autofocus>OK</button></ndd-modal-dialog>');
 		await waitForUpdate(el);
 		(el as NDDModalDialog).show();
-		const inner = el.shadowRoot!.querySelector('ndd-inline-dialog');
-		const heading = inner?.shadowRoot?.querySelector('.inline-dialog__text') as HTMLElement;
-		expect(heading.getAttribute('tabindex')).toBe('-1');
+		const button = el.querySelector<HTMLElement>('button')!;
+		expect(document.activeElement === button).toBe(true);
 	});
 
 	it('prevents default on cancel event and calls hide()', async () => {

--- a/src/components/status-and-feedback/modal-dialog/ndd-modal-dialog.ts
+++ b/src/components/status-and-feedback/modal-dialog/ndd-modal-dialog.ts
@@ -24,6 +24,7 @@ import { LitElement } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { modalDialogStyles } from './ndd-modal-dialog.styles.ts';
 import { modalDialogTemplate } from './ndd-modal-dialog.template.ts';
+import { isKeyboardMode } from '../../../utilities/keyboard-mode.js';
 import type { InlineDialogVariant } from '../inline-dialog/ndd-inline-dialog.ts';
 import '../inline-dialog/ndd-inline-dialog.ts';
 
@@ -61,24 +62,11 @@ export class NDDModalDialog extends LitElement {
 		// 1. autofocus element present — let the browser handle it natively
 		if (this.querySelector('[autofocus]')) return;
 
-		// 2. Focus the inline-dialog__text heading inside ndd-inline-dialog's shadow DOM
-		const inner = this.shadowRoot?.querySelector('ndd-inline-dialog');
-		const heading = inner?.shadowRoot?.querySelector<HTMLElement>('.inline-dialog__text') ?? null;
-
-		if (heading) {
-			const hadTabindex = heading.hasAttribute('tabindex');
-			if (!hadTabindex) heading.setAttribute('tabindex', '-1');
-			heading.focus();
-			if (!hadTabindex) {
-				heading.addEventListener('blur', () => {
-					heading.removeAttribute('tabindex');
-				}, { once: true });
-			}
-			return;
-		}
-
-		// 3. Fallback — focus the native dialog itself
-		this._dialog?.focus();
+		// 2. Focus the dialog — show focus ring only when opened via keyboard
+		const dialog = this._dialog;
+		if (!dialog) return;
+		dialog.classList.toggle('is-keyboard-focus', isKeyboardMode());
+		dialog.focus();
 	}
 
 	hide(): void {

--- a/src/components/status-and-feedback/modal-dialog/ndd-modal-dialog.ts
+++ b/src/components/status-and-feedback/modal-dialog/ndd-modal-dialog.ts
@@ -10,6 +10,7 @@
  * @attr {string}  icon-name        - Forwarded to ndd-inline-dialog; absent when not set
  * @attr {string}  text             - Forwarded to ndd-inline-dialog; main text
  * @attr {string}  supporting-text  - Forwarded to ndd-inline-dialog; supporting text
+ * @attr {string}  accessible-label - Accessible name for the dialog (aria-label); falls back to text
  *
  * @slot         - Optional custom content, forwarded to ndd-inline-dialog
  * @slot actions - ndd-button elements, forwarded to ndd-inline-dialog
@@ -43,6 +44,10 @@ export class NDDModalDialog extends LitElement {
 
 	@property({ type: String, reflect: true, attribute: 'supporting-text' })
 	supportingText = '';
+
+	/** Accessible name for the dialog — forwarded as aria-label. Falls back to text. */
+	@property({ type: String, attribute: 'accessible-label' })
+	accessibleLabel = '';
 
 	private _closing = false;
 

--- a/src/utilities/keyboard-mode.test.ts
+++ b/src/utilities/keyboard-mode.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+
+// Fresh import per test by resetting module state
+let isKeyboardMode: () => boolean;
+
+async function loadFresh() {
+	// Reset module state by re-importing
+	const mod = await import('./keyboard-mode.ts');
+	isKeyboardMode = mod.isKeyboardMode;
+}
+
+describe('isKeyboardMode', () => {
+	beforeEach(async () => {
+		await loadFresh();
+	});
+
+	it('returns false by default', () => {
+		expect(isKeyboardMode()).toBe(false);
+	});
+
+	it('returns true after Tab keydown', () => {
+		isKeyboardMode(); // init listeners
+		document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab' }));
+		expect(isKeyboardMode()).toBe(true);
+	});
+
+	it('returns true after ArrowDown keydown', () => {
+		isKeyboardMode();
+		document.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+		expect(isKeyboardMode()).toBe(true);
+	});
+
+	it('returns true after Enter keydown', () => {
+		isKeyboardMode();
+		document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+		expect(isKeyboardMode()).toBe(true);
+	});
+
+	it('returns false after mousedown', () => {
+		isKeyboardMode();
+		document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab' }));
+		expect(isKeyboardMode()).toBe(true);
+		document.dispatchEvent(new MouseEvent('mousedown'));
+		expect(isKeyboardMode()).toBe(false);
+	});
+
+	it('returns false after touchstart', () => {
+		isKeyboardMode();
+		document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab' }));
+		expect(isKeyboardMode()).toBe(true);
+		document.dispatchEvent(new Event('touchstart'));
+		expect(isKeyboardMode()).toBe(false);
+	});
+
+	it('does not set keyboard mode for unrelated keys', () => {
+		isKeyboardMode();
+		document.dispatchEvent(new KeyboardEvent('keydown', { key: 'a' }));
+		expect(isKeyboardMode()).toBe(false);
+	});
+});

--- a/src/utilities/keyboard-mode.test.ts
+++ b/src/utilities/keyboard-mode.test.ts
@@ -4,6 +4,7 @@ import { isKeyboardMode, _resetKeyboardModeForTesting } from './keyboard-mode.ts
 describe('isKeyboardMode', () => {
 	beforeEach(() => {
 		_resetKeyboardModeForTesting();
+		isKeyboardMode(); // re-register listeners
 	});
 
 	it('returns false by default', () => {

--- a/src/utilities/keyboard-mode.test.ts
+++ b/src/utilities/keyboard-mode.test.ts
@@ -1,17 +1,9 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-
-// Fresh import per test by resetting module state
-let isKeyboardMode: () => boolean;
-
-async function loadFresh() {
-	// Reset module state by re-importing
-	const mod = await import('./keyboard-mode.ts');
-	isKeyboardMode = mod.isKeyboardMode;
-}
+import { isKeyboardMode, _resetKeyboardModeForTesting } from './keyboard-mode.ts';
 
 describe('isKeyboardMode', () => {
-	beforeEach(async () => {
-		await loadFresh();
+	beforeEach(() => {
+		_resetKeyboardModeForTesting();
 	});
 
 	it('returns false by default', () => {
@@ -19,25 +11,21 @@ describe('isKeyboardMode', () => {
 	});
 
 	it('returns true after Tab keydown', () => {
-		isKeyboardMode(); // init listeners
 		document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab' }));
 		expect(isKeyboardMode()).toBe(true);
 	});
 
 	it('returns true after ArrowDown keydown', () => {
-		isKeyboardMode();
 		document.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
 		expect(isKeyboardMode()).toBe(true);
 	});
 
 	it('returns true after Enter keydown', () => {
-		isKeyboardMode();
 		document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
 		expect(isKeyboardMode()).toBe(true);
 	});
 
 	it('returns false after mousedown', () => {
-		isKeyboardMode();
 		document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab' }));
 		expect(isKeyboardMode()).toBe(true);
 		document.dispatchEvent(new MouseEvent('mousedown'));
@@ -45,7 +33,6 @@ describe('isKeyboardMode', () => {
 	});
 
 	it('returns false after touchstart', () => {
-		isKeyboardMode();
 		document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab' }));
 		expect(isKeyboardMode()).toBe(true);
 		document.dispatchEvent(new Event('touchstart'));
@@ -53,7 +40,6 @@ describe('isKeyboardMode', () => {
 	});
 
 	it('does not set keyboard mode for unrelated keys', () => {
-		isKeyboardMode();
 		document.dispatchEvent(new KeyboardEvent('keydown', { key: 'a' }));
 		expect(isKeyboardMode()).toBe(false);
 	});

--- a/src/utilities/keyboard-mode.ts
+++ b/src/utilities/keyboard-mode.ts
@@ -28,4 +28,5 @@ export function isKeyboardMode(): boolean {
 /** @internal Reset state for testing only. */
 export function _resetKeyboardModeForTesting(): void {
 	keyboardMode = false;
+	initialized = false;
 }

--- a/src/utilities/keyboard-mode.ts
+++ b/src/utilities/keyboard-mode.ts
@@ -6,7 +6,9 @@ function init(): void {
 	initialized = true;
 
 	document.addEventListener('keydown', (e: KeyboardEvent) => {
-		if (e.key === 'Tab') keyboardMode = true;
+		if (['Tab', 'ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight', 'Enter', ' ', 'Escape'].includes(e.key)) {
+			keyboardMode = true;
+		}
 	});
 
 	document.addEventListener('mousedown', () => {

--- a/src/utilities/keyboard-mode.ts
+++ b/src/utilities/keyboard-mode.ts
@@ -1,23 +1,26 @@
 let keyboardMode = false;
 let initialized = false;
+let controller: AbortController | null = null;
 
 function init(): void {
 	if (initialized) return;
 	initialized = true;
+	controller = new AbortController();
+	const { signal } = controller;
 
 	document.addEventListener('keydown', (e: KeyboardEvent) => {
 		if (['Tab', 'ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight', 'Enter', ' ', 'Escape'].includes(e.key)) {
 			keyboardMode = true;
 		}
-	});
+	}, { signal });
 
 	document.addEventListener('mousedown', () => {
 		keyboardMode = false;
-	});
+	}, { signal });
 
 	document.addEventListener('touchstart', () => {
 		keyboardMode = false;
-	}, { passive: true });
+	}, { passive: true, signal });
 }
 
 export function isKeyboardMode(): boolean {
@@ -27,6 +30,8 @@ export function isKeyboardMode(): boolean {
 
 /** @internal Reset state for testing only. */
 export function _resetKeyboardModeForTesting(): void {
+	controller?.abort();
+	controller = null;
 	keyboardMode = false;
 	initialized = false;
 }

--- a/src/utilities/keyboard-mode.ts
+++ b/src/utilities/keyboard-mode.ts
@@ -24,3 +24,8 @@ export function isKeyboardMode(): boolean {
 	init();
 	return keyboardMode;
 }
+
+/** @internal Reset state for testing only. */
+export function _resetKeyboardModeForTesting(): void {
+	keyboardMode = false;
+}

--- a/src/utilities/keyboard-mode.ts
+++ b/src/utilities/keyboard-mode.ts
@@ -1,0 +1,24 @@
+let keyboardMode = false;
+let initialized = false;
+
+function init(): void {
+	if (initialized) return;
+	initialized = true;
+
+	document.addEventListener('keydown', (e: KeyboardEvent) => {
+		if (e.key === 'Tab') keyboardMode = true;
+	});
+
+	document.addEventListener('mousedown', () => {
+		keyboardMode = false;
+	});
+
+	document.addEventListener('touchstart', () => {
+		keyboardMode = false;
+	}, { passive: true });
+}
+
+export function isKeyboardMode(): boolean {
+	init();
+	return keyboardMode;
+}

--- a/src/utilities/popover-guard.ts
+++ b/src/utilities/popover-guard.ts
@@ -6,4 +6,4 @@
  * first (closing the popover), then the click handler fires and would
  * reopen it. This guard prevents reopening within the threshold.
  */
-export const POPOVER_REOPEN_GUARD_MS = 50;
+export const POPOVER_REOPEN_GUARD_MS = 100;

--- a/src/utilities/popover-guard.ts
+++ b/src/utilities/popover-guard.ts
@@ -1,0 +1,9 @@
+/**
+ * Minimum ms between popover close and reopen to prevent iOS
+ * touch light-dismiss from immediately reopening the popover.
+ *
+ * On iOS, tapping the anchor to close a popover triggers light dismiss
+ * first (closing the popover), then the click handler fires and would
+ * reopen it. This guard prevents reopening within the threshold.
+ */
+export const POPOVER_REOPEN_GUARD_MS = 50;


### PR DESCRIPTION
- **Indicator → pseudo-elements**: Replace indicator divs/spans with `::before` in segmented-control, tab-bar, pagination, list-item
- **Webkit tap highlight**: Add `-webkit-tap-highlight-color: transparent` to 22 interactive components
- **Modal dialog padding**: Responsive padding (16px sm, 24px md+)
- **Menu touch toggle**: Fix light dismiss race condition on iOS
- **Focus management**: Simplify menu/sheet/modal-dialog focus — focus container on open, keyboard-only focus ring via shared `isKeyboardMode()` utility
- **Menu highlight**: No highlight on open (filter still highlights for combobox), clear on mouseleave
- **Tooltip integration**: Add tooltip to icon-only segmented-control, toggle-button, tab-bar items, and document-tab-bar short modus
- **Tooltip placement**: Default bottom (mouse), top on touch devices
- **Document tab bar**: Fix touch drag (`touch-action: pan-y`), overflow menu toggle, selected drag clone styling, updated overflow button translation
- **List no-dividers**: New `no-dividers` attribute to hide dividers

## Test plan

- [ ] Verify indicator hover/selected/focus states on segmented-control, tab-bar, pagination, list-item
- [ ] Test menu open/close on iOS (touch toggle)
- [ ] Test keyboard focus ring on menu, sheet, modal-dialog (Tab + Enter)
- [ ] Test tooltip on icon-only components and short document-tab-bar items
- [ ] Test document-tab-bar drag on touch devices
- [ ] Test list with `no-dividers` attribute