### PR TITLE
feat!: publish to npmjs as @nldd/design-system

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -1,5 +1,9 @@
 name: Publish to npmjs
 
+# Requires repository secret NPM_TOKEN: a granular npmjs token with
+# read+write access to the @nldd scope and 2FA bypass enabled.
+# Without it, the publish step fails with E401/EAUTH at runtime.
+
 on:
   push:
     branches:

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -29,6 +29,7 @@ jobs:
       startsWith(github.event.head_commit.message, 'chore(release):')
     permissions:
       contents: read
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -52,6 +53,6 @@ jobs:
         run: npm version ${{ inputs.version }} --no-git-tag-version
 
       - name: Publish to npmjs
-        run: npm publish
+        run: npm publish --provenance
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -1,4 +1,4 @@
-name: Publish to GitHub Packages
+name: Publish to npmjs
 
 on:
   push:
@@ -25,7 +25,6 @@ jobs:
       startsWith(github.event.head_commit.message, 'chore(release):')
     permissions:
       contents: read
-      packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -35,8 +34,8 @@ jobs:
         with:
           node-version: '20'
           cache: 'npm'
-          registry-url: 'https://npm.pkg.github.com'
-          scope: '@minbzk'
+          registry-url: 'https://registry.npmjs.org'
+          scope: '@nldd'
 
       - name: Install dependencies
         run: npm ci
@@ -48,7 +47,7 @@ jobs:
         if: ${{ inputs.version != '' }}
         run: npm version ${{ inputs.version }} --no-git-tag-version
 
-      - name: Publish to GitHub Packages
+      - name: Publish to npmjs
         run: npm publish
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-@minbzk:registry=https://npm.pkg.github.com

--- a/README.md
+++ b/README.md
@@ -4,38 +4,21 @@ Web Components voor Nederlandse Digitale Dienst (Rijksoverheid).
 
 ## Installatie
 
-### Via npm (GitHub Packages)
-
-1. Voeg `.npmrc` toe aan je project voor GitHub Packages authenticatie:
-
-```
-@minbzk:registry=https://npm.pkg.github.com
-```
-
-2. Authenticeer bij GitHub Packages (eenmalig):
-
 ```bash
-npm login --registry=https://npm.pkg.github.com
-# Gebruik je GitHub-gebruikersnaam en een personal access token met `read:packages` scope
-```
-
-3. Installeer het pakket:
-
-```bash
-npm install @minbzk/storybook
+npm install @nldd/design-system
 ```
 
 ### Gebruik
 
 ```javascript
 // Importeer CSS variabelen en fonts (vereist voor styling)
-import '@minbzk/storybook/styles';
+import '@nldd/design-system/styles';
 
 // Importeer alle componenten
-import '@minbzk/storybook';
+import '@nldd/design-system';
 
 // Of importeer specifieke componenten
-import { NLDDButton, NLDDCheckbox, NLDDSwitch } from '@minbzk/storybook';
+import { NLDDButton, NLDDCheckbox, NLDDSwitch } from '@nldd/design-system';
 ```
 
 ```html

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "@minbzk/storybook",
-  "version": "0.8.35",
+  "name": "@nldd/design-system",
+  "version": "0.8.36",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@minbzk/storybook",
-      "version": "0.8.35",
+      "name": "@nldd/design-system",
+      "version": "0.8.36",
       "license": "EUPL-1.2",
       "dependencies": {
         "@floating-ui/dom": "^1.7.6",

--- a/package.json
+++ b/package.json
@@ -334,7 +334,8 @@
     "url": "https://github.com/MinBZK/storybook.git"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "registry": "https://registry.npmjs.org"
   },
   "scripts": {
     "build": "npm run build:styles && npm run validate:styles && npm run build:components",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@minbzk/storybook",
+  "name": "@nldd/design-system",
   "version": "0.8.36",
   "description": "Design System voor Nederlandse Digitale Dienst",
   "type": "module",
@@ -334,7 +334,7 @@
     "url": "https://github.com/MinBZK/storybook.git"
   },
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com"
+    "access": "public"
   },
   "scripts": {
     "build": "npm run build:styles && npm run validate:styles && npm run build:components",

--- a/src/components/forms/form/form.ts
+++ b/src/components/forms/form/form.ts
@@ -68,7 +68,7 @@
  * @example
  * Globale stylesheet import (eenmalig in je app entry):
  * ```js
- * import '@minbzk/storybook/dist/css/global.css';
+ * import '@nldd/design-system/styles';
  * ```
  *
  * Auto-wrap mode:

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -2,10 +2,10 @@
  * Nederlandse Digitale Dienst Design System Components
  *
  * Import this file to register all components:
- * import '@minbzk/storybook';
+ * import '@nldd/design-system';
  *
  * Or import individual components:
- * import '@minbzk/storybook/components/actions/button';
+ * import '@nldd/design-system/button';
  */
 
 


### PR DESCRIPTION
## Summary

- Switch van GitHub Packages naar npmjs.com als publieke registry
- Pakketnaam: `@minbzk/storybook` → `@nldd/design-system`
- Geen `.npmrc` / auth-token meer nodig voor consumers
- Workflow gebruikt `NPM_TOKEN` secret en target `https://registry.npmjs.org`

## Breaking change

Bestaande consumers moeten `package.json` en imports bijwerken:
- `@minbzk/storybook` → `@nldd/design-system`
- imports: `@minbzk/storybook/...` → `@nldd/design-system/...`

Oude `@minbzk/storybook` versies blijven beschikbaar op GitHub Packages, maar krijgen geen updates meer.

## Test plan
- [ ] PR merget naar main
- [ ] semantic-release bumpt naar 0.8.37
- [ ] Workflow `Publish to npmjs` slaagt
- [ ] `@nldd/design-system@0.8.37` verschijnt op npmjs.com/org/nldd
- [ ] `npm install @nldd/design-system` werkt zonder `.npmrc`