### PR TITLE
feat(inputs): smaller size variants + password-field fix

### DIFF
--- a/src/assets/styles/settings.css
+++ b/src/assets/styles/settings.css
@@ -830,6 +830,7 @@
 
 	--semantics-input-fields-border-thickness: var(--primitives-space-2);
 	--semantics-input-fields-border-color: light-dark(var(--primitives-color-neutral-550), var(--primitives-color-neutral-650));
+	--semantics-input-fields-border: var(--semantics-input-fields-border-thickness) solid var(--semantics-input-fields-border-color);
 	--semantics-input-fields-background-color: var(--semantics-surfaces-background-color);
 	--semantics-input-fields-placeholder-color: light-dark(var(--primitives-color-neutral-550), var(--primitives-color-neutral-650));
 	--semantics-input-fields-is-valid-border-color: light-dark(var(--primitives-color-success-550), var(--primitives-color-success-650));
@@ -840,6 +841,8 @@
 	--semantics-input-fields-is-read-only-border-color: light-dark(var(--primitives-color-neutral-50), var(--primitives-color-neutral-150));
 	--semantics-input-fields-is-autofill-background-color: light-dark(var(--primitives-color-mark-50), var(--primitives-color-mark-150));
 
+	--semantics-input-fields-xs-text-font: var(--primitives-font-body-xs-regular-flat);
+	--semantics-input-fields-xs-mask-font: 400 var(--primitives-font-size-80)/var(--primitives-line-height-flat) Verdana, system-ui;
 	--semantics-input-fields-sm-text-font: var(--primitives-font-body-sm-regular-flat);
 	--semantics-input-fields-sm-mask-font: 400 var(--primitives-font-size-90)/var(--primitives-line-height-flat) Verdana, system-ui;
 	--semantics-input-fields-md-text-font: var(--primitives-font-body-md-regular-flat);

--- a/src/assets/styles/settings.css
+++ b/src/assets/styles/settings.css
@@ -843,6 +843,9 @@
 
 	--semantics-input-fields-xs-text-font: var(--primitives-font-body-xs-regular-flat);
 	--semantics-input-fields-xs-mask-font: 400 var(--primitives-font-size-80)/var(--primitives-line-height-flat) Verdana, system-ui;
+	/* Font for the invisible native <select>: Safari derives the option popup size from this,
+	   and iOS Safari auto-zooms inputs below 16px — so this must stay >= 16px. */
+	--semantics-input-fields-native-select-font: var(--primitives-font-body-sm-regular-snug);
 	--semantics-input-fields-sm-text-font: var(--primitives-font-body-sm-regular-flat);
 	--semantics-input-fields-sm-mask-font: 400 var(--primitives-font-size-90)/var(--primitives-line-height-flat) Verdana, system-ui;
 	--semantics-input-fields-md-text-font: var(--primitives-font-body-md-regular-flat);

--- a/src/assets/styles/settings.css
+++ b/src/assets/styles/settings.css
@@ -842,7 +842,6 @@
 	--semantics-input-fields-is-autofill-background-color: light-dark(var(--primitives-color-mark-50), var(--primitives-color-mark-150));
 
 	--semantics-input-fields-xs-text-font: var(--primitives-font-body-xs-regular-flat);
-	--semantics-input-fields-xs-mask-font: 400 var(--primitives-font-size-80)/var(--primitives-line-height-flat) Verdana, system-ui;
 	/* Font for the invisible native <select>: Safari derives the option popup size from this,
 	   and iOS Safari auto-zooms inputs below 16px — so this must stay >= 16px. */
 	--semantics-input-fields-native-select-font: var(--primitives-font-body-sm-regular-snug);
@@ -850,6 +849,10 @@
 	--semantics-input-fields-sm-mask-font: 400 var(--primitives-font-size-90)/var(--primitives-line-height-flat) Verdana, system-ui;
 	--semantics-input-fields-md-text-font: var(--primitives-font-body-md-regular-flat);
 	--semantics-input-fields-md-mask-font: 400 var(--primitives-font-size-100)/var(--primitives-line-height-flat) Verdana, system-ui;
+
+	--semantics-input-fields-xs-validation-icon-size: var(--primitives-space-16);
+	--semantics-input-fields-sm-validation-icon-size: var(--primitives-space-20);
+	--semantics-input-fields-md-validation-icon-size: var(--primitives-space-24);
 
 	/* ## Grab handles */
 

--- a/src/components/inputs/combo-box/combo-box.stories.js
+++ b/src/components/inputs/combo-box/combo-box.stories.js
@@ -151,14 +151,14 @@ AlleLanden.parameters = { controls: { disable: true } };
 
 export const AlleToestanden = () => html`
 	<div style="display: flex; flex-direction: column; gap: 1rem;">
-		<nldd-combo-box placeholder="Zoek een land" size="md">
+		<nldd-combo-box placeholder="Zoek een land" size="sm">
 			<nldd-menu empty-text="Geen resultaten">
 				<nldd-menu-item text="Nederland" value="nl"></nldd-menu-item>
 				<nldd-menu-item text="België" value="be"></nldd-menu-item>
 				<nldd-menu-item text="Duitsland" value="de"></nldd-menu-item>
 			</nldd-menu>
 		</nldd-combo-box>
-		<nldd-combo-box placeholder="Zoek een land" size="sm">
+		<nldd-combo-box placeholder="Zoek een land" size="md">
 			<nldd-menu empty-text="Geen resultaten">
 				<nldd-menu-item text="Nederland" value="nl"></nldd-menu-item>
 				<nldd-menu-item text="België" value="be"></nldd-menu-item>

--- a/src/components/inputs/combo-box/combo-box.stories.js
+++ b/src/components/inputs/combo-box/combo-box.stories.js
@@ -29,6 +29,12 @@ export default {
 			description: 'Placeholder tekst',
 			table: { defaultValue: { summary: '' } },
 		},
+		size: {
+			control: 'select',
+			options: ['sm', 'md'],
+			description: 'Grootte van het veld',
+			table: { defaultValue: { summary: 'md' } },
+		},
 		disabled: {
 			control: 'boolean',
 			description: 'Uitgeschakelde toestand',
@@ -42,6 +48,7 @@ export default {
 	args: {
 		value: '',
 		placeholder: 'Zoek een land',
+		size: 'md',
 		disabled: false,
 		name: '',
 	},
@@ -50,6 +57,7 @@ export default {
 const Template = (args) => html`
 	<nldd-combo-box
 		placeholder=${args.placeholder}
+		size=${args.size}
 		?disabled=${args.disabled}
 		name=${args.name}
 	>
@@ -143,7 +151,14 @@ AlleLanden.parameters = { controls: { disable: true } };
 
 export const AlleToestanden = () => html`
 	<div style="display: flex; flex-direction: column; gap: 1rem;">
-		<nldd-combo-box placeholder="Zoek een land">
+		<nldd-combo-box placeholder="Zoek een land" size="md">
+			<nldd-menu empty-text="Geen resultaten">
+				<nldd-menu-item text="Nederland" value="nl"></nldd-menu-item>
+				<nldd-menu-item text="België" value="be"></nldd-menu-item>
+				<nldd-menu-item text="Duitsland" value="de"></nldd-menu-item>
+			</nldd-menu>
+		</nldd-combo-box>
+		<nldd-combo-box placeholder="Zoek een land" size="sm">
 			<nldd-menu empty-text="Geen resultaten">
 				<nldd-menu-item text="Nederland" value="nl"></nldd-menu-item>
 				<nldd-menu-item text="België" value="be"></nldd-menu-item>

--- a/src/components/inputs/combo-box/combo-box.stories.js
+++ b/src/components/inputs/combo-box/combo-box.stories.js
@@ -35,6 +35,16 @@ export default {
 			description: 'Grootte van het veld',
 			table: { defaultValue: { summary: 'md' } },
 		},
+		valid: {
+			control: 'boolean',
+			description: 'Markeert het veld als geldig',
+			table: { defaultValue: { summary: false } },
+		},
+		invalid: {
+			control: 'boolean',
+			description: 'Markeert het veld als ongeldig',
+			table: { defaultValue: { summary: false } },
+		},
 		disabled: {
 			control: 'boolean',
 			description: 'Uitgeschakelde toestand',
@@ -49,6 +59,8 @@ export default {
 		value: '',
 		placeholder: 'Zoek een land',
 		size: 'md',
+		valid: false,
+		invalid: false,
 		disabled: false,
 		name: '',
 	},
@@ -58,6 +70,8 @@ const Template = (args) => html`
 	<nldd-combo-box
 		placeholder=${args.placeholder}
 		size=${args.size}
+		?valid=${args.valid}
+		?invalid=${args.invalid}
 		?disabled=${args.disabled}
 		name=${args.name}
 	>
@@ -163,6 +177,18 @@ export const AlleToestanden = () => html`
 				<nldd-menu-item text="Nederland" value="nl"></nldd-menu-item>
 				<nldd-menu-item text="België" value="be"></nldd-menu-item>
 				<nldd-menu-item text="Duitsland" value="de"></nldd-menu-item>
+			</nldd-menu>
+		</nldd-combo-box>
+		<nldd-combo-box placeholder="Zoek een land" valid>
+			<nldd-menu empty-text="Geen resultaten">
+				<nldd-menu-item text="Nederland" value="nl"></nldd-menu-item>
+				<nldd-menu-item text="België" value="be"></nldd-menu-item>
+			</nldd-menu>
+		</nldd-combo-box>
+		<nldd-combo-box placeholder="Zoek een land" invalid>
+			<nldd-menu empty-text="Geen resultaten">
+				<nldd-menu-item text="Nederland" value="nl"></nldd-menu-item>
+				<nldd-menu-item text="België" value="be"></nldd-menu-item>
 			</nldd-menu>
 		</nldd-combo-box>
 		<nldd-combo-box placeholder="Zoek een land" disabled>

--- a/src/components/inputs/combo-box/combo-box.styles.ts
+++ b/src/components/inputs/combo-box/combo-box.styles.ts
@@ -7,6 +7,7 @@ export const comboBoxStyles = css`
 
 	:host {
 		display: block;
+		--_background-color: var(--semantics-input-fields-background-color);
 		-webkit-tap-highlight-color: transparent;
 	}
 
@@ -28,11 +29,19 @@ export const comboBoxStyles = css`
 		align-items: center;
 		box-sizing: border-box;
 		width: 100%;
-		min-height: var(--semantics-controls-md-min-size);
 		background-color: var(--_background-color);
-		border: var(--semantics-input-fields-border-thickness) solid var(--semantics-input-fields-border-color);
+		border: var(--semantics-input-fields-border);
+	}
+
+	:host([size='sm']) .combo-box {
+		min-height: var(--semantics-controls-sm-min-size);
+		border-radius: var(--semantics-controls-sm-corner-radius);
+	}
+
+	:host([size='md']) .combo-box,
+	:host(:not([size])) .combo-box {
+		min-height: var(--semantics-controls-md-min-size);
 		border-radius: var(--semantics-controls-md-corner-radius);
-		--_background-color: var(--semantics-input-fields-background-color);
 	}
 
 	.combo-box:has(input:-webkit-autofill),
@@ -53,14 +62,23 @@ export const comboBoxStyles = css`
 		border: none;
 		background: transparent;
 		margin: 0;
-		padding: 0 calc(var(--semantics-controls-md-inline-padding) - var(--semantics-input-fields-border-thickness));
 		outline: none;
 		box-sizing: border-box;
 		flex: 1;
 		min-width: 0;
 		width: 100%;
-		font: var(--semantics-input-fields-md-text-font);
 		color: var(--semantics-content-color);
+	}
+
+	:host([size='sm']) .combo-box__input {
+		padding: 0 calc(var(--semantics-controls-sm-inline-padding) - var(--semantics-input-fields-border-thickness));
+		font: var(--semantics-input-fields-sm-text-font);
+	}
+
+	:host([size='md']) .combo-box__input,
+	:host(:not([size])) .combo-box__input {
+		padding: 0 calc(var(--semantics-controls-md-inline-padding) - var(--semantics-input-fields-border-thickness));
+		font: var(--semantics-input-fields-md-text-font);
 	}
 
 	.combo-box__input::placeholder {
@@ -80,6 +98,14 @@ export const comboBoxStyles = css`
 		flex-shrink: 0;
 		align-items: center;
 		gap: var(--primitives-space-6);
+	}
+
+	:host([size='sm']) .combo-box__actions {
+		padding-right: calc((var(--semantics-controls-sm-min-size) - var(--semantics-controls-xs-min-size)) / 2 - var(--semantics-input-fields-border-thickness));
+	}
+
+	:host([size='md']) .combo-box__actions,
+	:host(:not([size])) .combo-box__actions {
 		padding-right: calc((var(--semantics-controls-md-min-size) - var(--semantics-controls-sm-min-size)) / 2 - var(--semantics-input-fields-border-thickness));
 	}
 

--- a/src/components/inputs/combo-box/combo-box.styles.ts
+++ b/src/components/inputs/combo-box/combo-box.styles.ts
@@ -8,6 +8,7 @@ export const comboBoxStyles = css`
 	:host {
 		display: block;
 		--_background-color: var(--semantics-input-fields-background-color);
+		--_z-index-button-focus: 1;
 		-webkit-tap-highlight-color: transparent;
 	}
 
@@ -44,6 +45,14 @@ export const comboBoxStyles = css`
 		border-radius: var(--semantics-controls-md-corner-radius);
 	}
 
+	:host([valid]) .combo-box {
+		border-color: var(--semantics-input-fields-is-valid-border-color);
+	}
+
+	:host([invalid]) .combo-box {
+		border-color: var(--semantics-input-fields-is-invalid-border-color);
+	}
+
 	.combo-box:has(input:-webkit-autofill),
 	.combo-box:has(input:autofill) {
 		--_background-color: var(--semantics-input-fields-is-autofill-background-color);
@@ -71,13 +80,13 @@ export const comboBoxStyles = css`
 	}
 
 	:host([size='sm']) .combo-box__input {
-		padding: 0 calc(var(--semantics-controls-sm-inline-padding) - var(--semantics-input-fields-border-thickness));
+		padding-left: calc(var(--semantics-controls-sm-inline-padding) - var(--semantics-input-fields-border-thickness));
 		font: var(--semantics-input-fields-sm-text-font);
 	}
 
 	:host([size='md']) .combo-box__input,
 	:host(:not([size])) .combo-box__input {
-		padding: 0 calc(var(--semantics-controls-md-inline-padding) - var(--semantics-input-fields-border-thickness));
+		padding-left: calc(var(--semantics-controls-md-inline-padding) - var(--semantics-input-fields-border-thickness));
 		font: var(--semantics-input-fields-md-text-font);
 	}
 
