### PR TITLE
fix: prebuild-storybook hook, remove stale review prefix, wordmark styling fixes

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -73,7 +73,6 @@ jobs:
 
             - Are semantic variables preferred over primitives?
             - No fallback values on CSS variables (strict validation)?
-            - Override hooks use `--rr-*` prefix?
             - Context hooks use `--context-*` prefix?
             - Internal variables use `--_*` prefix?
 

--- a/package.json
+++ b/package.json
@@ -309,6 +309,7 @@
     "sb:stop": "node scripts/storybook-manager.js stop",
     "sb:status": "node scripts/storybook-manager.js status",
     "sb:stop-all": "node scripts/storybook-manager.js stop-all",
+    "prebuild-storybook": "npm run build:icons",
     "build-storybook": "storybook build",
     "lint": "eslint src/",
     "lint:fix": "eslint src/ --fix",

--- a/src/components/navigation/top-navigation-bar/ndd-top-navigation-bar.styles.ts
+++ b/src/components/navigation/top-navigation-bar/ndd-top-navigation-bar.styles.ts
@@ -109,7 +109,6 @@ export const styles = css`
 	}
 
 	a.top-navigation-bar__logo-and-wordmark {
-		color: inherit;
 		text-decoration: none;
 	}
 
@@ -124,14 +123,14 @@ export const styles = css`
 		grid-column: 3;
 		display: flex;
 		flex-direction: column;
-		height: calc(var(--_logo-width) * 2);
+		min-height: calc(var(--_logo-width) * 2);
 		color: var(--_wordmark-content-color);
 	}
 
 	.top-navigation-bar__wordmark-spacer {
-		flex-grow: 1;
-		flex-shrink: 1;
-		flex-basis: 50%;
+		flex-grow: 0;
+		flex-shrink: 0;
+		height: var(--_logo-width);
 	}
 
 	.top-navigation-bar__wordmark-content {


### PR DESCRIPTION
## Summary

- Add `prebuild-storybook` hook so `npm run build-storybook` generates icons/logo before building (fixes `Could not resolve "./ndd-icon-registry.js"` error)
- Remove outdated `--rr-*` override hook prefix from Claude code review prompt
- Fix wordmark spacing: use fixed-height spacer instead of flex-grow, `min-height` instead of `height`, remove unnecessary `color: inherit`

## Test plan

- [ ] Run `npm run build-storybook` on a fresh checkout (no prior `npm run build`)
- [ ] Verify wordmark alignment in Storybook top-navigation-bar stories