@@ -91,27 +100,90 @@ export const comboBoxStyles = css`
 	}
 
 
-	/* # Actions */
+	/* # Input fade */
 
-	.combo-box__actions {
+	.combo-box__input-fade {
+		position: relative;
+		flex-shrink: 0;
+		align-self: stretch;
+		width: 0;
+	}
+
+	.combo-box__input-fade::after {
+		content: '';
+		position: absolute;
+		top: 0;
+		bottom: 0;
+		right: 0;
+		width: var(--primitives-space-8);
+		background: linear-gradient(90deg, color-mix(in oklch, var(--_background-color) 0%, transparent) 0%, var(--_background-color) 100%);
+		pointer-events: none;
+	}
+
+
+	/* # End */
+
+	.combo-box__end {
 		display: flex;
 		flex-shrink: 0;
 		align-items: center;
-		gap: var(--primitives-space-6);
 	}
 
-	:host([size='sm']) .combo-box__actions {
+	:host([size='sm']) .combo-box__end {
 		padding-right: calc((var(--semantics-controls-sm-min-size) - var(--semantics-controls-xs-min-size)) / 2 - var(--semantics-input-fields-border-thickness));
 	}
 
-	:host([size='md']) .combo-box__actions,
-	:host(:not([size])) .combo-box__actions {
+	:host([size='md']) .combo-box__end,
+	:host(:not([size])) .combo-box__end {
 		padding-right: calc((var(--semantics-controls-md-min-size) - var(--semantics-controls-sm-min-size)) / 2 - var(--semantics-input-fields-border-thickness));
 	}
 
-	.combo-box__clear-action:focus-within,
-	.combo-box__picker:focus-within {
+
+	/* # Clear button */
+
+	.combo-box__clear-button:focus-within {
 		position: relative;
-		z-index: 1;
+		z-index: var(--_z-index-button-focus);
+	}
+
+
+	/* # Validation icon */
+
+	.combo-box__validation-icon-area {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		flex-shrink: 0;
+		height: 100%;
+	}
+
+	:host([valid]) .combo-box__validation-icon-area {
+		color: var(--semantics-input-fields-is-valid-icon-color);
+	}
+
+	:host([invalid]) .combo-box__validation-icon-area {
+		color: var(--semantics-input-fields-is-invalid-icon-color);
+	}
+
+	:host([size='sm']) .combo-box__validation-icon {
+		width: var(--semantics-input-fields-sm-validation-icon-size);
+		height: var(--semantics-input-fields-sm-validation-icon-size);
+	}
+
+	:host([size='md']) .combo-box__validation-icon,
+	:host(:not([size])) .combo-box__validation-icon {
+		width: var(--semantics-input-fields-md-validation-icon-size);
+		height: var(--semantics-input-fields-md-validation-icon-size);
+	}
+
+	/* # Picker button */
+
+	.combo-box__picker-button {
+		margin-left: var(--primitives-space-6);
+	}
+
+	.combo-box__picker-button:focus-within {
+		position: relative;
+		z-index: var(--_z-index-button-focus);
 	}
 `;

--- a/src/components/inputs/combo-box/combo-box.template.ts
+++ b/src/components/inputs/combo-box/combo-box.template.ts
@@ -1,6 +1,31 @@
 import { html, nothing, TemplateResult } from 'lit';
 import type { NLDDComboBox } from './combo-box.js';
 import '../../actions/icon-button/icon-button.js';
+import '../../content/icon/icon.js';
+
+function renderValidationIcon(component: NLDDComboBox): TemplateResult | typeof nothing {
+	if (component.valid) {
+		return html`
+			<div class="combo-box__validation-icon-area">
+				<nldd-icon class="combo-box__validation-icon"
+					name="valid"
+					aria-hidden="true"
+				></nldd-icon>
+			</div>
+		`;
+	}
+	if (component.invalid) {
+		return html`
+			<div class="combo-box__validation-icon-area">
+				<nldd-icon class="combo-box__validation-icon"
+					name="invalid"
+					aria-hidden="true"
+				></nldd-icon>
+			</div>
+		`;
+	}
+	return nothing;
+}
 
 export function comboBoxTemplate(component: NLDDComboBox): TemplateResult {
 	const iconButtonSize = component.size === 'sm' ? 'xs' : 'sm';
@@ -16,6 +41,7 @@ export function comboBoxTemplate(component: NLDDComboBox): TemplateResult {
 				aria-autocomplete="list"
 				aria-haspopup="listbox"
 				aria-activedescendant=${component._highlightedId || nothing}
+				aria-invalid=${component.invalid ? 'true' : nothing}
 				.value=${component._displayValue}
 				placeholder=${component.placeholder || nothing}
 				?disabled=${component.disabled}
@@ -24,9 +50,10 @@ export function comboBoxTemplate(component: NLDDComboBox): TemplateResult {
 				@keydown=${component._handleKeydown}
 				@blur=${component._handleBlur}
 			>
-			<div class="combo-box__actions">
+			<div class="combo-box__input-fade"></div>
+			<div class="combo-box__end">
 				${component._displayValue ? html`
-					<div class="combo-box__clear-action">
+					<div class="combo-box__clear-button">
 						<nldd-icon-button
 							variant="neutral-transparent"
 							size=${iconButtonSize}
@@ -37,7 +64,8 @@ export function comboBoxTemplate(component: NLDDComboBox): TemplateResult {
 						></nldd-icon-button>
 					</div>
 				` : nothing}
-				<div class="combo-box__picker">
+				${renderValidationIcon(component)}
+				<div class="combo-box__picker-button">
 					<nldd-icon-button
 						variant="neutral-tinted"
 						size=${iconButtonSize}

--- a/src/components/inputs/combo-box/combo-box.template.ts
+++ b/src/components/inputs/combo-box/combo-box.template.ts
@@ -4,21 +4,21 @@ import '../../actions/icon-button/icon-button.js';
 import '../../content/icon/icon.js';
 
 function renderValidationIcon(component: NLDDComboBox): TemplateResult | typeof nothing {
-	if (component.valid) {
-		return html`
-			<div class="combo-box__validation-icon-area">
-				<nldd-icon class="combo-box__validation-icon"
-					name="valid"
-					aria-hidden="true"
-				></nldd-icon>
-			</div>
-		`;
-	}
 	if (component.invalid) {
 		return html`
 			<div class="combo-box__validation-icon-area">
 				<nldd-icon class="combo-box__validation-icon"
 					name="invalid"
+					aria-hidden="true"
+				></nldd-icon>
+			</div>
+		`;
+	}
+	if (component.valid) {
+		return html`
+			<div class="combo-box__validation-icon-area">
+				<nldd-icon class="combo-box__validation-icon"
+					name="valid"
 					aria-hidden="true"
 				></nldd-icon>
 			</div>

--- a/src/components/inputs/combo-box/combo-box.template.ts
+++ b/src/components/inputs/combo-box/combo-box.template.ts
@@ -3,6 +3,8 @@ import type { NLDDComboBox } from './combo-box.js';
 import '../../actions/icon-button/icon-button.js';
 
 export function comboBoxTemplate(component: NLDDComboBox): TemplateResult {
+	const iconButtonSize = component.size === 'sm' ? 'xs' : 'sm';
+
 	return html`
 		<div class="combo-box">
 			<input class="combo-box__input"
@@ -27,7 +29,7 @@ export function comboBoxTemplate(component: NLDDComboBox): TemplateResult {
 					<div class="combo-box__clear-action">
 						<nldd-icon-button
 							variant="neutral-transparent"
-							size="sm"
+							size=${iconButtonSize}
 							icon="dismiss"
 							text=${component._t('components.combo-box.clear-action')}
 							?disabled=${component.disabled}
@@ -38,7 +40,7 @@ export function comboBoxTemplate(component: NLDDComboBox): TemplateResult {
 				<div class="combo-box__picker">
 					<nldd-icon-button
 						variant="neutral-tinted"
-						size="sm"
+						size=${iconButtonSize}
 						icon="chevron-down"
 						text=${component._t('components.combo-box.open-menu-action')}
 						?disabled=${component.disabled}

--- a/src/components/inputs/combo-box/combo-box.test.ts
+++ b/src/components/inputs/combo-box/combo-box.test.ts
@@ -67,6 +67,14 @@ describe('nldd-combo-box – validation', () => {
 		await waitForUpdate(el);
 		expect(el.shadowRoot!.querySelector('input')!.getAttribute('aria-invalid')).toBe('true');
 	});
+
+	it('removes aria-invalid when invalid is cleared', async () => {
+		el = await fixture<NLDDComboBox>('<nldd-combo-box invalid></nldd-combo-box>');
+		await waitForUpdate(el);
+		el.invalid = false;
+		await waitForUpdate(el);
+		expect(el.shadowRoot!.querySelector('input')!.hasAttribute('aria-invalid')).toBe(false);
+	});
 });
 
 

--- a/src/components/inputs/combo-box/combo-box.test.ts
+++ b/src/components/inputs/combo-box/combo-box.test.ts
@@ -32,6 +32,45 @@ describe('nldd-combo-box', () => {
 
 
 /* ============================================================
+   Validation
+   ============================================================ */
+
+describe('nldd-combo-box – validation', () => {
+	let el: NLDDComboBox;
+
+	afterEach(() => {
+		if (el) cleanup(el);
+	});
+
+	it('renders no validation icon by default', async () => {
+		el = await fixture<NLDDComboBox>('<nldd-combo-box></nldd-combo-box>');
+		await waitForUpdate(el);
+		expect(el.shadowRoot!.querySelector('.combo-box__validation-icon-area')).toBeNull();
+	});
+
+	it('renders a valid icon when valid', async () => {
+		el = await fixture<NLDDComboBox>('<nldd-combo-box valid></nldd-combo-box>');
+		await waitForUpdate(el);
+		const icon = el.shadowRoot!.querySelector('.combo-box__validation-icon')!;
+		expect(icon.getAttribute('name')).toBe('valid');
+	});
+
+	it('renders an invalid icon when invalid', async () => {
+		el = await fixture<NLDDComboBox>('<nldd-combo-box invalid></nldd-combo-box>');
+		await waitForUpdate(el);
+		const icon = el.shadowRoot!.querySelector('.combo-box__validation-icon')!;
+		expect(icon.getAttribute('name')).toBe('invalid');
+	});
+
+	it('sets aria-invalid on the input when invalid', async () => {
+		el = await fixture<NLDDComboBox>('<nldd-combo-box invalid></nldd-combo-box>');
+		await waitForUpdate(el);
+		expect(el.shadowRoot!.querySelector('input')!.getAttribute('aria-invalid')).toBe('true');
+	});
+});
+
+
+/* ============================================================
    Size
    ============================================================ */
 
@@ -55,16 +94,16 @@ describe('nldd-combo-box – size', () => {
 	});
 
 	it('renders sm icon buttons when size is md', async () => {
-		el = await fixture<NLDDComboBox>('<nldd-combo-box></nldd-combo-box>');
+		el = await fixture<NLDDComboBox>('<nldd-combo-box size="md"></nldd-combo-box>');
 		await waitForUpdate(el);
-		const picker = el.shadowRoot!.querySelector('.combo-box__picker nldd-icon-button')!;
+		const picker = el.shadowRoot!.querySelector('.combo-box__picker-button nldd-icon-button')!;
 		expect(picker.getAttribute('size')).toBe('sm');
 	});
 
 	it('renders xs icon buttons when size is sm', async () => {
 		el = await fixture<NLDDComboBox>('<nldd-combo-box size="sm"></nldd-combo-box>');
 		await waitForUpdate(el);
-		const picker = el.shadowRoot!.querySelector('.combo-box__picker nldd-icon-button')!;
+		const picker = el.shadowRoot!.querySelector('.combo-box__picker-button nldd-icon-button')!;
 		expect(picker.getAttribute('size')).toBe('xs');
 	});
 });
@@ -192,7 +231,7 @@ describe('nldd-combo-box – clear', () => {
 	it('does not render clear button when display value is empty', async () => {
 		el = await fixture<NLDDComboBox>('<nldd-combo-box></nldd-combo-box>');
 		await waitForUpdate(el);
-		expect(el.shadowRoot!.querySelector('.combo-box__clear-action')).toBeNull();
+		expect(el.shadowRoot!.querySelector('.combo-box__clear-button')).toBeNull();
 	});
 
 	it('renders clear button when there is a display value', async () => {
@@ -202,7 +241,7 @@ describe('nldd-combo-box – clear', () => {
 		(input as any).value = 'Ned';
 		input.dispatchEvent(new Event('input', { bubbles: true }));
 		await waitForUpdate(el);
-		expect(el.shadowRoot!.querySelector('.combo-box__clear-action')).not.toBeNull();
+		expect(el.shadowRoot!.querySelector('.combo-box__clear-button')).not.toBeNull();
 	});
 
 	it('clears value, fires change event and refocuses input on clear click', async () => {
@@ -217,7 +256,7 @@ describe('nldd-combo-box – clear', () => {
 		let changeDetail: any;
 		el.addEventListener('change', ((e: CustomEvent) => { changeDetail = e.detail; }) as EventListener);
 
-		const clearButton = el.shadowRoot!.querySelector<HTMLElement>('.combo-box__clear-action nldd-icon-button')!;
+		const clearButton = el.shadowRoot!.querySelector<HTMLElement>('.combo-box__clear-button nldd-icon-button')!;
 		clearButton.click();
 		await waitForUpdate(el);
 

--- a/src/components/inputs/combo-box/combo-box.test.ts
+++ b/src/components/inputs/combo-box/combo-box.test.ts
@@ -32,6 +32,45 @@ describe('nldd-combo-box', () => {
 
 
 /* ============================================================
+   Size
+   ============================================================ */
+
+describe('nldd-combo-box – size', () => {
+	let el: NLDDComboBox;
+
+	afterEach(() => {
+		if (el) cleanup(el);
+	});
+
+	it('defaults size to md', async () => {
+		el = await fixture<NLDDComboBox>('<nldd-combo-box></nldd-combo-box>');
+		await waitForUpdate(el);
+		expect(el.size).toBe('md');
+	});
+
+	it('reflects size attribute to host', async () => {
+		el = await fixture<NLDDComboBox>('<nldd-combo-box size="sm"></nldd-combo-box>');
+		await waitForUpdate(el);
+		expect(el.getAttribute('size')).toBe('sm');
+	});
+
+	it('renders sm icon buttons when size is md', async () => {
+		el = await fixture<NLDDComboBox>('<nldd-combo-box></nldd-combo-box>');
+		await waitForUpdate(el);
+		const picker = el.shadowRoot!.querySelector('.combo-box__picker nldd-icon-button')!;
+		expect(picker.getAttribute('size')).toBe('sm');
+	});
+
+	it('renders xs icon buttons when size is sm', async () => {
+		el = await fixture<NLDDComboBox>('<nldd-combo-box size="sm"></nldd-combo-box>');
+		await waitForUpdate(el);
+		const picker = el.shadowRoot!.querySelector('.combo-box__picker nldd-icon-button')!;
+		expect(picker.getAttribute('size')).toBe('xs');
+	});
+});
+
+
+/* ============================================================
    ARIA
    ============================================================ */
 

--- a/src/components/inputs/combo-box/combo-box.ts
+++ b/src/components/inputs/combo-box/combo-box.ts
@@ -14,6 +14,7 @@
  * @element nldd-combo-box
  * @attr {string}  value        - The selected form value
  * @attr {string}  placeholder  - Placeholder text for the input
+ * @attr {string}  size         - Size: 'sm' | 'md' (default: 'md')
  * @attr {boolean} disabled     - Disabled state
  * @attr {string}  name         - Input name for form submission
  * @attr {string}  accessible-label - Accessible label forwarded as aria-label to the input. Required for screen reader accessibility.
@@ -51,6 +52,7 @@ import '../../lists-and-menus/menu/menu.js';
 import '../../actions/icon-button/icon-button.js';
 import '../../content/icon/icon.js';
 
+export type ComboBoxSize = 'sm' | 'md';
 
 @customElement('nldd-combo-box')
 export class NLDDComboBox extends LitElement {
@@ -61,6 +63,9 @@ export class NLDDComboBox extends LitElement {
 
 	@property({ type: String })
 	placeholder = '';
+
+	@property({ type: String, reflect: true })
+	size: ComboBoxSize = 'md';
 
 	@property({ type: Boolean, reflect: true })
 	disabled = false;

--- a/src/components/inputs/combo-box/combo-box.ts
+++ b/src/components/inputs/combo-box/combo-box.ts
@@ -15,6 +15,8 @@
  * @attr {string}  value        - The selected form value
  * @attr {string}  placeholder  - Placeholder text for the input
  * @attr {string}  size         - Size: 'sm' | 'md' (default: 'md')
+ * @attr {boolean} valid        - Marks the field as valid
+ * @attr {boolean} invalid      - Marks the field as invalid
  * @attr {boolean} disabled     - Disabled state
  * @attr {string}  name         - Input name for form submission
  * @attr {string}  accessible-label - Accessible label forwarded as aria-label to the input. Required for screen reader accessibility.
@@ -66,6 +68,12 @@ export class NLDDComboBox extends LitElement {
 
 	@property({ type: String, reflect: true })
 	size: ComboBoxSize = 'md';
+
+	@property({ type: Boolean, reflect: true })
+	valid = false;
+
+	@property({ type: Boolean, reflect: true })
+	invalid = false;
 
 	@property({ type: Boolean, reflect: true })
 	disabled = false;

--- a/src/components/inputs/dropdown/dropdown.stories.js
+++ b/src/components/inputs/dropdown/dropdown.stories.js
@@ -54,15 +54,9 @@ Standaard.args = {};
 
 export const AlleToestanden = () => html`
 	<div style="display: flex; flex-direction: column; gap: 1rem;">
-		<nldd-dropdown size="md">
-			<select name="optie-1" aria-label="Selecteer een optie">
+		<nldd-dropdown size="xs">
+			<select name="optie-xs" aria-label="Selecteer een optie">
 				<option value="" disabled selected>Selecteer een optie</option>
-				<option value="optie-1">Optie 1</option>
-				<option value="optie-2">Optie 2</option>
-			</select>
-		</nldd-dropdown>
-		<nldd-dropdown size="md">
-			<select name="optie-2" aria-label="Selecteer een optie">
 				<option value="optie-1">Optie 1</option>
 				<option value="optie-2">Optie 2</option>
 			</select>
@@ -74,9 +68,15 @@ export const AlleToestanden = () => html`
 				<option value="optie-2">Optie 2</option>
 			</select>
 		</nldd-dropdown>
-		<nldd-dropdown size="xs">
-			<select name="optie-xs" aria-label="Selecteer een optie">
+		<nldd-dropdown size="md">
+			<select name="optie-1" aria-label="Selecteer een optie">
 				<option value="" disabled selected>Selecteer een optie</option>
+				<option value="optie-1">Optie 1</option>
+				<option value="optie-2">Optie 2</option>
+			</select>
+		</nldd-dropdown>
+		<nldd-dropdown size="md">
+			<select name="optie-2" aria-label="Selecteer een optie">
 				<option value="optie-1">Optie 1</option>
 				<option value="optie-2">Optie 2</option>
 			</select>

--- a/src/components/inputs/dropdown/dropdown.stories.js
+++ b/src/components/inputs/dropdown/dropdown.stories.js
@@ -22,7 +22,7 @@ export default {
 	argTypes: {
 		size: {
 			control: 'select',
-			options: ['sm', 'md'],
+			options: ['xs', 'sm', 'md'],
 			description: 'Grootte van het veld',
 			table: { defaultValue: { summary: 'md' } },
 		},
@@ -69,6 +69,13 @@ export const AlleToestanden = () => html`
 		</nldd-dropdown>
 		<nldd-dropdown size="sm">
 			<select name="optie-3" aria-label="Selecteer een optie">
+				<option value="" disabled selected>Selecteer een optie</option>
+				<option value="optie-1">Optie 1</option>
+				<option value="optie-2">Optie 2</option>
+			</select>
+		</nldd-dropdown>
+		<nldd-dropdown size="xs">
+			<select name="optie-xs" aria-label="Selecteer een optie">
 				<option value="" disabled selected>Selecteer een optie</option>
 				<option value="optie-1">Optie 1</option>
 				<option value="optie-2">Optie 2</option>

--- a/src/components/inputs/dropdown/dropdown.stories.js
+++ b/src/components/inputs/dropdown/dropdown.stories.js
@@ -26,6 +26,16 @@ export default {
 			description: 'Grootte van het veld',
 			table: { defaultValue: { summary: 'md' } },
 		},
+		valid: {
+			control: 'boolean',
+			description: 'Markeert het veld als geldig',
+			table: { defaultValue: { summary: false } },
+		},
+		invalid: {
+			control: 'boolean',
+			description: 'Markeert het veld als ongeldig',
+			table: { defaultValue: { summary: false } },
+		},
 		disabled: {
 			control: 'boolean',
 			description: 'Uitgeschakelde toestand',
@@ -34,12 +44,14 @@ export default {
 	},
 	args: {
 		size: 'md',
+		valid: false,
+		invalid: false,
 		disabled: false,
 	},
 };
 
-const Template = ({ size, disabled }) => html`
-	<nldd-dropdown size=${size} ?disabled=${disabled}>
+const Template = ({ size, valid, invalid, disabled }) => html`
+	<nldd-dropdown size=${size} ?valid=${valid} ?invalid=${invalid} ?disabled=${disabled}>
 		<select name="optie" aria-label="Selecteer een optie">
 			<option value="" disabled selected>Selecteer een optie</option>
 			<option value="optie-1">Optie 1</option>
@@ -79,6 +91,18 @@ export const AlleToestanden = () => html`
 			<select name="optie-2" aria-label="Selecteer een optie">
 				<option value="optie-1">Optie 1</option>
 				<option value="optie-2">Optie 2</option>
+			</select>
+		</nldd-dropdown>
+		<nldd-dropdown size="md" valid>
+			<select name="optie-valid" aria-label="Selecteer een optie">
+				<option value="optie-1" selected>Optie 1</option>
+				<option value="optie-2">Optie 2</option>
+			</select>
+		</nldd-dropdown>
+		<nldd-dropdown size="md" invalid>
+			<select name="optie-invalid" aria-label="Selecteer een optie">
+				<option value="" disabled selected>Selecteer een optie</option>
+				<option value="optie-1">Optie 1</option>
 			</select>
 		</nldd-dropdown>
 		<nldd-dropdown size="md" disabled>

--- a/src/components/inputs/dropdown/dropdown.styles.ts
+++ b/src/components/inputs/dropdown/dropdown.styles.ts
@@ -73,7 +73,7 @@ export const dropdownStyles = css`
 		background: transparent;
 		outline: none;
 		box-sizing: border-box;
-		font: var(--primitives-font-body-sm-regular-snug);
+		font: var(--semantics-input-fields-native-select-font);
 	}
 
 

--- a/src/components/inputs/dropdown/dropdown.styles.ts
+++ b/src/components/inputs/dropdown/dropdown.styles.ts
@@ -7,8 +7,9 @@ export const dropdownStyles = css`
 
 	:host {
 		display: block;
-		--_md-icon-size: var(--primitives-space-24);
+		--_xs-icon-size: var(--primitives-space-16);
 		--_sm-icon-size: var(--primitives-space-20);
+		--_md-icon-size: var(--primitives-space-24);
 		-webkit-tap-highlight-color: transparent;
 	}
 
@@ -35,15 +36,20 @@ export const dropdownStyles = css`
 		color: var(--semantics-buttons-neutral-tinted-content-color);
 	}
 
-	:host([size='md']) .dropdown,
-	:host(:not([size])) .dropdown {
-		min-height: var(--semantics-controls-md-min-size);
-		border-radius: var(--semantics-controls-md-corner-radius);
+	:host([size='xs']) .dropdown {
+		min-height: var(--semantics-controls-xs-min-size);
+		border-radius: var(--semantics-controls-xs-corner-radius);
 	}
 
 	:host([size='sm']) .dropdown {
 		min-height: var(--semantics-controls-sm-min-size);
 		border-radius: var(--semantics-controls-sm-corner-radius);
+	}
+
+	:host([size='md']) .dropdown,
+	:host(:not([size])) .dropdown {
+		min-height: var(--semantics-controls-md-min-size);
+		border-radius: var(--semantics-controls-md-corner-radius);
 	}
 
 	.dropdown:focus-within {
@@ -67,15 +73,7 @@ export const dropdownStyles = css`
 		background: transparent;
 		outline: none;
 		box-sizing: border-box;
-	}
-
-	:host([size='md']) ::slotted(select),
-	:host(:not([size])) ::slotted(select) {
-		font: var(--semantics-input-fields-md-text-font);
-	}
-
-	:host([size='sm']) ::slotted(select) {
-		font: var(--semantics-input-fields-sm-text-font);
+		font: var(--primitives-font-body-sm-regular-snug);
 	}
 
 
@@ -88,6 +86,11 @@ export const dropdownStyles = css`
 		overflow: hidden;
 		text-overflow: ellipsis;
 		color: inherit;
+	}
+
+	:host([size='xs']) .dropdown__value {
+		padding: 0 var(--semantics-controls-xs-inline-padding);
+		font: var(--semantics-input-fields-xs-text-font);
 	}
 
 	:host([size='sm']) .dropdown__value {
@@ -112,16 +115,22 @@ export const dropdownStyles = css`
 		color: inherit;
 	}
 
-	:host([size='md']) .dropdown__picker-icon,
-	:host(:not([size])) .dropdown__picker-icon {
-		width: var(--_md-icon-size);
-		height: var(--_md-icon-size);
-		padding-right: calc((var(--semantics-controls-md-min-size) - var(--_md-icon-size)) / 2);
+	:host([size='xs']) .dropdown__picker-icon {
+		width: var(--_xs-icon-size);
+		height: var(--_xs-icon-size);
+		padding-right: calc((var(--semantics-controls-xs-min-size) - var(--_xs-icon-size)) / 2);
 	}
 
 	:host([size='sm']) .dropdown__picker-icon {
 		width: var(--_sm-icon-size);
 		height: var(--_sm-icon-size);
 		padding-right: calc((var(--semantics-controls-sm-min-size) - var(--_sm-icon-size)) / 2);
+	}
+
+	:host([size='md']) .dropdown__picker-icon,
+	:host(:not([size])) .dropdown__picker-icon {
+		width: var(--_md-icon-size);
+		height: var(--_md-icon-size);
+		padding-right: calc((var(--semantics-controls-md-min-size) - var(--_md-icon-size)) / 2);
 	}
 `;

--- a/src/components/inputs/dropdown/dropdown.styles.ts
+++ b/src/components/inputs/dropdown/dropdown.styles.ts
@@ -7,9 +7,9 @@ export const dropdownStyles = css`
 
 	:host {
 		display: block;
-		--_xs-icon-size: var(--primitives-space-16);
-		--_sm-icon-size: var(--primitives-space-20);
-		--_md-icon-size: var(--primitives-space-24);
+		--_xs-picker-icon-size: var(--primitives-space-16);
+		--_sm-picker-icon-size: var(--primitives-space-20);
+		--_md-picker-icon-size: var(--primitives-space-24);
 		-webkit-tap-highlight-color: transparent;
 	}
 
@@ -80,7 +80,7 @@ export const dropdownStyles = css`
 	/* # Value */
 
 	.dropdown__value {
-		flex: 1;
+		flex-grow: 1;
 		min-width: 0;
 		white-space: nowrap;
 		overflow: hidden;
@@ -105,6 +105,54 @@ export const dropdownStyles = css`
 	}
 
 
+	/* # Validation icon */
+
+	.dropdown__validation-icon-area {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		flex-shrink: 0;
+		height: 100%;
+	}
+
+	:host([size='xs']) .dropdown__validation-icon-area {
+		padding-right: var(--primitives-space-0);
+	}
+
+	:host([size='sm']) .dropdown__validation-icon-area {
+		padding-right: var(--primitives-space-2);
+	}
+
+	:host([size='md']) .dropdown__validation-icon-area,
+	:host(:not([size])) .dropdown__validation-icon-area {
+		padding-right: var(--primitives-space-4);
+	}
+
+	:host([valid]) .dropdown__validation-icon-area {
+		color: var(--semantics-input-fields-is-valid-icon-color);
+	}
+
+	:host([invalid]) .dropdown__validation-icon-area {
+		color: var(--semantics-input-fields-is-invalid-icon-color);
+	}
+
+	:host([size='xs']) .dropdown__validation-icon {
+		width: var(--semantics-input-fields-xs-validation-icon-size);
+		height: var(--semantics-input-fields-xs-validation-icon-size);
+	}
+
+	:host([size='sm']) .dropdown__validation-icon {
+		width: var(--semantics-input-fields-sm-validation-icon-size);
+		height: var(--semantics-input-fields-sm-validation-icon-size);
+	}
+
+	:host([size='md']) .dropdown__validation-icon,
+	:host(:not([size])) .dropdown__validation-icon {
+		width: var(--semantics-input-fields-md-validation-icon-size);
+		height: var(--semantics-input-fields-md-validation-icon-size);
+	}
+
+
 	/* # Picker icon */
 
 	.dropdown__picker-icon {
@@ -116,21 +164,21 @@ export const dropdownStyles = css`
 	}
 
 	:host([size='xs']) .dropdown__picker-icon {
-		width: var(--_xs-icon-size);
-		height: var(--_xs-icon-size);
-		padding-right: calc((var(--semantics-controls-xs-min-size) - var(--_xs-icon-size)) / 2);
+		width: var(--_xs-picker-icon-size);
+		height: var(--_xs-picker-icon-size);
+		padding-right: calc((var(--semantics-controls-xs-min-size) - var(--_xs-picker-icon-size)) / 2);
 	}
 
 	:host([size='sm']) .dropdown__picker-icon {
-		width: var(--_sm-icon-size);
-		height: var(--_sm-icon-size);
-		padding-right: calc((var(--semantics-controls-sm-min-size) - var(--_sm-icon-size)) / 2);
+		width: var(--_sm-picker-icon-size);
+		height: var(--_sm-picker-icon-size);
+		padding-right: calc((var(--semantics-controls-sm-min-size) - var(--_sm-picker-icon-size)) / 2);
 	}
 
 	:host([size='md']) .dropdown__picker-icon,
 	:host(:not([size])) .dropdown__picker-icon {
-		width: var(--_md-icon-size);
-		height: var(--_md-icon-size);
-		padding-right: calc((var(--semantics-controls-md-min-size) - var(--_md-icon-size)) / 2);
+		width: var(--_md-picker-icon-size);
+		height: var(--_md-picker-icon-size);
+		padding-right: calc((var(--semantics-controls-md-min-size) - var(--_md-picker-icon-size)) / 2);
 	}
 `;

--- a/src/components/inputs/dropdown/dropdown.template.ts
+++ b/src/components/inputs/dropdown/dropdown.template.ts
@@ -3,21 +3,21 @@ import type { NLDDDropdown } from './dropdown.js';
 import './../../content/icon/icon.js';
 
 function renderValidationIcon(component: NLDDDropdown): TemplateResult | typeof nothing {
-	if (component.valid) {
-		return html`
-			<div class="dropdown__validation-icon-area">
-				<nldd-icon class="dropdown__validation-icon"
-					name="valid"
-					aria-hidden="true"
-				></nldd-icon>
-			</div>
-		`;
-	}
 	if (component.invalid) {
 		return html`
 			<div class="dropdown__validation-icon-area">
 				<nldd-icon class="dropdown__validation-icon"
 					name="invalid"
+					aria-hidden="true"
+				></nldd-icon>
+			</div>
+		`;
+	}
+	if (component.valid) {
+		return html`
+			<div class="dropdown__validation-icon-area">
+				<nldd-icon class="dropdown__validation-icon"
+					name="valid"
 					aria-hidden="true"
 				></nldd-icon>
 			</div>

--- a/src/components/inputs/dropdown/dropdown.template.ts
+++ b/src/components/inputs/dropdown/dropdown.template.ts
@@ -1,12 +1,37 @@
-import { html, TemplateResult } from 'lit';
+import { html, nothing, TemplateResult } from 'lit';
 import type { NLDDDropdown } from './dropdown.js';
 import './../../content/icon/icon.js';
+
+function renderValidationIcon(component: NLDDDropdown): TemplateResult | typeof nothing {
+	if (component.valid) {
+		return html`
+			<div class="dropdown__validation-icon-area">
+				<nldd-icon class="dropdown__validation-icon"
+					name="valid"
+					aria-hidden="true"
+				></nldd-icon>
+			</div>
+		`;
+	}
+	if (component.invalid) {
+		return html`
+			<div class="dropdown__validation-icon-area">
+				<nldd-icon class="dropdown__validation-icon"
+					name="invalid"
+					aria-hidden="true"
+				></nldd-icon>
+			</div>
+		`;
+	}
+	return nothing;
+}
 
 export function dropdownTemplate(component: NLDDDropdown): TemplateResult {
 	return html`
 		<div class="dropdown">
 			<slot @slotchange=${component._onSlotChange}></slot>
 			<span class="dropdown__value">${component._displayValue}</span>
+			${renderValidationIcon(component)}
 			<div class="dropdown__picker-icon">
 				<nldd-icon name="chevron-up-down"></nldd-icon>
 			</div>

--- a/src/components/inputs/dropdown/dropdown.test.ts
+++ b/src/components/inputs/dropdown/dropdown.test.ts
@@ -37,6 +37,31 @@ describe('nldd-dropdown', () => {
 
 
 /* ============================================================
+   Size
+   ============================================================ */
+
+describe('nldd-dropdown – size', () => {
+	let el: NLDDDropdown;
+
+	afterEach(() => {
+		if (el) cleanup(el);
+	});
+
+	it('defaults size to md', async () => {
+		el = await fixture<NLDDDropdown>('<nldd-dropdown></nldd-dropdown>');
+		await waitForUpdate(el);
+		expect(el.size).toBe('md');
+	});
+
+	it('reflects size="xs" to host', async () => {
+		el = await fixture<NLDDDropdown>('<nldd-dropdown size="xs"></nldd-dropdown>');
+		await waitForUpdate(el);
+		expect(el.getAttribute('size')).toBe('xs');
+	});
+});
+
+
+/* ============================================================
    State
    ============================================================ */
 

--- a/src/components/inputs/dropdown/dropdown.test.ts
+++ b/src/components/inputs/dropdown/dropdown.test.ts
@@ -37,6 +37,61 @@ describe('nldd-dropdown', () => {
 
 
 /* ============================================================
+   Validation
+   ============================================================ */
+
+describe('nldd-dropdown – validation', () => {
+	let el: NLDDDropdown;
+
+	afterEach(() => {
+		if (el) cleanup(el);
+	});
+
+	it('renders no validation icon by default', async () => {
+		el = await fixture<NLDDDropdown>('<nldd-dropdown></nldd-dropdown>');
+		await waitForUpdate(el);
+		expect(el.shadowRoot!.querySelector('.dropdown__validation-icon-area')).toBeNull();
+	});
+
+	it('renders a valid icon when valid', async () => {
+		el = await fixture<NLDDDropdown>('<nldd-dropdown valid></nldd-dropdown>');
+		await waitForUpdate(el);
+		const icon = el.shadowRoot!.querySelector('.dropdown__validation-icon')!;
+		expect(icon.getAttribute('name')).toBe('valid');
+	});
+
+	it('renders an invalid icon when invalid', async () => {
+		el = await fixture<NLDDDropdown>('<nldd-dropdown invalid></nldd-dropdown>');
+		await waitForUpdate(el);
+		const icon = el.shadowRoot!.querySelector('.dropdown__validation-icon')!;
+		expect(icon.getAttribute('name')).toBe('invalid');
+	});
+
+	it('forwards aria-invalid to the slotted select', async () => {
+		el = await fixture<NLDDDropdown>(`
+			<nldd-dropdown invalid>
+				<select aria-label="Land"><option value="nl">Nederland</option></select>
+			</nldd-dropdown>
+		`);
+		await waitForUpdate(el);
+		expect(el.querySelector('select')!.getAttribute('aria-invalid')).toBe('true');
+	});
+
+	it('removes aria-invalid when invalid is cleared', async () => {
+		el = await fixture<NLDDDropdown>(`
+			<nldd-dropdown invalid>
+				<select aria-label="Land"><option value="nl">Nederland</option></select>
+			</nldd-dropdown>
+		`);
+		await waitForUpdate(el);
+		el.invalid = false;
+		await waitForUpdate(el);
+		expect(el.querySelector('select')!.hasAttribute('aria-invalid')).toBe(false);
+	});
+});
+
+
+/* ============================================================
    Size
    ============================================================ */
 

--- a/src/components/inputs/dropdown/dropdown.ts
+++ b/src/components/inputs/dropdown/dropdown.ts
@@ -8,7 +8,7 @@
  * dynamic changes to options.
  *
  * @element nldd-dropdown
- * @attr {string}  size     - Size: 'sm' | 'md' (default: 'md')
+ * @attr {string}  size     - Size: 'xs' | 'sm' | 'md' (default: 'md')
  * @attr {boolean} disabled - Disabled state; also forwarded to the slotted select
  *
  * @slot - A native `<select>` element with `<option>` and/or `<optgroup>` children
@@ -32,7 +32,7 @@ import { dropdownStyles } from './dropdown.styles.js';
 import { dropdownTemplate } from './dropdown.template.js';
 import './../../content/icon/icon.js';
 
-export type DropdownSize = 'sm' | 'md';
+export type DropdownSize = 'xs' | 'sm' | 'md';
 
 @customElement('nldd-dropdown')
 export class NLDDDropdown extends LitElement {

--- a/src/components/inputs/dropdown/dropdown.ts
+++ b/src/components/inputs/dropdown/dropdown.ts
@@ -9,6 +9,8 @@
  *
  * @element nldd-dropdown
  * @attr {string}  size     - Size: 'xs' | 'sm' | 'md' (default: 'md')
+ * @attr {boolean} valid    - Marks the field as valid
+ * @attr {boolean} invalid  - Marks the field as invalid
  * @attr {boolean} disabled - Disabled state; also forwarded to the slotted select
  *
  * @slot - A native `<select>` element with `<option>` and/or `<optgroup>` children
@@ -42,6 +44,12 @@ export class NLDDDropdown extends LitElement {
 	size: DropdownSize = 'md';
 
 	@property({ type: Boolean, reflect: true })
+	valid = false;
+
+	@property({ type: Boolean, reflect: true })
+	invalid = false;
+
+	@property({ type: Boolean, reflect: true })
 	disabled = false;
 
 	@state()
@@ -54,6 +62,9 @@ export class NLDDDropdown extends LitElement {
 	override updated(changedProperties: Map<string, unknown>): void {
 		if (changedProperties.has('disabled')) {
 			this._syncDisabled();
+		}
+		if (changedProperties.has('invalid')) {
+			this._syncAriaInvalid();
 		}
 	}
 
@@ -81,6 +92,7 @@ export class NLDDDropdown extends LitElement {
 
 		select.addEventListener('change', this._handleSelectChange);
 		this._syncDisabled();
+		this._syncAriaInvalid();
 		this._syncDisplayValue();
 	}
 
@@ -89,6 +101,15 @@ export class NLDDDropdown extends LitElement {
 	private _syncDisabled(): void {
 		if (!this._select) return;
 		this._select.disabled = this.disabled;
+	}
+
+	private _syncAriaInvalid(): void {
+		if (!this._select) return;
+		if (this.invalid) {
+			this._select.setAttribute('aria-invalid', 'true');
+		} else {
+			this._select.removeAttribute('aria-invalid');
+		}
 	}
 
 	private _syncDisplayValue(): void {

--- a/src/components/inputs/number-field/number-field.i18n.ts
+++ b/src/components/inputs/number-field/number-field.i18n.ts
@@ -1,6 +1,6 @@
 export const nlddNumberFieldTranslations = {
-	'components.number-field.decrement-action': 'Verlaag waarde',
-	'components.number-field.increment-action': 'Verhoog waarde',
+	'components.number-field.decrement-action': 'Verlaag',
+	'components.number-field.increment-action': 'Verhoog',
 	'components.number-field.to-adjust-value-action': 'Waarde aanpassen',
 };
 

--- a/src/components/inputs/number-field/number-field.stories.js
+++ b/src/components/inputs/number-field/number-field.stories.js
@@ -104,8 +104,8 @@ Standaard.args = {};
 
 export const AlleToestanden = () => html`
 	<div style="display: flex; flex-direction: column; gap: 1rem;">
-		<nldd-number-field value="5" min="0" max="10" size="md"></nldd-number-field>
 		<nldd-number-field value="5" min="0" max="10" size="sm"></nldd-number-field>
+		<nldd-number-field value="5" min="0" max="10" size="md"></nldd-number-field>
 		<nldd-number-field value="0" min="0" max="10"></nldd-number-field>
 		<nldd-number-field value="10" min="0" max="10"></nldd-number-field>
 		<nldd-number-field value="5" min="0" max="10" disabled></nldd-number-field>

--- a/src/components/inputs/number-field/number-field.stories.js
+++ b/src/components/inputs/number-field/number-field.stories.js
@@ -38,6 +38,12 @@ export default {
 			description: 'Stapgrootte',
 			table: { defaultValue: { summary: 1 } },
 		},
+		size: {
+			control: 'select',
+			options: ['sm', 'md'],
+			description: 'Grootte van het veld',
+			table: { defaultValue: { summary: 'md' } },
+		},
 		disabled: {
 			control: 'boolean',
 			description: 'Uitgeschakelde toestand',
@@ -69,6 +75,7 @@ export default {
 		min: 0,
 		max: 10,
 		step: 1,
+		size: 'md',
 		disabled: false,
 		name: '',
 		hideSpinButtons: false,
@@ -77,12 +84,13 @@ export default {
 	},
 };
 
-const Template = ({ value, min, max, step, disabled, name, hideSpinButtons, fullWidth, width }) => html`
+const Template = ({ value, min, max, step, size, disabled, name, hideSpinButtons, fullWidth, width }) => html`
 	<nldd-number-field
 		value=${value}
 		min=${min}
 		max=${max}
 		step=${step}
+		size=${size}
 		?disabled=${disabled}
 		name=${name}
 		?hide-spin-buttons=${hideSpinButtons}
@@ -96,12 +104,14 @@ Standaard.args = {};
 
 export const AlleToestanden = () => html`
 	<div style="display: flex; flex-direction: column; gap: 1rem;">
-		<nldd-number-field value="5" min="0" max="10"></nldd-number-field>
+		<nldd-number-field value="5" min="0" max="10" size="md"></nldd-number-field>
+		<nldd-number-field value="5" min="0" max="10" size="sm"></nldd-number-field>
 		<nldd-number-field value="0" min="0" max="10"></nldd-number-field>
 		<nldd-number-field value="10" min="0" max="10"></nldd-number-field>
 		<nldd-number-field value="5" min="0" max="10" disabled></nldd-number-field>
 		<nldd-number-field value="5" min="0" max="10" hide-spin-buttons></nldd-number-field>
 		<nldd-number-field value="5" min="0" max="10" hide-spin-buttons disabled></nldd-number-field>
+		<nldd-number-field value="5" min="0" max="10" size="sm" hide-spin-buttons></nldd-number-field>
 		<nldd-number-field value="5" min="0" max="10" width="240px"></nldd-number-field>
 		<nldd-number-field value="5" min="0" max="10" hide-spin-buttons width="240px"></nldd-number-field>
 		<div style="width: 400px;">

--- a/src/components/inputs/number-field/number-field.styles.ts
+++ b/src/components/inputs/number-field/number-field.styles.ts
@@ -69,28 +69,28 @@ export const numberFieldStyles = css`
 
 	/* # Controls */
 
-	.number-field__decrement-control,
-	.number-field__increment-control {
+	.number-field__decrement-button,
+	.number-field__increment-button {
 		display: flex;
 		align-items: center;
 		height: 100%;
 	}
 
-	:host([size='sm']) .number-field__decrement-control {
+	:host([size='sm']) .number-field__decrement-button {
 		padding-left: calc((var(--semantics-controls-sm-min-size) - var(--semantics-controls-xs-min-size)) / 2 - var(--semantics-input-fields-border-thickness));
 	}
 
-	:host([size='sm']) .number-field__increment-control {
+	:host([size='sm']) .number-field__increment-button {
 		padding-right: calc((var(--semantics-controls-sm-min-size) - var(--semantics-controls-xs-min-size)) / 2 - var(--semantics-input-fields-border-thickness));
 	}
 
-	:host([size='md']) .number-field__decrement-control,
-	:host(:not([size])) .number-field__decrement-control {
+	:host([size='md']) .number-field__decrement-button,
+	:host(:not([size])) .number-field__decrement-button {
 		padding-left: calc((var(--semantics-controls-md-min-size) - var(--semantics-controls-sm-min-size)) / 2 - var(--semantics-input-fields-border-thickness));
 	}
 
-	:host([size='md']) .number-field__increment-control,
-	:host(:not([size])) .number-field__increment-control {
+	:host([size='md']) .number-field__increment-button,
+	:host(:not([size])) .number-field__increment-button {
 		padding-right: calc((var(--semantics-controls-md-min-size) - var(--semantics-controls-sm-min-size)) / 2 - var(--semantics-input-fields-border-thickness));
 	}
 
@@ -136,7 +136,7 @@ export const numberFieldStyles = css`
 
 	:host([full-width]) .number-field__input,
 	:host([width]) .number-field__input {
-		flex: 1;
+		flex-grow: 1;
 		min-width: 0;
 	}
 `;

--- a/src/components/inputs/number-field/number-field.styles.ts
+++ b/src/components/inputs/number-field/number-field.styles.ts
@@ -40,11 +40,20 @@ export const numberFieldStyles = css`
 		display: inline-flex;
 		flex-direction: row;
 		align-items: center;
-		height: var(--semantics-controls-md-min-size);
 		background-color: var(--semantics-input-fields-background-color);
-		border: var(--semantics-input-fields-border-thickness) solid var(--semantics-input-fields-border-color);
-		border-radius: var(--semantics-controls-md-corner-radius);
+		border: var(--semantics-input-fields-border);
 		box-sizing: border-box;
+	}
+
+	:host([size='sm']) .number-field {
+		height: var(--semantics-controls-sm-min-size);
+		border-radius: var(--semantics-controls-sm-corner-radius);
+	}
+
+	:host([size='md']) .number-field,
+	:host(:not([size])) .number-field {
+		height: var(--semantics-controls-md-min-size);
+		border-radius: var(--semantics-controls-md-corner-radius);
 	}
 
 	:host([full-width]) .number-field,
@@ -60,17 +69,28 @@ export const numberFieldStyles = css`
 
 	/* # Controls */
 
-	.number-field__decrement-control {
-		display: flex;
-		align-items: center;
-		height: 100%;
-		padding-left: calc((var(--semantics-controls-md-min-size) - var(--semantics-controls-sm-min-size)) / 2 - var(--semantics-input-fields-border-thickness));
-	}
-
+	.number-field__decrement-control,
 	.number-field__increment-control {
 		display: flex;
 		align-items: center;
 		height: 100%;
+	}
+
+	:host([size='sm']) .number-field__decrement-control {
+		padding-left: calc((var(--semantics-controls-sm-min-size) - var(--semantics-controls-xs-min-size)) / 2 - var(--semantics-input-fields-border-thickness));
+	}
+
+	:host([size='sm']) .number-field__increment-control {
+		padding-right: calc((var(--semantics-controls-sm-min-size) - var(--semantics-controls-xs-min-size)) / 2 - var(--semantics-input-fields-border-thickness));
+	}
+
+	:host([size='md']) .number-field__decrement-control,
+	:host(:not([size])) .number-field__decrement-control {
+		padding-left: calc((var(--semantics-controls-md-min-size) - var(--semantics-controls-sm-min-size)) / 2 - var(--semantics-input-fields-border-thickness));
+	}
+
+	:host([size='md']) .number-field__increment-control,
+	:host(:not([size])) .number-field__increment-control {
 		padding-right: calc((var(--semantics-controls-md-min-size) - var(--semantics-controls-sm-min-size)) / 2 - var(--semantics-input-fields-border-thickness));
 	}
 
@@ -85,9 +105,18 @@ export const numberFieldStyles = css`
 		padding: 0 var(--primitives-space-6);
 		outline: none;
 		box-sizing: border-box;
-		font: var(--semantics-input-fields-md-text-font);
 		color: var(--semantics-content-color);
 		text-align: center;
+	}
+
+	:host([size='sm']) .number-field__input {
+		font: var(--semantics-input-fields-sm-text-font);
+		min-width: var(--semantics-controls-sm-min-size);
+	}
+
+	:host([size='md']) .number-field__input,
+	:host(:not([size])) .number-field__input {
+		font: var(--semantics-input-fields-md-text-font);
 		min-width: var(--semantics-controls-md-min-size);
 	}
 

--- a/src/components/inputs/number-field/number-field.template.ts
+++ b/src/components/inputs/number-field/number-field.template.ts
@@ -34,6 +34,7 @@ export function numberFieldTemplate(component: NLDDNumberField): TemplateResult 
 				?disabled=${component.disabled}
 				name=${component.name || nothing}
 				@input=${component._handleInput}
+				@change=${component._handleChange}
 			>
 			${!component.hideSpinButtons ? html`
 				<div class="number-field__increment-button">

--- a/src/components/inputs/number-field/number-field.template.ts
+++ b/src/components/inputs/number-field/number-field.template.ts
@@ -13,7 +13,7 @@ export function numberFieldTemplate(component: NLDDNumberField): TemplateResult 
 			aria-label=${component._t('components.number-field.to-adjust-value-action')}
 		>
 			${!component.hideSpinButtons ? html`
-				<div class="number-field__decrement-control">
+				<div class="number-field__decrement-button">
 					<nldd-icon-button
 						variant="neutral-tinted"
 						size=${iconButtonSize}
@@ -36,7 +36,7 @@ export function numberFieldTemplate(component: NLDDNumberField): TemplateResult 
 				@input=${component._handleInput}
 			>
 			${!component.hideSpinButtons ? html`
-				<div class="number-field__increment-control">
+				<div class="number-field__increment-button">
 					<nldd-icon-button
 						variant="neutral-tinted"
 						size=${iconButtonSize}

--- a/src/components/inputs/number-field/number-field.template.ts
+++ b/src/components/inputs/number-field/number-field.template.ts
@@ -5,6 +5,7 @@ import './../../actions/icon-button/icon-button.js';
 export function numberFieldTemplate(component: NLDDNumberField): TemplateResult {
 	const canDecrease = component.value > component.min;
 	const canIncrease = component.value < component.max;
+	const iconButtonSize = component.size === 'sm' ? 'xs' : 'sm';
 
 	return html`
 		<div class="number-field"
@@ -15,7 +16,7 @@ export function numberFieldTemplate(component: NLDDNumberField): TemplateResult 
 				<div class="number-field__decrement-control">
 					<nldd-icon-button
 						variant="neutral-tinted"
-						size="sm"
+						size=${iconButtonSize}
 						icon="minus"
 						text=${component._t('components.number-field.decrement-action')}
 						?disabled=${component.disabled || !canDecrease}
@@ -38,7 +39,7 @@ export function numberFieldTemplate(component: NLDDNumberField): TemplateResult 
 				<div class="number-field__increment-control">
 					<nldd-icon-button
 						variant="neutral-tinted"
-						size="sm"
+						size=${iconButtonSize}
 						icon="plus"
 						text=${component._t('components.number-field.increment-action')}
 						?disabled=${component.disabled || !canIncrease}

--- a/src/components/inputs/number-field/number-field.test.ts
+++ b/src/components/inputs/number-field/number-field.test.ts
@@ -327,15 +327,18 @@ describe('nldd-number-field – typing & clamping on commit', () => {
 		expect(el.value).toBe(8);
 	});
 
-	it('dispatches change event once on commit when value is corrected', async () => {
+	it('dispatches a single input followed by a single change when a typed value is corrected', async () => {
 		el = await fixture<NLDDNumberField>('<nldd-number-field value="5" max="10"></nldd-number-field>');
 		await waitForUpdate(el);
 		const input = type(el, '50');
 		await waitForUpdate(el);
+		let inputCount = 0;
 		let changeCount = 0;
+		el.addEventListener('input', () => { inputCount++; });
 		el.addEventListener('change', () => { changeCount++; });
 		blur(input);
 		await waitForUpdate(el);
+		expect(inputCount).toBe(1);
 		expect(changeCount).toBe(1);
 		expect(el.value).toBe(10);
 	});

--- a/src/components/inputs/number-field/number-field.test.ts
+++ b/src/components/inputs/number-field/number-field.test.ts
@@ -250,6 +250,99 @@ describe('nldd-number-field – change event', () => {
 
 
 /* ============================================================
+   Typing & clamping on commit
+   ============================================================ */
+
+describe('nldd-number-field – typing & clamping on commit', () => {
+	let el: NLDDNumberField;
+
+	afterEach(() => {
+		if (el) cleanup(el);
+	});
+
+	function type(el: NLDDNumberField, value: string): HTMLInputElement {
+		const input = el.shadowRoot!.querySelector('input')!;
+		input.value = value;
+		input.dispatchEvent(new Event('input', { bubbles: true }));
+		return input;
+	}
+
+	function blur(input: HTMLInputElement): void {
+		input.dispatchEvent(new Event('change', { bubbles: true }));
+	}
+
+	it('does not clamp while typing an out-of-range value', async () => {
+		el = await fixture<NLDDNumberField>('<nldd-number-field value="5" max="10"></nldd-number-field>');
+		await waitForUpdate(el);
+		type(el, '109999');
+		await waitForUpdate(el);
+		expect(el.value).toBe(109999);
+	});
+
+	it('clamps to max on commit when value exceeds max', async () => {
+		el = await fixture<NLDDNumberField>('<nldd-number-field value="5" max="10"></nldd-number-field>');
+		await waitForUpdate(el);
+		const input = type(el, '109999');
+		await waitForUpdate(el);
+		blur(input);
+		await waitForUpdate(el);
+		expect(el.value).toBe(10);
+		expect(input.value).toBe('10');
+	});
+
+	it('clamps to min on commit when value is below min', async () => {
+		el = await fixture<NLDDNumberField>('<nldd-number-field value="5" min="0"></nldd-number-field>');
+		await waitForUpdate(el);
+		const input = type(el, '-50');
+		await waitForUpdate(el);
+		blur(input);
+		await waitForUpdate(el);
+		expect(el.value).toBe(0);
+		expect(input.value).toBe('0');
+	});
+
+	it('falls back to the last valid value on empty commit', async () => {
+		el = await fixture<NLDDNumberField>('<nldd-number-field value="7" min="0" max="10"></nldd-number-field>');
+		await waitForUpdate(el);
+		const input = type(el, '');
+		await waitForUpdate(el);
+		blur(input);
+		await waitForUpdate(el);
+		expect(el.value).toBe(7);
+		expect(input.value).toBe('7');
+	});
+
+	it('updates the last valid value when a new in-range value is committed', async () => {
+		el = await fixture<NLDDNumberField>('<nldd-number-field value="5" min="0" max="10"></nldd-number-field>');
+		await waitForUpdate(el);
+		const first = type(el, '8');
+		await waitForUpdate(el);
+		blur(first);
+		await waitForUpdate(el);
+		// Now empty the field and commit — should fall back to 8, not 5.
+		const second = type(el, '');
+		await waitForUpdate(el);
+		blur(second);
+		await waitForUpdate(el);
+		expect(el.value).toBe(8);
+	});
+
+	it('dispatches change event once on commit when value is corrected', async () => {
+		el = await fixture<NLDDNumberField>('<nldd-number-field value="5" max="10"></nldd-number-field>');
+		await waitForUpdate(el);
+		const input = type(el, '50');
+		await waitForUpdate(el);
+		let changeCount = 0;
+		el.addEventListener('change', () => { changeCount++; });
+		blur(input);
+		await waitForUpdate(el);
+		expect(changeCount).toBe(1);
+		expect(el.value).toBe(10);
+	});
+});
+
+
+/* ============================================================
    Accessibility
    ============================================================ */
 

--- a/src/components/inputs/number-field/number-field.test.ts
+++ b/src/components/inputs/number-field/number-field.test.ts
@@ -31,6 +31,45 @@ describe('nldd-number-field', () => {
 
 
 /* ============================================================
+   Size
+   ============================================================ */
+
+describe('nldd-number-field – size', () => {
+	let el: NLDDNumberField;
+
+	afterEach(() => {
+		if (el) cleanup(el);
+	});
+
+	it('defaults size to md', async () => {
+		el = await fixture<NLDDNumberField>('<nldd-number-field></nldd-number-field>');
+		await waitForUpdate(el);
+		expect(el.size).toBe('md');
+	});
+
+	it('reflects size attribute to host', async () => {
+		el = await fixture<NLDDNumberField>('<nldd-number-field size="sm"></nldd-number-field>');
+		await waitForUpdate(el);
+		expect(el.getAttribute('size')).toBe('sm');
+	});
+
+	it('renders sm icon buttons when size is md', async () => {
+		el = await fixture<NLDDNumberField>('<nldd-number-field></nldd-number-field>');
+		await waitForUpdate(el);
+		const buttons = el.shadowRoot!.querySelectorAll('nldd-icon-button');
+		expect(buttons[0].getAttribute('size')).toBe('sm');
+	});
+
+	it('renders xs icon buttons when size is sm', async () => {
+		el = await fixture<NLDDNumberField>('<nldd-number-field size="sm"></nldd-number-field>');
+		await waitForUpdate(el);
+		const buttons = el.shadowRoot!.querySelectorAll('nldd-icon-button');
+		expect(buttons[0].getAttribute('size')).toBe('xs');
+	});
+});
+
+
+/* ============================================================
    State
    ============================================================ */
 

--- a/src/components/inputs/number-field/number-field.test.ts
+++ b/src/components/inputs/number-field/number-field.test.ts
@@ -54,7 +54,7 @@ describe('nldd-number-field – size', () => {
 	});
 
 	it('renders sm icon buttons when size is md', async () => {
-		el = await fixture<NLDDNumberField>('<nldd-number-field></nldd-number-field>');
+		el = await fixture<NLDDNumberField>('<nldd-number-field size="md"></nldd-number-field>');
 		await waitForUpdate(el);
 		const buttons = el.shadowRoot!.querySelectorAll('nldd-icon-button');
 		expect(buttons[0].getAttribute('size')).toBe('sm');

--- a/src/components/inputs/number-field/number-field.test.ts
+++ b/src/components/inputs/number-field/number-field.test.ts
@@ -58,6 +58,7 @@ describe('nldd-number-field – size', () => {
 		await waitForUpdate(el);
 		const buttons = el.shadowRoot!.querySelectorAll('nldd-icon-button');
 		expect(buttons[0].getAttribute('size')).toBe('sm');
+		expect(buttons[1].getAttribute('size')).toBe('sm');
 	});
 
 	it('renders xs icon buttons when size is sm', async () => {
@@ -65,6 +66,7 @@ describe('nldd-number-field – size', () => {
 		await waitForUpdate(el);
 		const buttons = el.shadowRoot!.querySelectorAll('nldd-icon-button');
 		expect(buttons[0].getAttribute('size')).toBe('xs');
+		expect(buttons[1].getAttribute('size')).toBe('xs');
 	});
 });
 

--- a/src/components/inputs/number-field/number-field.ts
+++ b/src/components/inputs/number-field/number-field.ts
@@ -17,10 +17,12 @@
  * @attr {boolean} hide-spin-buttons - When set, hides the decrement and increment buttons
  * @attr {string}  accessible-label  - Accessible label (aria-label) forwarded to the native input
  *
- * @fires input  - When the value changes while typing; detail: { value: number }
- * @fires change - When the value is committed on blur/Enter or via +/- buttons, clamped to
- *                 min/max; empty input falls back to the last valid value.
+ * @fires input  - When the value changes (typing, +/- button, or on-commit correction);
  *                 detail: { value: number }
+ * @fires change - When the value is committed (blur/Enter or +/- button), clamped to
+ *                 [min, max]; empty input falls back to the last valid value. When the
+ *                 committed value differs from the typed value, a matching input event
+ *                 is fired immediately before this one. detail: { value: number }
  */
 import { LitElement } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
@@ -76,7 +78,9 @@ export class NLDDNumberField extends LitElement {
 	@property({ type: Object })
 	translations: Partial<NLDDNumberFieldTranslations> = {};
 
-	/** Last value inside [min, max]; used as fallback when the input is cleared. */
+	/** Last value inside [min, max]; used as fallback when the input is cleared.
+	 *  Initialised to the clamped `value` in firstUpdated — the 0 default is only
+	 *  relevant before the first render, which no user-facing handler can reach. */
 	private _lastValidValue = 0;
 
 	override firstUpdated(): void {

--- a/src/components/inputs/number-field/number-field.ts
+++ b/src/components/inputs/number-field/number-field.ts
@@ -17,8 +17,10 @@
  * @attr {boolean} hide-spin-buttons - When set, hides the decrement and increment buttons
  * @attr {string}  accessible-label  - Accessible label (aria-label) forwarded to the native input
  *
- * @fires input  - When the value changes; detail: { value: number }
- * @fires change - When the value is confirmed; detail: { value: number }
+ * @fires input  - When the value changes while typing; detail: { value: number }
+ * @fires change - When the value is committed on blur/Enter or via +/- buttons, clamped to
+ *                 min/max; empty input falls back to the last valid value.
+ *                 detail: { value: number }
  */
 import { LitElement } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
@@ -74,10 +76,14 @@ export class NLDDNumberField extends LitElement {
 	@property({ type: Object })
 	translations: Partial<NLDDNumberFieldTranslations> = {};
 
+	/** Last value inside [min, max]; used as fallback when the input is cleared. */
+	private _lastValidValue = 0;
+
 	override firstUpdated(): void {
 		if (!this.accessibleLabel) {
 			console.warn('<nldd-number-field>: No accessible-label provided. Add an accessible-label attribute so screen readers can announce the input\'s purpose.');
 		}
+		this._lastValidValue = this._clamp(this.value);
 	}
 
 	override updated(changedProperties: Map<string, unknown>): void {
@@ -102,37 +108,61 @@ export class NLDDNumberField extends LitElement {
 
 	public _handleDecrease(): void {
 		if (this.disabled) return;
-		this._updateValue(this.value - this.step);
+		this._commitValue(this.value - this.step);
 	}
 
 	public _handleIncrease(): void {
 		if (this.disabled) return;
-		this._updateValue(this.value + this.step);
+		this._commitValue(this.value + this.step);
 	}
 
+	/** Fires while the user types. The value may be outside [min, max]; clamping happens on change. */
 	public _handleInput(e: Event): void {
+		if (this.disabled) return;
 		const input = e.target as HTMLInputElement;
-		const newValue = parseFloat(input.value);
-		if (!isNaN(newValue)) {
-			this._updateValue(newValue);
-		}
+		const parsed = parseFloat(input.value);
+		if (isNaN(parsed)) return;
+		this.value = parsed;
+		this.dispatchEvent(new CustomEvent('input', {
+			detail: { value: this.value },
+			bubbles: true,
+			composed: true,
+		}));
 	}
 
-	private _updateValue(newValue: number): void {
-		const clampedValue = Math.max(this.min, Math.min(this.max, newValue));
-		if (clampedValue !== this.value) {
-			this.value = clampedValue;
-			this.dispatchEvent(new CustomEvent('input', {
-				detail: { value: this.value },
-				bubbles: true,
-				composed: true,
-			}));
-			this.dispatchEvent(new CustomEvent('change', {
-				detail: { value: this.value },
-				bubbles: true,
-				composed: true,
-			}));
-		}
+	/** Fires on blur or Enter. Clamps the value and falls back to the last valid value when empty. */
+	public _handleChange(e: Event): void {
+		if (this.disabled) return;
+		const input = e.target as HTMLInputElement;
+		const parsed = parseFloat(input.value);
+		const finalValue = isNaN(parsed) ? this._lastValidValue : this._clamp(parsed);
+		this._commitValue(finalValue, input);
+	}
+
+	private _commitValue(newValue: number, input?: HTMLInputElement): void {
+		const clampedValue = this._clamp(newValue);
+		const changed = clampedValue !== this.value;
+		this.value = clampedValue;
+		this._lastValidValue = clampedValue;
+		// Force the input DOM to match the committed value — Lit's property binding
+		// may not re-sync when the user typed an out-of-range value that parses to
+		// the same number after clamping (e.g. empty → fallback).
+		if (input) input.value = String(clampedValue);
+		if (!changed) return;
+		this.dispatchEvent(new CustomEvent('input', {
+			detail: { value: this.value },
+			bubbles: true,
+			composed: true,
+		}));
+		this.dispatchEvent(new CustomEvent('change', {
+			detail: { value: this.value },
+			bubbles: true,
+			composed: true,
+		}));
+	}
+
+	private _clamp(value: number): number {
+		return Math.max(this.min, Math.min(this.max, value));
 	}
 
 	override render() {

--- a/src/components/inputs/number-field/number-field.ts
+++ b/src/components/inputs/number-field/number-field.ts
@@ -8,6 +8,7 @@
  * @attr {number}  min          - Minimum value (default: -Infinity)
  * @attr {number}  max          - Maximum value (default: Infinity)
  * @attr {number}  step         - Step size (default: 1)
+ * @attr {string}  size         - Size: 'sm' | 'md' (default: 'md')
  * @attr {boolean} disabled     - Disabled state
  * @attr {string}  name         - Name for form submission
  * @attr {object}  translations - Translations; unspecified keys fall back to Dutch
@@ -28,6 +29,8 @@ import type { NLDDNumberFieldTranslations } from './number-field.i18n.js';
 import './../../actions/icon-button/icon-button.js';
 import './../../content/icon/icon.js';
 
+export type NumberFieldSize = 'sm' | 'md';
+
 @customElement('nldd-number-field')
 export class NLDDNumberField extends LitElement {
 	static override styles = numberFieldStyles;
@@ -43,6 +46,9 @@ export class NLDDNumberField extends LitElement {
 
 	@property({ type: Number })
 	step = 1;
+
+	@property({ type: String, reflect: true })
+	size: NumberFieldSize = 'md';
 
 	@property({ type: Boolean, reflect: true })
 	disabled = false;

--- a/src/components/inputs/password-field/password-field.stories.js
+++ b/src/components/inputs/password-field/password-field.stories.js
@@ -35,7 +35,7 @@ export default {
 		},
 		size: {
 			control: 'select',
-			options: ['md', 'sm'],
+			options: ['sm', 'md'],
 			description: 'Size variant',
 			table: { defaultValue: { summary: 'md' } },
 		},

--- a/src/components/inputs/password-field/password-field.styles.ts
+++ b/src/components/inputs/password-field/password-field.styles.ts
@@ -8,6 +8,7 @@ export const passwordFieldStyles = css`
 	:host {
 		display: block;
 		--_background-color: var(--semantics-input-fields-background-color);
+		--_z-index-visibility-toggle-button: 1;
 		-webkit-tap-highlight-color: transparent;
 	}
 
@@ -63,12 +64,12 @@ export const passwordFieldStyles = css`
 		--_background-color: var(--semantics-input-fields-is-autofill-background-color);
 	}
 
-	.password-field:focus-within:not(:has(.password-field__visibility-toggle:focus-within)) {
+	.password-field:focus-within:not(:has(.password-field__visibility-toggle-button:focus-within)) {
 		outline: var(--semantics-focus-ring-outline);
 		box-shadow: var(--semantics-focus-ring-box-shadow);
 	}
 
-	.password-field:has(.password-field__visibility-toggle:focus-within) {
+	.password-field:has(.password-field__visibility-toggle-button:focus-within) {
 		overflow: visible;
 	}
 
@@ -183,9 +184,9 @@ export const passwordFieldStyles = css`
 	}
 
 
-	/* # Toggle button */
+	/* # Visibility toggle button */
 
-	.password-field__visibility-toggle {
+	.password-field__visibility-toggle-button {
 		display: flex;
 		align-items: center;
 		justify-content: center;
@@ -194,9 +195,10 @@ export const passwordFieldStyles = css`
 		/* (field height - 2 x border - sm button height) / 2 */
 		padding-block: calc((var(--semantics-controls-md-min-size) - var(--semantics-input-fields-border-thickness) * 2 - var(--semantics-controls-sm-min-size)) / 2);
 		padding-inline-end: calc((var(--semantics-controls-md-min-size) - var(--semantics-input-fields-border-thickness) * 2 - var(--semantics-controls-sm-min-size)) / 2);
+		z-index: var(--_z-index-visibility-toggle-button);
 	}
 
-	:host([size='sm']) .password-field__visibility-toggle {
+	:host([size='sm']) .password-field__visibility-toggle-button {
 		/* (field height - 2 x border - xs button height) / 2 */
 		padding-block: calc((var(--semantics-controls-sm-min-size) - var(--semantics-input-fields-border-thickness) * 2 - var(--semantics-controls-xs-min-size)) / 2);
 		padding-inline-end: calc((var(--semantics-controls-sm-min-size) - var(--semantics-input-fields-border-thickness) * 2 - var(--semantics-controls-xs-min-size)) / 2);

--- a/src/components/inputs/password-field/password-field.styles.ts
+++ b/src/components/inputs/password-field/password-field.styles.ts
@@ -24,7 +24,7 @@ export const passwordFieldStyles = css`
 		align-items: center;
 		overflow: hidden;
 		box-sizing: border-box;
-		border: var(--semantics-input-fields-border-thickness) solid var(--semantics-input-fields-border-color);
+		border: var(--semantics-input-fields-border);
 		background-color: var(--_background-color);
 	}
 

--- a/src/components/inputs/password-field/password-field.styles.ts
+++ b/src/components/inputs/password-field/password-field.styles.ts
@@ -8,7 +8,7 @@ export const passwordFieldStyles = css`
 	:host {
 		display: block;
 		--_background-color: var(--semantics-input-fields-background-color);
-		--_z-index-visibility-toggle-button: 1;
+		--_z-index-button-focus: 1;
 		-webkit-tap-highlight-color: transparent;
 	}
 
@@ -83,8 +83,6 @@ export const passwordFieldStyles = css`
 		box-sizing: border-box;
 		padding: 0;
 		margin: 0;
-		min-height: calc(var(--semantics-controls-md-min-size) - var(--semantics-input-fields-border-thickness) * 2);
-		font: var(--semantics-input-fields-md-text-font);
 		color: var(--semantics-content-color);
 		background: transparent;
 		border: none;
@@ -92,31 +90,37 @@ export const passwordFieldStyles = css`
 		appearance: none;
 	}
 
-	.password-field__input.is-masked {
-		font: var(--semantics-input-fields-md-mask-font);
-	}
-
 	:host([size='sm']) .password-field__input {
 		min-height: calc(var(--semantics-controls-sm-min-size) - var(--semantics-input-fields-border-thickness) * 2);
 		font: var(--semantics-input-fields-sm-text-font);
+	}
+
+	:host([size='md']) .password-field__input,
+	:host(:not([size])) .password-field__input {
+		min-height: calc(var(--semantics-controls-md-min-size) - var(--semantics-input-fields-border-thickness) * 2);
+		font: var(--semantics-input-fields-md-text-font);
 	}
 
 	:host([size='sm']) .password-field__input.is-masked {
 		font: var(--semantics-input-fields-sm-mask-font);
 	}
 
-	:host([disabled]) .password-field__input {
-		pointer-events: none;
+	:host([size='md']) .password-field__input.is-masked,
+	:host(:not([size])) .password-field__input.is-masked {
+		font: var(--semantics-input-fields-md-mask-font);
 	}
 
 	.password-field__input::placeholder {
 		color: var(--semantics-input-fields-placeholder-color);
-		/* Always use text font for placeholder, regardless of masked state */
-		font: var(--semantics-input-fields-md-text-font);
 	}
 
 	:host([size='sm']) .password-field__input::placeholder {
 		font: var(--semantics-input-fields-sm-text-font);
+	}
+
+	:host([size='md']) .password-field__input::placeholder,
+	:host(:not([size])) .password-field__input::placeholder {
+		font: var(--semantics-input-fields-md-text-font);
 	}
 
 	.password-field__input:-webkit-autofill,
@@ -124,17 +128,21 @@ export const passwordFieldStyles = css`
 		box-shadow: 0 0 0 999px var(--_background-color) inset;
 	}
 
+	:host([disabled]) .password-field__input {
+		pointer-events: none;
+	}
 
-	/* # Fade */
 
-	.password-field__fade {
+	/* # Input fade */
+
+	.password-field__input-fade {
 		position: relative;
 		flex-shrink: 0;
 		align-self: stretch;
 		width: 0;
 	}
 
-	.password-field__fade::after {
+	.password-field__input-fade::after {
 		content: '';
 		position: absolute;
 		top: 0;
@@ -147,19 +155,23 @@ export const passwordFieldStyles = css`
 	}
 
 
-	/* # Validation icon area */
+	/* # Validation icon */
 
 	.password-field__validation-icon-area {
 		display: flex;
 		align-items: center;
 		justify-content: center;
 		flex-shrink: 0;
-		width: calc(var(--semantics-controls-md-min-size) - var(--semantics-input-fields-border-thickness) * 2);
 		height: 100%;
 	}
 
 	:host([size='sm']) .password-field__validation-icon-area {
 		width: calc(var(--semantics-controls-sm-min-size) - var(--semantics-input-fields-border-thickness) * 2);
+	}
+
+	:host([size='md']) .password-field__validation-icon-area,
+	:host(:not([size])) .password-field__validation-icon-area {
+		width: calc(var(--semantics-controls-md-min-size) - var(--semantics-input-fields-border-thickness) * 2);
 	}
 
 	:host([valid]) .password-field__validation-icon-area {
@@ -170,17 +182,15 @@ export const passwordFieldStyles = css`
 		color: var(--semantics-input-fields-is-invalid-icon-color);
 	}
 
-
-	/* # Validation icon */
-
-	.password-field__validation-icon {
-		width: var(--primitives-space-24);
-		height: var(--primitives-space-24);
+	:host([size='sm']) .password-field__validation-icon {
+		width: var(--semantics-input-fields-sm-validation-icon-size);
+		height: var(--semantics-input-fields-sm-validation-icon-size);
 	}
 
-	:host([size='sm']) .password-field__validation-icon {
-		width: var(--primitives-space-20);
-		height: var(--primitives-space-20);
+	:host([size='md']) .password-field__validation-icon,
+	:host(:not([size])) .password-field__validation-icon {
+		width: var(--semantics-input-fields-md-validation-icon-size);
+		height: var(--semantics-input-fields-md-validation-icon-size);
 	}
 
 
@@ -192,15 +202,21 @@ export const passwordFieldStyles = css`
 		justify-content: center;
 		flex-shrink: 0;
 		height: 100%;
-		/* (field height - 2 x border - sm button height) / 2 */
-		padding-block: calc((var(--semantics-controls-md-min-size) - var(--semantics-input-fields-border-thickness) * 2 - var(--semantics-controls-sm-min-size)) / 2);
-		padding-inline-end: calc((var(--semantics-controls-md-min-size) - var(--semantics-input-fields-border-thickness) * 2 - var(--semantics-controls-sm-min-size)) / 2);
-		z-index: var(--_z-index-visibility-toggle-button);
 	}
 
 	:host([size='sm']) .password-field__visibility-toggle-button {
-		/* (field height - 2 x border - xs button height) / 2 */
 		padding-block: calc((var(--semantics-controls-sm-min-size) - var(--semantics-input-fields-border-thickness) * 2 - var(--semantics-controls-xs-min-size)) / 2);
 		padding-inline-end: calc((var(--semantics-controls-sm-min-size) - var(--semantics-input-fields-border-thickness) * 2 - var(--semantics-controls-xs-min-size)) / 2);
+	}
+
+	:host([size='md']) .password-field__visibility-toggle-button,
+	:host(:not([size])) .password-field__visibility-toggle-button {
+		padding-block: calc((var(--semantics-controls-md-min-size) - var(--semantics-input-fields-border-thickness) * 2 - var(--semantics-controls-sm-min-size)) / 2);
+		padding-inline-end: calc((var(--semantics-controls-md-min-size) - var(--semantics-input-fields-border-thickness) * 2 - var(--semantics-controls-sm-min-size)) / 2);
+	}
+
+	.password-field__visibility-toggle-button:focus-within {
+		position: relative;
+		z-index: var(--_z-index-button-focus);
 	}
 `;

--- a/src/components/inputs/password-field/password-field.template.ts
+++ b/src/components/inputs/password-field/password-field.template.ts
@@ -4,21 +4,21 @@ import './../../content/icon/icon.js';
 import './../../actions/button/button.js';
 
 function renderValidationIcon(component: NLDDPasswordField): TemplateResult | typeof nothing {
-	if (component.valid) {
-		return html`
-			<div class="password-field__validation-icon-area">
-				<nldd-icon class="password-field__validation-icon"
-					name="valid"
-					aria-hidden="true"
-				></nldd-icon>
-			</div>
-		`;
-	}
 	if (component.invalid) {
 		return html`
 			<div class="password-field__validation-icon-area">
 				<nldd-icon class="password-field__validation-icon"
 					name="invalid"
+					aria-hidden="true"
+				></nldd-icon>
+			</div>
+		`;
+	}
+	if (component.valid) {
+		return html`
+			<div class="password-field__validation-icon-area">
+				<nldd-icon class="password-field__validation-icon"
+					name="valid"
 					aria-hidden="true"
 				></nldd-icon>
 			</div>

--- a/src/components/inputs/password-field/password-field.template.ts
+++ b/src/components/inputs/password-field/password-field.template.ts
@@ -33,7 +33,7 @@ function renderVisibilityToggle(component: NLDDPasswordField): TemplateResult {
 	const accessibleLabel = component.masked ? component.showAccessibleLabel : component.hideAccessibleLabel;
 
 	return html`
-		<div class="password-field__visibility-toggle">
+		<div class="password-field__visibility-toggle-button">
 			<nldd-button
 				size=${buttonSize}
 				type="button"

--- a/src/components/inputs/password-field/password-field.template.ts
+++ b/src/components/inputs/password-field/password-field.template.ts
@@ -66,7 +66,7 @@ export function passwordFieldTemplate(component: NLDDPasswordField): TemplateRes
 				@input=${component._handleInput}
 				@change=${component._handleChange}
 			/>
-			<div class="password-field__fade"></div>
+			<div class="password-field__input-fade"></div>
 			${renderValidationIcon(component)}
 			${renderVisibilityToggle(component)}
 		</div>

--- a/src/components/inputs/password-field/password-field.test.ts
+++ b/src/components/inputs/password-field/password-field.test.ts
@@ -34,7 +34,7 @@ describe('nldd-password-field', () => {
 		el = await fixture('<nldd-password-field></nldd-password-field>');
 		await waitForUpdate(el);
 		expect((el as any).masked).toBe(true);
-		const button = el.shadowRoot!.querySelector('.password-field__visibility-toggle nldd-button')!;
+		const button = el.shadowRoot!.querySelector('.password-field__visibility-toggle-button nldd-button')!;
 		(button as HTMLElement).click();
 		await waitForUpdate(el);
 		expect((el as any).masked).toBe(false);
@@ -175,7 +175,7 @@ describe('nldd-password-field', () => {
 	it('disables visibility toggle button when disabled', async () => {
 		el = await fixture('<nldd-password-field disabled></nldd-password-field>');
 		await waitForUpdate(el);
-		const button = el.shadowRoot!.querySelector('.password-field__visibility-toggle nldd-button')!;
+		const button = el.shadowRoot!.querySelector('.password-field__visibility-toggle-button nldd-button')!;
 		expect(button.hasAttribute('disabled')).toBe(true);
 	});
 

--- a/src/components/inputs/search-field/search-field.styles.ts
+++ b/src/components/inputs/search-field/search-field.styles.ts
@@ -8,6 +8,7 @@ export const searchFieldStyles = css`
 	:host {
 		display: block;
 		--_background-color: var(--semantics-input-fields-background-color);
+		--_z-index-button-focus: 1;
 		-webkit-tap-highlight-color: transparent;
 	}
 
@@ -66,17 +67,17 @@ export const searchFieldStyles = css`
 		color: var(--semantics-content-secondary-color);
 	}
 
+	:host([size='sm']) .search-field__search-icon {
+		width: var(--primitives-space-20);
+		height: var(--primitives-space-20);
+		margin-inline: calc((var(--semantics-controls-sm-min-size) - var(--primitives-space-20)) / 2 - var(--semantics-input-fields-border-thickness));
+	}
+
 	:host([size='md']) .search-field__search-icon,
 	:host(:not([size])) .search-field__search-icon {
 		width: var(--primitives-space-24);
 		height: var(--primitives-space-24);
 		margin-inline: calc((var(--semantics-controls-md-min-size) - var(--primitives-space-24)) / 2 - var(--semantics-input-fields-border-thickness));
-	}
-
-	:host([size='sm']) .search-field__search-icon {
-		width: var(--primitives-space-20);
-		height: var(--primitives-space-20);
-		margin-inline: calc((var(--semantics-controls-sm-min-size) - var(--primitives-space-20)) / 2 - var(--semantics-input-fields-border-thickness));
 	}
 
 
@@ -95,13 +96,13 @@ export const searchFieldStyles = css`
 		color: var(--semantics-content-color);
 	}
 
+	:host([size='sm']) .search-field__input {
+		font: var(--semantics-input-fields-sm-text-font);
+	}
+
 	:host([size='md']) .search-field__input,
 	:host(:not([size])) .search-field__input {
 		font: var(--semantics-input-fields-md-text-font);
-	}
-
-	:host([size='sm']) .search-field__input {
-		font: var(--semantics-input-fields-sm-text-font);
 	}
 
 	.search-field__input::placeholder {
@@ -118,52 +119,59 @@ export const searchFieldStyles = css`
 	}
 
 
-	/* # Fade */
+	/* # Input fade */
 
-	.search-field__fade {
+	.search-field__input-fade {
 		position: relative;
 		flex-shrink: 0;
 		align-self: stretch;
 		width: 0;
 	}
 
-	.search-field__fade::after {
+	.search-field__input-fade::after {
 		content: '';
 		position: absolute;
 		top: 0;
 		bottom: 0;
 		right: 0;
 		width: var(--primitives-space-8);
-		border-radius: var(--semantics-controls-md-corner-radius);
 		background: linear-gradient(90deg, color-mix(in oklch, var(--_background-color) 0%, transparent) 0%, var(--_background-color) 100%);
 		pointer-events: none;
 	}
 
+	:host([size='sm']) .search-field__input-fade::after {
+		border-radius: var(--semantics-controls-sm-corner-radius);
+	}
 
-	/* # Actions */
+	:host([size='md']) .search-field__input-fade::after,
+	:host(:not([size])) .search-field__input-fade::after {
+		border-radius: var(--semantics-controls-md-corner-radius);
+	}
 
-	.search-field__actions {
+
+	/* # End */
+
+	.search-field__end {
 		display: flex;
 		flex-shrink: 0;
 		align-items: center;
 		position: relative;
-		z-index: 1;
 	}
 
-	:host([size='md']) .search-field__actions,
-	:host(:not([size])) .search-field__actions {
-		padding-right: calc((var(--semantics-controls-md-min-size) - var(--semantics-controls-sm-min-size)) / 2 - var(--semantics-input-fields-border-thickness));
-		gap: var(--primitives-space-6);
-	}
-
-	:host([size='sm']) .search-field__actions {
+	:host([size='sm']) .search-field__end {
 		padding-right: calc((var(--semantics-controls-sm-min-size) - var(--semantics-controls-xs-min-size)) / 2 - var(--semantics-input-fields-border-thickness));
 		gap: var(--primitives-space-4);
 	}
 
-	.search-field__clear-action:focus-within,
-	.search-field__search-action:focus-within {
+	:host([size='md']) .search-field__end,
+	:host(:not([size])) .search-field__end {
+		padding-right: calc((var(--semantics-controls-md-min-size) - var(--semantics-controls-sm-min-size)) / 2 - var(--semantics-input-fields-border-thickness));
+		gap: var(--primitives-space-6);
+	}
+
+	.search-field__clear-button:focus-within,
+	.search-field__search-button:focus-within {
 		position: relative;
-		z-index: 1;
+		z-index: var(--_z-index-button-focus);
 	}
 `;

--- a/src/components/inputs/search-field/search-field.styles.ts
+++ b/src/components/inputs/search-field/search-field.styles.ts
@@ -31,7 +31,7 @@ export const searchFieldStyles = css`
 		box-sizing: border-box;
 		width: 100%;
 		background-color: var(--_background-color);
-		border: var(--semantics-input-fields-border-thickness) solid var(--semantics-input-fields-border-color);
+		border: var(--semantics-input-fields-border);
 	}
 
 	:host([size='sm']) .search-field {

--- a/src/components/inputs/search-field/search-field.template.ts
+++ b/src/components/inputs/search-field/search-field.template.ts
@@ -23,10 +23,10 @@ export function searchFieldTemplate(component: NLDDSearchField): TemplateResult 
 				@change=${component._handleChange}
 				@keydown=${component._handleKeydown}
 			>
-			<div class="search-field__fade"></div>
-			<div class="search-field__actions">
+			<div class="search-field__input-fade"></div>
+			<div class="search-field__end">
 				${component.value ? html`
-					<div class="search-field__clear-action">
+					<div class="search-field__clear-button">
 						<nldd-icon-button
 							variant="neutral-transparent"
 							size=${buttonSize}
@@ -37,7 +37,7 @@ export function searchFieldTemplate(component: NLDDSearchField): TemplateResult 
 					</div>
 				` : nothing}
 				${component.hasSearchButton ? html`
-					<div class="search-field__search-action">
+					<div class="search-field__search-button">
 						<nldd-button
 							variant="neutral-tinted"
 							size=${buttonSize}

--- a/src/components/inputs/search-field/search-field.test.ts
+++ b/src/components/inputs/search-field/search-field.test.ts
@@ -192,4 +192,24 @@ describe('nldd-search-field – dismiss', () => {
 		await waitForUpdate(el);
 		expect(el.shadowRoot!.querySelector('nldd-icon-button')).toBeNull();
 	});
+
+	it('dispatches input event with empty value on dismiss', async () => {
+		el = await fixture<NLDDSearchField>('<nldd-search-field value="test"></nldd-search-field>');
+		await waitForUpdate(el);
+		let detail: any;
+		el.addEventListener('input', ((e: CustomEvent) => { detail = e.detail; }) as EventListener);
+		el._handleClear();
+		expect(detail?.value).toBe('');
+	});
+
+	it('refocuses the input after dismiss', async () => {
+		el = await fixture<NLDDSearchField>('<nldd-search-field value="test"></nldd-search-field>');
+		await waitForUpdate(el);
+		const input = el.shadowRoot!.querySelector('input')!;
+		el._handleClear();
+		await waitForUpdate(el);
+		let active: Element | null = document.activeElement;
+		while (active?.shadowRoot?.activeElement) active = active.shadowRoot.activeElement;
+		expect(active).toBe(input);
+	});
 });

--- a/src/components/inputs/search-field/search-field.ts
+++ b/src/components/inputs/search-field/search-field.ts
@@ -106,11 +106,17 @@ export class NLDDSearchField extends LitElement {
 
 	public _handleClear(): void {
 		this.value = '';
+		this.dispatchEvent(new CustomEvent('input', {
+			detail: { value: '' },
+			bubbles: true,
+			composed: true,
+		}));
 		this.dispatchEvent(new CustomEvent('change', {
 			detail: { value: '' },
 			bubbles: true,
 			composed: true,
 		}));
+		this._input?.focus();
 	}
 
 	public _handleSearch(): void {

--- a/src/components/inputs/stepper/stepper.i18n.ts
+++ b/src/components/inputs/stepper/stepper.i18n.ts
@@ -1,6 +1,6 @@
 export const nlddStepperTranslations = {
-	'components.stepper.decrement-action': 'Verlaag aantal',
-	'components.stepper.increment-action': 'Verhoog aantal',
+	'components.stepper.decrement-action': 'Verlaag',
+	'components.stepper.increment-action': 'Verhoog',
 	'components.stepper.to-adjust-value-action': 'Aantal aanpassen',
 };
 

--- a/src/components/inputs/stepper/stepper.stories.js
+++ b/src/components/inputs/stepper/stepper.stories.js
@@ -45,7 +45,7 @@ export default {
 		},
 		size: {
 			control: 'select',
-			options: ['sm', 'md'],
+			options: ['xs', 'sm', 'md'],
 			description: 'Grootte van de stepper',
 			table: { defaultValue: { summary: 'md' } },
 		},
@@ -94,6 +94,12 @@ export const AlleToestanden = () => html`
 		<div style="display: flex; gap: 1rem; align-items: center;">
 			<span style="font: var(--primitives-font-body-md-regular-snug); min-width: 2ch;">5</span>
 			<nldd-stepper value="5" min="0" max="10" size="sm"
+				@change=${(e) => { e.target.previousElementSibling.textContent = e.detail.value; }}
+			></nldd-stepper>
+		</div>
+		<div style="display: flex; gap: 1rem; align-items: center;">
+			<span style="font: var(--primitives-font-body-md-regular-snug); min-width: 2ch;">5</span>
+			<nldd-stepper value="5" min="0" max="10" size="xs"
 				@change=${(e) => { e.target.previousElementSibling.textContent = e.detail.value; }}
 			></nldd-stepper>
 		</div>

--- a/src/components/inputs/stepper/stepper.stories.js
+++ b/src/components/inputs/stepper/stepper.stories.js
@@ -87,7 +87,7 @@ export const AlleToestanden = () => html`
 	<div style="display: flex; flex-direction: column; gap: 1rem;">
 		<div style="display: flex; gap: 1rem; align-items: center;">
 			<span style="font: var(--primitives-font-body-md-regular-snug); min-width: 2ch;">5</span>
-			<nldd-stepper value="5" min="0" max="10" size="md"
+			<nldd-stepper value="5" min="0" max="10" size="xs"
 				@change=${(e) => { e.target.previousElementSibling.textContent = e.detail.value; }}
 			></nldd-stepper>
 		</div>
@@ -99,7 +99,7 @@ export const AlleToestanden = () => html`
 		</div>
 		<div style="display: flex; gap: 1rem; align-items: center;">
 			<span style="font: var(--primitives-font-body-md-regular-snug); min-width: 2ch;">5</span>
-			<nldd-stepper value="5" min="0" max="10" size="xs"
+			<nldd-stepper value="5" min="0" max="10" size="md"
 				@change=${(e) => { e.target.previousElementSibling.textContent = e.detail.value; }}
 			></nldd-stepper>
 		</div>

--- a/src/components/inputs/stepper/stepper.styles.ts
+++ b/src/components/inputs/stepper/stepper.styles.ts
@@ -33,6 +33,10 @@ export const stepperStyles = css`
 		background-color: var(--semantics-buttons-neutral-tinted-background-color);
 	}
 
+	:host([size='xs']) .stepper {
+		border-radius: var(--semantics-controls-xs-corner-radius);
+	}
+
 	:host([size='sm']) .stepper {
 		border-radius: var(--semantics-controls-sm-corner-radius);
 	}
@@ -54,6 +58,10 @@ export const stepperStyles = css`
 		width: var(--semantics-dividers-thickness);
 		flex-shrink: 0;
 		background-color: var(--semantics-buttons-neutral-tinted-divider-color);
+	}
+
+	:host([size='xs']) .stepper__divider {
+		height: var(--semantics-buttons-xs-divider-length);
 	}
 
 	:host([size='sm']) .stepper__divider {

--- a/src/components/inputs/stepper/stepper.test.ts
+++ b/src/components/inputs/stepper/stepper.test.ts
@@ -231,8 +231,8 @@ describe('nldd-stepper – translations', () => {
 	it('uses Dutch defaults when no translations are set', async () => {
 		el = await fixture<NLDDStepper>('<nldd-stepper></nldd-stepper>');
 		await waitForUpdate(el);
-		expect(el._t('components.stepper.decrement-action')).toBe('Verlaag aantal');
-		expect(el._t('components.stepper.increment-action')).toBe('Verhoog aantal');
+		expect(el._t('components.stepper.decrement-action')).toBe('Verlaag');
+		expect(el._t('components.stepper.increment-action')).toBe('Verhoog');
 		expect(el._t('components.stepper.to-adjust-value-action')).toBe('Aantal aanpassen');
 	});
 
@@ -247,6 +247,6 @@ describe('nldd-stepper – translations', () => {
 		el = await fixture<NLDDStepper>('<nldd-stepper></nldd-stepper>');
 		await waitForUpdate(el);
 		el.translations = { 'components.stepper.decrement-action': 'Decrease' };
-		expect(el._t('components.stepper.increment-action')).toBe('Verhoog aantal');
+		expect(el._t('components.stepper.increment-action')).toBe('Verhoog');
 	});
 });

--- a/src/components/inputs/stepper/stepper.test.ts
+++ b/src/components/inputs/stepper/stepper.test.ts
@@ -25,6 +25,33 @@ describe('nldd-stepper', () => {
 
 
 /* ============================================================
+   Size
+   ============================================================ */
+
+describe('nldd-stepper – size', () => {
+	let el: NLDDStepper;
+
+	afterEach(() => {
+		if (el) cleanup(el);
+	});
+
+	it('defaults size to md', async () => {
+		el = await fixture<NLDDStepper>('<nldd-stepper></nldd-stepper>');
+		await waitForUpdate(el);
+		expect(el.size).toBe('md');
+	});
+
+	it('reflects size="xs" to host and propagates to icon buttons', async () => {
+		el = await fixture<NLDDStepper>('<nldd-stepper size="xs"></nldd-stepper>');
+		await waitForUpdate(el);
+		expect(el.getAttribute('size')).toBe('xs');
+		const buttons = el.shadowRoot!.querySelectorAll('nldd-icon-button');
+		expect(buttons[0].getAttribute('size')).toBe('xs');
+	});
+});
+
+
+/* ============================================================
    State
    ============================================================ */
 

--- a/src/components/inputs/stepper/stepper.test.ts
+++ b/src/components/inputs/stepper/stepper.test.ts
@@ -41,12 +41,13 @@ describe('nldd-stepper – size', () => {
 		expect(el.size).toBe('md');
 	});
 
-	it('reflects size="xs" to host and propagates to icon buttons', async () => {
+	it('reflects size="xs" to host and propagates to both icon buttons', async () => {
 		el = await fixture<NLDDStepper>('<nldd-stepper size="xs"></nldd-stepper>');
 		await waitForUpdate(el);
 		expect(el.getAttribute('size')).toBe('xs');
 		const buttons = el.shadowRoot!.querySelectorAll('nldd-icon-button');
 		expect(buttons[0].getAttribute('size')).toBe('xs');
+		expect(buttons[1].getAttribute('size')).toBe('xs');
 	});
 });
 

--- a/src/components/inputs/stepper/stepper.ts
+++ b/src/components/inputs/stepper/stepper.ts
@@ -9,7 +9,7 @@
  * @attr {number}  max          - Maximum value (default: Infinity)
  * @attr {number}  step         - Step size (default: 1)
  * @attr {boolean} disabled     - Disabled state
- * @attr {string}  size         - Size: 'sm' | 'md' (default: 'md')
+ * @attr {string}  size         - Size: 'xs' | 'sm' | 'md' (default: 'md')
  * @attr {object}  translations - Translations; unspecified keys fall back to Dutch
  *
  * @fires change - When the value changes; detail: { value: number }
@@ -23,7 +23,7 @@ import type { NLDDStepperTranslations } from './stepper.i18n.js';
 import './../../actions/icon-button/icon-button.js';
 import './../../content/icon/icon.js';
 
-export type StepperSize = 'sm' | 'md';
+export type StepperSize = 'xs' | 'sm' | 'md';
 
 @customElement('nldd-stepper')
 export class NLDDStepper extends LitElement {

--- a/src/components/inputs/text-field/text-field.stories.js
+++ b/src/components/inputs/text-field/text-field.stories.js
@@ -48,7 +48,7 @@ export default {
 		},
 		size: {
 			control: 'select',
-			options: ['md', 'sm'],
+			options: ['sm', 'md'],
 			description: 'Size variant',
 			table: { defaultValue: { summary: 'md' } },
 		},

--- a/src/components/inputs/text-field/text-field.styles.ts
+++ b/src/components/inputs/text-field/text-field.styles.ts
@@ -78,8 +78,6 @@ export const textFieldStyles = css`
 		box-sizing: border-box;
 		padding: 0;
 		margin: 0;
-		min-height: calc(var(--semantics-controls-md-min-size) - var(--semantics-input-fields-border-thickness) * 2);
-		font: var(--semantics-input-fields-md-text-font);
 		color: var(--semantics-content-color);
 		background: transparent;
 		border: none;
@@ -90,6 +88,12 @@ export const textFieldStyles = css`
 	:host([size='sm']) .text-field__input {
 		min-height: calc(var(--semantics-controls-sm-min-size) - var(--semantics-input-fields-border-thickness) * 2);
 		font: var(--semantics-input-fields-sm-text-font);
+	}
+
+	:host([size='md']) .text-field__input,
+	:host(:not([size])) .text-field__input {
+		min-height: calc(var(--semantics-controls-md-min-size) - var(--semantics-input-fields-border-thickness) * 2);
+		font: var(--semantics-input-fields-md-text-font);
 	}
 
 	:host([disabled]) .text-field__input {
@@ -106,29 +110,33 @@ export const textFieldStyles = css`
 	}
 
 
-	/* # Fade */
+	/* # Input fade */
 
-	.text-field__fade {
+	.text-field__input-fade {
 		position: relative;
 		flex-shrink: 0;
 		align-self: stretch;
 		width: 0;
 	}
 
-	.text-field__fade::after {
+	.text-field__input-fade::after {
 		content: '';
 		position: absolute;
 		top: 0;
 		bottom: 0;
 		right: 0;
 		width: var(--primitives-space-8);
-		border-radius: var(--semantics-controls-md-corner-radius);
 		background: linear-gradient(90deg, color-mix(in oklch, var(--_background-color) 0%, transparent) 0%, var(--_background-color) 100%);
 		pointer-events: none;
 	}
 
-	:host([size='sm']) .text-field__fade::after {
+	:host([size='sm']) .text-field__input-fade::after {
 		border-radius: var(--semantics-controls-sm-corner-radius);
+	}
+
+	:host([size='md']) .text-field__input-fade::after,
+	:host(:not([size])) .text-field__input-fade::after {
+		border-radius: var(--semantics-controls-md-corner-radius);
 	}
 
 
@@ -139,12 +147,16 @@ export const textFieldStyles = css`
 		align-items: center;
 		justify-content: center;
 		flex-shrink: 0;
-		width: calc(var(--semantics-controls-md-min-size) - var(--semantics-input-fields-border-thickness) * 2);
 		height: 100%;
 	}
 
 	:host([size='sm']) .text-field__validation-icon-area {
 		width: calc(var(--semantics-controls-sm-min-size) - var(--semantics-input-fields-border-thickness) * 2);
+	}
+
+	:host([size='md']) .text-field__validation-icon-area,
+	:host(:not([size])) .text-field__validation-icon-area {
+		width: calc(var(--semantics-controls-md-min-size) - var(--semantics-input-fields-border-thickness) * 2);
 	}
 
 	:host([valid]) .text-field__validation-icon-area {
@@ -158,13 +170,14 @@ export const textFieldStyles = css`
 
 	/* # Validation icon */
 
-	.text-field__validation-icon {
-		width: var(--primitives-space-24);
-		height: var(--primitives-space-24);
+	:host([size='sm']) .text-field__validation-icon {
+		width: var(--semantics-input-fields-sm-validation-icon-size);
+		height: var(--semantics-input-fields-sm-validation-icon-size);
 	}
 
-	:host([size='sm']) .text-field__validation-icon {
-		width: var(--primitives-space-20);
-		height: var(--primitives-space-20);
+	:host([size='md']) .text-field__validation-icon,
+	:host(:not([size])) .text-field__validation-icon {
+		width: var(--semantics-input-fields-md-validation-icon-size);
+		height: var(--semantics-input-fields-md-validation-icon-size);
 	}
 `;

--- a/src/components/inputs/text-field/text-field.styles.ts
+++ b/src/components/inputs/text-field/text-field.styles.ts
@@ -24,7 +24,7 @@ export const textFieldStyles = css`
 		align-items: center;
 		overflow: hidden;
 		box-sizing: border-box;
-		border: var(--semantics-input-fields-border-thickness) solid var(--semantics-input-fields-border-color);
+		border: var(--semantics-input-fields-border);
 		background-color: var(--_background-color);
 	}
 

--- a/src/components/inputs/text-field/text-field.template.ts
+++ b/src/components/inputs/text-field/text-field.template.ts
@@ -45,7 +45,7 @@ export function textFieldTemplate(component: NLDDTextField): TemplateResult {
 				@input=${component._handleInput}
 				@change=${component._handleChange}
 			/>
-			<div class="text-field__fade"></div>
+			<div class="text-field__input-fade"></div>
 			${renderValidationIcon(component)}
 		</div>
 	`;

--- a/src/components/inputs/text-field/text-field.template.ts
+++ b/src/components/inputs/text-field/text-field.template.ts
@@ -3,21 +3,21 @@ import type { NLDDTextField } from './text-field.js';
 import './../../content/icon/icon.js';
 
 function renderValidationIcon(component: NLDDTextField): TemplateResult | typeof nothing {
-	if (component.valid) {
-		return html`
-			<div class="text-field__validation-icon-area">
-				<nldd-icon class="text-field__validation-icon"
-					name="valid"
-					aria-hidden="true"
-				></nldd-icon>
-			</div>
-		`;
-	}
 	if (component.invalid) {
 		return html`
 			<div class="text-field__validation-icon-area">
 				<nldd-icon class="text-field__validation-icon"
 					name="invalid"
+					aria-hidden="true"
+				></nldd-icon>
+			</div>
+		`;
+	}
+	if (component.valid) {
+		return html`
+			<div class="text-field__validation-icon-area">
+				<nldd-icon class="text-field__validation-icon"
+					name="valid"
 					aria-hidden="true"
 				></nldd-icon>
 			</div>

--- a/src/components/lists-and-menus/cells/drag-handle-cell/drag-handle-cell.stories.js
+++ b/src/components/lists-and-menus/cells/drag-handle-cell/drag-handle-cell.stories.js
@@ -8,7 +8,7 @@ export default {
 	argTypes: {
 		size: {
 			control: 'select',
-			options: ['md', 'sm'],
+			options: ['sm', 'md'],
 			description: 'Handle size',
 			table: {
 				defaultValue: { summary: 'md' },

--- a/src/components/lists-and-menus/cells/text-cell/text-cell.stories.js
+++ b/src/components/lists-and-menus/cells/text-cell/text-cell.stories.js
@@ -8,7 +8,7 @@ export default {
 	argTypes: {
 		size: {
 			control: 'select',
-			options: ['md', 'sm'],
+			options: ['sm', 'md'],
 			description: 'Text cell size',
 			table: { defaultValue: { summary: 'md' } },
 		},


### PR DESCRIPTION
## Summary
- **combo-box** en **number-field**: nieuwe `sm` variant (size-attribuut toegevoegd)
- **stepper** en **dropdown**: nieuwe `xs` variant (uitbreiding van bestaande sm/md)
- **password-field**: focus-visibility toggle button blijft nu boven de fade layer staan (via lokale z-index var); class hernoemd naar `password-field__visibility-toggle-button`
- Nieuwe tokens `--semantics-input-fields-xs-text-font` + `-mask-font`, plus shorthand `--semantics-input-fields-border` (vervangt `... thickness solid ... color` in 5 componenten)
- Size-selectors herordend naar xs → sm → md in aangepaste componenten
- Size-opties in stories herordend klein → groot (password-field, text-field, text-cell, drag-handle-cell)
- Dropdown: font op onzichtbare `<select>` teruggebracht tot één waarde (16px) voor leesbaar native menu in Safari zonder iOS auto-zoom

## Test plan
- [x] `npm run validate:styles` groen
- [x] `npm test` — 1031/1031 tests groen
- [x] `npm run build` slaagt
- [x] Controleer in browser: elke size-variant in Storybook van stepper, dropdown, combo-box en number-field
- [x] Controleer native select-menu in Safari (desktop en iOS) — moet leesbaar zijn bij alle dropdown sizes
- [x] Controleer password-field: visibility toggle blijft zichtbaar wanneer je erop focust (niet afgekapt door fade)