### PR TITLE
Layout components for regelrecht editor

### DIFF
--- a/.claude/skills/responsive-css/SKILL.md
+++ b/.claude/skills/responsive-css/SKILL.md
@@ -248,6 +248,8 @@ Voor properties met *veel* breakpoint-varianten (bv. heading sizes met 6 levels 
 
 Deze workaround is acceptabel als de regel-explosie anders te erg wordt. Document de keuze in het component zelf.
 
+> **Let op:** dit voorbeeld breekt bewust de eerder beschreven nesting-conventie (at-rules genest binnen selectors). Bij dit var-swap patroon is het @container blok niet "een eigenschap toevoegen aan deze selector", maar "een hele property-waarde omschakelen voor de hele cascade". Top-level wrapping leest dan duidelijker dan nesting in elke selector die de var leest. Houd het wel binnen één component.
+
 ## State-conditional layouts (label-alignment, etc.)
 
 Sommige componenten hebben layouts die alleen wisselen op basis van een

--- a/.claude/skills/responsive-css/SKILL.md
+++ b/.claude/skills/responsive-css/SKILL.md
@@ -1,0 +1,292 @@
+---
+name: responsive-css
+description: Conventie voor responsive CSS in design-system componenten — expliciet per breakpoint, geen mobile-first overrides
+user-invocable: false
+---
+
+# Responsive CSS conventie
+
+Schrijf responsive component-CSS **expliciet per breakpoint**. Geen mobile-first base-waarde die in `@media` of `@container` queries wordt overschreven.
+
+## Waarom
+
+Voor een design-system zwaarder dan voor een gewone app. Componenten worden door derden geconsumeerd, geaudit, en visueel gecontroleerd per breakpoint. Een mobile-first override creëert een impliciete cascade die de developer moet "uitrekenen": *"wat is de actuele waarde op md?"*. Met expliciet-per-breakpoint staat het antwoord direct in de regel.
+
+Trade-off: méér CSS-regels per property dat verschilt per breakpoint. Voor design-system componenten weegt determinisme zwaarder dan kort-en-bondig.
+
+## Regel
+
+Een property die varieert per breakpoint mag **niet** een base-waarde buiten queries hebben. Elke variant zit in z'n eigen `@media`/`@container` block.
+
+Een property die **niet** varieert per breakpoint blijft buiten queries — dat is de natuurlijke base.
+
+## Voorbeeld
+
+❌ **Mobile-first met override (vermijd):**
+
+```css
+.simple-section {
+  display: flex;
+  padding: var(--sm-padding);    /* sm value als "base" */
+
+  @container (min-width: 641px) {
+    padding: var(--md-padding);  /* override */
+  }
+  @container (min-width: 1008px) {
+    padding: var(--lg-padding);  /* nog een override */
+  }
+}
+```
+
+✅ **Expliciet per breakpoint:**
+
+```css
+.simple-section {
+  display: flex;                 /* niet-responsief: blijft in base */
+
+  @container (max-width: 640px) {
+    padding: var(--sm-padding);
+  }
+
+  @container (min-width: 641px) and (max-width: 1007px) {
+    padding: var(--md-padding);
+  }
+
+  @container (min-width: 1008px) {
+    padding: var(--lg-padding);
+  }
+}
+```
+
+## At-rule positie: nest binnen de selector
+
+Voorkeur: `@media`/`@container` genest binnen de selector via native CSS
+nesting. Niet gehoist als top-level wrapper. Argumenten:
+
+- **Lokaliteit**: alle responsive-regels voor een component-element staan
+  bij elkaar — om uit te zoeken hoe `.foo` zich gedraagt zoek je op `.foo`,
+  niet op alle media queries verspreid door 't bestand
+- **Geen selector-duplicatie**: één keer `.foo {}`, daarbinnen alle varianten
+- **Past bij component-architectuur**: elk element heeft één regel met
+  z'n volledige verantwoordelijkheid
+
+❌ **Wrapper rond selector (vermijd):**
+```css
+.foo {
+  display: flex;
+}
+
+@media (max-width: 640px) {
+  .foo {
+    padding: 8px;
+  }
+}
+```
+
+✅ **Nested in selector:**
+```css
+.foo {
+  display: flex;
+
+  @media (max-width: 640px) {
+    padding: 8px;
+  }
+}
+```
+
+## Lokale CSS-variabelen bovenaan
+
+Declareer lokale custom properties (`--_*` voor private, `--components-*`/
+`--context-*` voor public) bovenaan het `:host` (of vergelijkbare top-level
+selector) blok, gescheiden van de rest met een witregel. Zo zie je in één
+oogopslag wat er instelbaar is voordat je de eigen properties leest.
+
+```css
+:host {
+  --_max-height: calc(100vh - var(--semantics-overlays-inset) * 2);
+  --components-popover-default-width: 320px;
+
+  display: flex;
+  margin: 0;
+  padding: 0;
+  /* ... */
+}
+```
+
+## Volgorde: kleinste breakpoint eerst
+
+Plaats `@media`/`@container` blokken in oplopende volgorde — sm, md, lg.
+Binnen elk paar (eerst `@media`, dan `@container`) ook in die volgorde.
+Maakt scannen voorspelbaar: linksboven sm, rechtsonder lg.
+
+```css
+.foo {
+  display: flex;
+
+  @media (max-width: 640px) { … }                                /* sm */
+  @media (min-width: 641px) and (max-width: 1007px) { … }        /* md */
+  @media (min-width: 1008px) { … }                               /* lg */
+
+  @container layout-area (max-width: 640px) { … }                /* sm */
+  @container layout-area (min-width: 641px) and (max-width: 1007px) { … }  /* md */
+  @container layout-area (min-width: 1008px) { … }               /* lg */
+}
+```
+
+## Witregels tussen breakpoint-blokken
+
+Zet een witregel tussen elk `@media`/`@container` blok binnen dezelfde
+selector — ook tussen twee opeenvolgende `@media` of twee opeenvolgende
+`@container` blokken. Dat geeft elk breakpoint visueel z'n eigen ruimte.
+
+```css
+.foo {
+  display: flex;
+
+  @media (max-width: 640px) {
+    padding: 8px;
+  }
+
+  @media (min-width: 641px) and (max-width: 1007px) {
+    padding: 16px;
+  }
+
+  @media (min-width: 1008px) {
+    padding: 24px;
+  }
+
+  @container layout-area (max-width: 640px) {
+    padding: 8px;
+  }
+
+  @container layout-area (min-width: 641px) and (max-width: 1007px) {
+    padding: 16px;
+  }
+
+  @container layout-area (min-width: 1008px) {
+    padding: 24px;
+  }
+}
+```
+
+## Wanneer welke breakpoint-bereiken
+
+Gebruik altijd de bestaande tokens uit `src/assets/styles/breakpoints.ts`:
+
+- `smMax` (640px) — kleinste viewport
+- `mdMin` (641px) — vanaf medium
+- `mdMax` (1007px) — bovengrens medium
+- `lgMin` (1008px) — vanaf large
+
+Bereik-conventie:
+
+- **sm only**: `(max-width: ${smMax})`
+- **md only**: `(min-width: ${mdMin}) and (max-width: ${mdMax})`
+- **lg only**: `(min-width: ${lgMin})`
+- **md+**: `(min-width: ${mdMin})` — gebruik *alleen* als de waarde voor md én lg gelijk is
+- **sm+md (niet lg)**: `(max-width: ${mdMax})`
+
+## `@container` versus `@media`
+
+- **`@container`**: voorkeursroute voor componenten die in panes/wrappers leven — reageert op de container-breedte ipv viewport. Vereist `container-type: inline-size` op de host of een ancestor.
+- **`@media`**: alleen waar de viewport echt 't relevante meetpunt is (top-level layout, of als er geen container-context is).
+
+Veel componenten gebruiken **beide** als fallback: `@container layout-area (...)` voor componenten binnen een nldd-page/nldd-card, plus `@media (...)` als fallback voor losstaand gebruik. Beide blokken volgen dezelfde regel — geen base, alleen explicit-per-breakpoint.
+
+## Wat blijft buiten breakpoint-queries
+
+Properties die op alle breakpoints hetzelfde zijn:
+
+```css
+.foo {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  box-sizing: border-box;
+  /* ... non-responsive properties */
+}
+```
+
+Geen probleem met deze base. De regel is alleen: *als een property varieert per breakpoint*, niet één waarde buiten en de andere binnen — alle waarden binnen, elk in z'n eigen breakpoint.
+
+## States en pseudo-classes
+
+Override-semantiek voor non-breakpoint condities (states, attributes, pseudo-classes) blijft normaal:
+
+```css
+.button {
+  background-color: var(--default);
+}
+.button:hover {
+  background-color: var(--hover);   /* override is hier prima */
+}
+.button[disabled] {
+  background-color: var(--disabled); /* override is hier prima */
+}
+```
+
+Het anti-override patroon is **alleen** voor breakpoint-varianten.
+
+## Pragmatische uitzondering
+
+Voor properties met *veel* breakpoint-varianten (bv. heading sizes met 6 levels × 3 breakpoints) wordt de duplicatie aanzienlijk. Als de duplicatie de leesbaarheid eerder schaadt dan helpt — bv. wanneer je elke regel min of meer kopieert met alleen één var-naam-verschil — overweeg dan een tabel-achtige indeling met CSS-custom-properties die je per breakpoint omschakelt:
+
+```css
+.foo {
+  --_padding: var(--sm-padding);   /* nog steeds een soort base, maar één var */
+}
+@container (min-width: ${mdMin}) {
+  .foo { --_padding: var(--md-padding); }
+}
+@container (min-width: ${lgMin}) {
+  .foo { --_padding: var(--lg-padding); }
+}
+.foo {
+  padding: var(--_padding);        /* één plek waar 't toegepast wordt */
+}
+```
+
+Deze workaround is acceptabel als de regel-explosie anders te erg wordt. Document de keuze in het component zelf.
+
+## State-conditional layouts (label-alignment, etc.)
+
+Sommige componenten hebben layouts die alleen wisselen op basis van een
+**combinatie** van state en breakpoint. Bijvoorbeeld `nldd-form-field` gaat
+naar row-layout alleen wanneer `[label-alignment='left'/'right']` én
+viewport ≥ md. Dat is een **state-conditional override**, geen mobile-first
+override. Patroon:
+
+```css
+.foo { flex-direction: column; }   /* default — geldt overal tenzij... */
+
+:host([variant='wide']) .foo {
+  @container (min-width: ${mdMin}) {
+    flex-direction: row;            /* alleen wanneer state én viewport matchen */
+  }
+}
+```
+
+De convention is **niet** van toepassing hier — de base (`column`) is een
+universele default die overal geldt tenzij de state-selector matcht. Dit
+mag zo blijven.
+
+## Geen overbodige comments
+
+CSS-properties spreken voor zichzelf. Comments alleen voor het uitleggen
+van iets niet-vanzelfsprekends (een workaround, browser-quirk, of een
+ongebruikelijk patroon). Geen comments die simpelweg herhalen wat de code
+doet (bv. "padding per breakpoint" boven een blok met padding-rules).
+
+## Checklist bij review
+
+- [ ] Geen base-waarde voor een property die ook in een `@media`/`@container` voorkomt
+- [ ] Breakpoints gebruiken de tokens uit `breakpoints.ts`
+- [ ] Bereiken sluiten op elkaar aan (640/641, 1007/1008) — geen gat of overlap
+- [ ] `@container` waar mogelijk, `@media` als fallback
+- [ ] At-rules genest binnen de selector — niet op top-level gehoist
+- [ ] Witregel tussen elk `@media`/`@container` blok binnen dezelfde selector
+- [ ] Breakpoints in oplopende volgorde (sm → md → lg), `@media` voor `@container`
+- [ ] Lokale CSS-variabelen bovenaan `:host`, witregel tussen vars en properties
+- [ ] Non-responsieve properties blijven in de base regel — niet onnodig in queries herhaald
+- [ ] State-conditional overrides (state + breakpoint combo) blijven met base default
+- [ ] Geen overbodige uitleg-comments

--- a/src/assets/styles/settings.css
+++ b/src/assets/styles/settings.css
@@ -1069,7 +1069,7 @@
 	--components-list-item-indicator-corner-radius: var(--primitives-corner-radius-md);
 	--components-list-item-is-hovered-background-color: light-dark(var(--primitives-color-neutral-50), var(--primitives-color-neutral-150));
 	--components-list-item-is-hovered-content-color: var(--primitives-color-neutral-1000);
-	--components-list-item-is-selected-background-color: light-dark(var(--primitives-color-neutral-150), var(--primitives-color-neutral-250));
+	--components-list-item-is-selected-background-color: light-dark(var(--primitives-color-neutral-100), var(--primitives-color-neutral-250));
 	--components-list-item-is-selected-content-color: var(--primitives-color-neutral-1000);
 	--components-list-item-is-highlighted-background-color: var(--semantics-controls-is-highlighted-indicator-color);
 	--components-list-item-is-highlighted-content-color: var(--semantics-controls-is-highlighted-contrast-color);

--- a/src/components/actions/button/button.styles.ts
+++ b/src/components/actions/button/button.styles.ts
@@ -41,6 +41,7 @@ export const buttonStyles = css`
 		align-items: center;
 		justify-content: center;
 		width: 100%;
+		text-wrap: pretty;
 		transition:
 			background-color var(--primitives-transition-duration-fast) var(--primitives-transition-easing-default),
 			color var(--primitives-transition-duration-fast) var(--primitives-transition-easing-default)

--- a/src/components/content/rich-text/rich-text.css
+++ b/src/components/content/rich-text/rich-text.css
@@ -63,6 +63,7 @@ nldd-rich-text h1 {
 	margin-top: calc(var(--_spacing) * 2);
 	margin-bottom: var(--_spacing);
 	font: var(--primitives-font-display-1-sm);
+	text-wrap: pretty;
 
 	@media (min-width: 641px) {
 		font: var(--primitives-font-display-1-md);
@@ -88,6 +89,7 @@ nldd-rich-text h2 {
 	margin-top: calc(var(--_spacing) * 2);
 	margin-bottom: var(--_spacing);
 	font: var(--primitives-font-display-2-sm);
+	text-wrap: pretty;
 
 	@media (min-width: 641px) {
 		font: var(--primitives-font-display-2-md);
@@ -113,6 +115,7 @@ nldd-rich-text h3 {
 	margin-top: calc(var(--_spacing) * 2);
 	margin-bottom: var(--_spacing);
 	font: var(--primitives-font-display-3-sm);
+	text-wrap: pretty;
 
 	@media (min-width: 641px) {
 		font: var(--primitives-font-display-3-md);
@@ -138,6 +141,7 @@ nldd-rich-text h4 {
 	margin-top: calc(var(--_spacing) * 2);
 	margin-bottom: var(--_spacing);
 	font: var(--primitives-font-display-4-sm);
+	text-wrap: pretty;
 
 	@media (min-width: 641px) {
 		font: var(--primitives-font-display-4-md);
@@ -163,6 +167,7 @@ nldd-rich-text h5 {
 	margin-top: calc(var(--_spacing) * 2);
 	margin-bottom: var(--_spacing);
 	font: var(--primitives-font-display-5-sm);
+	text-wrap: pretty;
 
 	@media (min-width: 641px) {
 		font: var(--primitives-font-display-5-md);
@@ -188,6 +193,7 @@ nldd-rich-text h6 {
 	margin-top: calc(var(--_spacing) * 2);
 	margin-bottom: var(--_spacing);
 	font: var(--primitives-font-display-6-sm);
+	text-wrap: pretty;
 
 	@media (min-width: 641px) {
 		font: var(--primitives-font-display-6-md);

--- a/src/components/content/rich-text/rich-text.css
+++ b/src/components/content/rich-text/rich-text.css
@@ -62,10 +62,13 @@ nldd-rich-text p {
 nldd-rich-text h1 {
 	margin-top: calc(var(--_spacing) * 2);
 	margin-bottom: var(--_spacing);
-	font: var(--primitives-font-display-1-sm);
 	text-wrap: pretty;
 
-	@media (min-width: 641px) {
+	@media (max-width: 640px) {
+		font: var(--primitives-font-display-1-sm);
+	}
+
+	@media (min-width: 641px) and (max-width: 1007px) {
 		font: var(--primitives-font-display-1-md);
 	}
 
@@ -73,7 +76,11 @@ nldd-rich-text h1 {
 		font: var(--primitives-font-display-1-lg);
 	}
 
-	@container layout-area (min-width: 641px) {
+	@container layout-area (max-width: 640px) {
+		font: var(--primitives-font-display-1-sm);
+	}
+
+	@container layout-area (min-width: 641px) and (max-width: 1007px) {
 		font: var(--primitives-font-display-1-md);
 	}
 
@@ -88,10 +95,13 @@ nldd-rich-text h1 {
 nldd-rich-text h2 {
 	margin-top: calc(var(--_spacing) * 2);
 	margin-bottom: var(--_spacing);
-	font: var(--primitives-font-display-2-sm);
 	text-wrap: pretty;
 
-	@media (min-width: 641px) {
+	@media (max-width: 640px) {
+		font: var(--primitives-font-display-2-sm);
+	}
+
+	@media (min-width: 641px) and (max-width: 1007px) {
 		font: var(--primitives-font-display-2-md);
 	}
 
@@ -99,7 +109,11 @@ nldd-rich-text h2 {
 		font: var(--primitives-font-display-2-lg);
 	}
 
-	@container layout-area (min-width: 641px) {
+	@container layout-area (max-width: 640px) {
+		font: var(--primitives-font-display-2-sm);
+	}
+
+	@container layout-area (min-width: 641px) and (max-width: 1007px) {
 		font: var(--primitives-font-display-2-md);
 	}
 
@@ -114,10 +128,13 @@ nldd-rich-text h2 {
 nldd-rich-text h3 {
 	margin-top: calc(var(--_spacing) * 2);
 	margin-bottom: var(--_spacing);
-	font: var(--primitives-font-display-3-sm);
 	text-wrap: pretty;
 
-	@media (min-width: 641px) {
+	@media (max-width: 640px) {
+		font: var(--primitives-font-display-3-sm);
+	}
+
+	@media (min-width: 641px) and (max-width: 1007px) {
 		font: var(--primitives-font-display-3-md);
 	}
 
@@ -125,7 +142,11 @@ nldd-rich-text h3 {
 		font: var(--primitives-font-display-3-lg);
 	}
 
-	@container layout-area (min-width: 641px) {
+	@container layout-area (max-width: 640px) {
+		font: var(--primitives-font-display-3-sm);
+	}
+
+	@container layout-area (min-width: 641px) and (max-width: 1007px) {
 		font: var(--primitives-font-display-3-md);
 	}
 
@@ -140,10 +161,13 @@ nldd-rich-text h3 {
 nldd-rich-text h4 {
 	margin-top: calc(var(--_spacing) * 2);
 	margin-bottom: var(--_spacing);
-	font: var(--primitives-font-display-4-sm);
 	text-wrap: pretty;
 
-	@media (min-width: 641px) {
+	@media (max-width: 640px) {
+		font: var(--primitives-font-display-4-sm);
+	}
+
+	@media (min-width: 641px) and (max-width: 1007px) {
 		font: var(--primitives-font-display-4-md);
 	}
 
@@ -151,7 +175,11 @@ nldd-rich-text h4 {
 		font: var(--primitives-font-display-4-lg);
 	}
 
-	@container layout-area (min-width: 641px) {
+	@container layout-area (max-width: 640px) {
+		font: var(--primitives-font-display-4-sm);
+	}
+
+	@container layout-area (min-width: 641px) and (max-width: 1007px) {
 		font: var(--primitives-font-display-4-md);
 	}
 
@@ -166,10 +194,13 @@ nldd-rich-text h4 {
 nldd-rich-text h5 {
 	margin-top: calc(var(--_spacing) * 2);
 	margin-bottom: var(--_spacing);
-	font: var(--primitives-font-display-5-sm);
 	text-wrap: pretty;
 
-	@media (min-width: 641px) {
+	@media (max-width: 640px) {
+		font: var(--primitives-font-display-5-sm);
+	}
+
+	@media (min-width: 641px) and (max-width: 1007px) {
 		font: var(--primitives-font-display-5-md);
 	}
 
@@ -177,7 +208,11 @@ nldd-rich-text h5 {
 		font: var(--primitives-font-display-5-lg);
 	}
 
-	@container layout-area (min-width: 641px) {
+	@container layout-area (max-width: 640px) {
+		font: var(--primitives-font-display-5-sm);
+	}
+
+	@container layout-area (min-width: 641px) and (max-width: 1007px) {
 		font: var(--primitives-font-display-5-md);
 	}
 
@@ -192,10 +227,13 @@ nldd-rich-text h5 {
 nldd-rich-text h6 {
 	margin-top: calc(var(--_spacing) * 2);
 	margin-bottom: var(--_spacing);
-	font: var(--primitives-font-display-6-sm);
 	text-wrap: pretty;
 
-	@media (min-width: 641px) {
+	@media (max-width: 640px) {
+		font: var(--primitives-font-display-6-sm);
+	}
+
+	@media (min-width: 641px) and (max-width: 1007px) {
 		font: var(--primitives-font-display-6-md);
 	}
 
@@ -203,7 +241,11 @@ nldd-rich-text h6 {
 		font: var(--primitives-font-display-6-lg);
 	}
 
-	@container layout-area (min-width: 641px) {
+	@container layout-area (max-width: 640px) {
+		font: var(--primitives-font-display-6-sm);
+	}
+
+	@container layout-area (min-width: 641px) and (max-width: 1007px) {
 		font: var(--primitives-font-display-6-md);
 	}
 

--- a/src/components/content/title/title.styles.ts
+++ b/src/components/content/title/title.styles.ts
@@ -45,6 +45,7 @@ export const titleStyles = css`
 
 	::slotted([slot='overline']) {
 		margin: 0;
+		overflow-wrap: anywhere;
 		color: var(--semantics-content-secondary-color);
 		font: var(--primitives-font-body-sm-regular-tight);
 	}
@@ -54,6 +55,7 @@ export const titleStyles = css`
 
 	::slotted(:not([slot])) {
 		margin: 0;
+		overflow-wrap: anywhere;
 		color: var(--semantics-content-color);
 		text-wrap: pretty;
 	}
@@ -220,6 +222,7 @@ export const titleStyles = css`
 
 	::slotted([slot='subtitle']) {
 		margin: 0;
+		overflow-wrap: anywhere;
 		color: var(--semantics-content-secondary-color);
 		font: var(--primitives-font-body-sm-regular-tight);
 	}

--- a/src/components/content/title/title.styles.ts
+++ b/src/components/content/title/title.styles.ts
@@ -55,6 +55,7 @@ export const titleStyles = css`
 	::slotted(:not([slot])) {
 		margin: 0;
 		color: var(--semantics-content-color);
+		text-wrap: pretty;
 	}
 
 	:host([size='1']) ::slotted(:not([slot])) {

--- a/src/components/content/tooltip/tooltip.styles.ts
+++ b/src/components/content/tooltip/tooltip.styles.ts
@@ -26,35 +26,29 @@ export const tooltipStyles = css`
 
 	.tooltip {
 		position: fixed;
-		z-index: var(--_z-index);
+		margin: 0;
+		padding: 0;
+		border: none;
+		background: none;
 		opacity: 0;
-		pointer-events: none;
-		visibility: hidden;
 		transition:
 			opacity var(--_hide-duration) ease,
-			visibility 0ms linear var(--_hide-duration),
-			pointer-events 0ms linear var(--_hide-duration);
+			display var(--_hide-duration) allow-discrete,
+			overlay var(--_hide-duration) allow-discrete;
 	}
 
-	.tooltip.is-visible {
+	.tooltip:popover-open {
 		opacity: 1;
-		visibility: visible;
-		pointer-events: auto;
-		transition:
-			opacity var(--_show-duration) ease var(--_show-delay),
-			visibility 0ms linear,
-			pointer-events 0ms linear var(--_show-delay);
-	}
-
-	/* Focus triggers: geen show delay */
-	.tooltip.is-focus-visible {
-		opacity: 1;
-		visibility: visible;
-		pointer-events: auto;
 		transition:
 			opacity var(--_show-duration) ease,
-			visibility 0ms linear,
-			pointer-events 0ms linear;
+			display var(--_show-duration) allow-discrete,
+			overlay var(--_show-duration) allow-discrete;
+	}
+
+	@starting-style {
+		.tooltip:popover-open {
+			opacity: 0;
+		}
 	}
 
 

--- a/src/components/content/tooltip/tooltip.template.ts
+++ b/src/components/content/tooltip/tooltip.template.ts
@@ -11,7 +11,8 @@ export function tooltipTemplate(component: NLDDTooltip): TemplateResult {
 			@focusin=${component._handleFocusIn}
 			@focusout=${component._handleFocusOut}
 		></slot>
-		<div class=${classMap({ tooltip: true, 'is-visible': component._visible && !component._focusVisible, 'is-focus-visible': component._visible && component._focusVisible })}
+		<div class=${classMap({ tooltip: true, 'is-focus-visible': component._visible && component._focusVisible })}
+			popover="manual"
 			aria-hidden="true"
 			@mouseenter=${component._handleTooltipEnter}
 			@mouseleave=${component._handleTooltipLeave}

--- a/src/components/content/tooltip/tooltip.template.ts
+++ b/src/components/content/tooltip/tooltip.template.ts
@@ -1,6 +1,5 @@
 import { html } from 'lit';
 import type { TemplateResult } from 'lit';
-import { classMap } from 'lit/directives/class-map.js';
 import type { NLDDTooltip } from './tooltip.js';
 
 export function tooltipTemplate(component: NLDDTooltip): TemplateResult {
@@ -11,7 +10,7 @@ export function tooltipTemplate(component: NLDDTooltip): TemplateResult {
 			@focusin=${component._handleFocusIn}
 			@focusout=${component._handleFocusOut}
 		></slot>
-		<div class=${classMap({ tooltip: true, 'is-focus-visible': component._visible && component._focusVisible })}
+		<div class="tooltip"
 			popover="manual"
 			aria-hidden="true"
 			@mouseenter=${component._handleTooltipEnter}

--- a/src/components/content/tooltip/tooltip.test.ts
+++ b/src/components/content/tooltip/tooltip.test.ts
@@ -149,6 +149,43 @@ describe('nldd-tooltip – show/hide', () => {
 
 		expect(isTooltipVisible(el)).toBe(false);
 	});
+
+	it('disabled flip annuleert een pending show-timer voordat die afloopt', async () => {
+		// Use a non-zero delay so we can flip `disabled` while the timer is
+		// still scheduled. This is the exact race the updated() handler is
+		// meant to win — without the clearTimeout, the timer would fire and
+		// open the tooltip even though the consumer just suppressed it.
+		el = await fixture<NLDDTooltip>('<nldd-tooltip text="Test"><button>Trigger</button></nldd-tooltip>');
+		await waitForUpdate(el);
+		el.style.setProperty('--_show-delay', '50');
+
+		const trigger = el.querySelector('button')!;
+		trigger.dispatchEvent(new MouseEvent('mouseenter', { bubbles: true }));
+		// Don't wait for the timer to fire — flip disabled mid-flight.
+		el.disabled = true;
+		await waitForUpdate(el);
+
+		// Wait past the original show-delay window — the cancelled timer must
+		// not still open the tooltip.
+		await new Promise(resolve => setTimeout(resolve, 100));
+		expect(isTooltipVisible(el)).toBe(false);
+	});
+
+	it('disabled flip verbergt een al zichtbare tooltip direct', async () => {
+		el = await fixture<NLDDTooltip>('<nldd-tooltip text="Test"><button>Trigger</button></nldd-tooltip>');
+		await waitForUpdate(el);
+		instantShow(el);
+
+		const trigger = el.querySelector('button')!;
+		trigger.dispatchEvent(new MouseEvent('mouseenter', { bubbles: true }));
+		await new Promise(resolve => setTimeout(resolve, 0));
+		await waitForUpdate(el);
+		expect(isTooltipVisible(el)).toBe(true);
+
+		el.disabled = true;
+		await waitForUpdate(el);
+		expect(isTooltipVisible(el)).toBe(false);
+	});
 });
 
 describe('nldd-tooltip – aria-describedby', () => {

--- a/src/components/content/tooltip/tooltip.test.ts
+++ b/src/components/content/tooltip/tooltip.test.ts
@@ -17,6 +17,18 @@ function instantShow(el: NLDDTooltip): void {
 	el.style.setProperty('--_show-delay', '0');
 }
 
+/**
+ * Common open-the-tooltip flow: zero out the show delay, fire mouseenter,
+ * yield once for the (now-immediate) timer, then await Lit's update so
+ * the tooltip's `_visible` state has flushed to the popover element.
+ */
+async function triggerShow(el: NLDDTooltip, trigger: Element): Promise<void> {
+	instantShow(el);
+	trigger.dispatchEvent(new MouseEvent('mouseenter', { bubbles: true }));
+	await new Promise(resolve => setTimeout(resolve, 0));
+	await waitForUpdate(el);
+}
+
 describe('nldd-tooltip', () => {
 	let el: NLDDTooltip;
 
@@ -67,13 +79,7 @@ describe('nldd-tooltip – show/hide', () => {
 	it('wordt zichtbaar bij mouseenter op trigger', async () => {
 		el = await fixture<NLDDTooltip>('<nldd-tooltip text="Test"><button>Trigger</button></nldd-tooltip>');
 		await waitForUpdate(el);
-		instantShow(el);
-
-		const trigger = el.querySelector('button')!;
-		trigger.dispatchEvent(new MouseEvent('mouseenter', { bubbles: true }));
-		await new Promise(resolve => setTimeout(resolve, 0));
-		await waitForUpdate(el);
-
+		await triggerShow(el, el.querySelector('button')!);
 		expect(isTooltipVisible(el)).toBe(true);
 	});
 
@@ -91,12 +97,8 @@ describe('nldd-tooltip – show/hide', () => {
 	it('wordt verborgen bij mouseleave', async () => {
 		el = await fixture<NLDDTooltip>('<nldd-tooltip text="Test"><button>Trigger</button></nldd-tooltip>');
 		await waitForUpdate(el);
-		instantShow(el);
-
 		const trigger = el.querySelector('button')!;
-		trigger.dispatchEvent(new MouseEvent('mouseenter', { bubbles: true }));
-		await new Promise(resolve => setTimeout(resolve, 0));
-		await waitForUpdate(el);
+		await triggerShow(el, trigger);
 		trigger.dispatchEvent(new MouseEvent('mouseleave', { bubbles: true }));
 		await new Promise(resolve => setTimeout(resolve, 250));
 
@@ -106,12 +108,8 @@ describe('nldd-tooltip – show/hide', () => {
 	it('blijft zichtbaar bij tooltip hover', async () => {
 		el = await fixture<NLDDTooltip>('<nldd-tooltip text="Test"><button>Trigger</button></nldd-tooltip>');
 		await waitForUpdate(el);
-		instantShow(el);
-
 		const trigger = el.querySelector('button')!;
-		trigger.dispatchEvent(new MouseEvent('mouseenter', { bubbles: true }));
-		await new Promise(resolve => setTimeout(resolve, 0));
-		await waitForUpdate(el);
+		await triggerShow(el, trigger);
 
 		trigger.dispatchEvent(new MouseEvent('mouseleave', { bubbles: true }));
 		const tooltipEl = el.shadowRoot!.querySelector('.tooltip')!;
@@ -124,12 +122,7 @@ describe('nldd-tooltip – show/hide', () => {
 	it('Escape sluit de tooltip', async () => {
 		el = await fixture<NLDDTooltip>('<nldd-tooltip text="Test"><button>Trigger</button></nldd-tooltip>');
 		await waitForUpdate(el);
-		instantShow(el);
-
-		const trigger = el.querySelector('button')!;
-		trigger.dispatchEvent(new MouseEvent('mouseenter', { bubbles: true }));
-		await new Promise(resolve => setTimeout(resolve, 0));
-		await waitForUpdate(el);
+		await triggerShow(el, el.querySelector('button')!);
 		expect(isTooltipVisible(el)).toBe(true);
 
 		el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
@@ -140,13 +133,7 @@ describe('nldd-tooltip – show/hide', () => {
 	it('toont niet bij lege text', async () => {
 		el = await fixture<NLDDTooltip>('<nldd-tooltip text=""><button>Trigger</button></nldd-tooltip>');
 		await waitForUpdate(el);
-		instantShow(el);
-
-		const trigger = el.querySelector('button')!;
-		trigger.dispatchEvent(new MouseEvent('mouseenter', { bubbles: true }));
-		await new Promise(resolve => setTimeout(resolve, 0));
-		await waitForUpdate(el);
-
+		await triggerShow(el, el.querySelector('button')!);
 		expect(isTooltipVisible(el)).toBe(false);
 	});
 
@@ -174,12 +161,7 @@ describe('nldd-tooltip – show/hide', () => {
 	it('disabled flip verbergt een al zichtbare tooltip direct', async () => {
 		el = await fixture<NLDDTooltip>('<nldd-tooltip text="Test"><button>Trigger</button></nldd-tooltip>');
 		await waitForUpdate(el);
-		instantShow(el);
-
-		const trigger = el.querySelector('button')!;
-		trigger.dispatchEvent(new MouseEvent('mouseenter', { bubbles: true }));
-		await new Promise(resolve => setTimeout(resolve, 0));
-		await waitForUpdate(el);
+		await triggerShow(el, el.querySelector('button')!);
 		expect(isTooltipVisible(el)).toBe(true);
 
 		el.disabled = true;

--- a/src/components/content/tooltip/tooltip.test.ts
+++ b/src/components/content/tooltip/tooltip.test.ts
@@ -4,8 +4,17 @@ import type { NLDDTooltip } from './tooltip.js';
 import './tooltip.js';
 
 function isTooltipVisible(el: NLDDTooltip): boolean {
-	const tooltip = el.shadowRoot!.querySelector('.tooltip');
-	return tooltip?.classList.contains('is-visible') || tooltip?.classList.contains('is-focus-visible') || false;
+	const tooltip = el.shadowRoot!.querySelector<HTMLElement>('.tooltip');
+	return tooltip?.matches(':popover-open') ?? false;
+}
+
+/**
+ * Tooltip uses a 700ms pointer-hover show delay (read from CSS
+ * `--_show-delay`). In tests we override it to 0 so mouseenter shows the
+ * tooltip on the next microtask instead of forcing every test to wait.
+ */
+function instantShow(el: NLDDTooltip): void {
+	el.style.setProperty('--_show-delay', '0');
 }
 
 describe('nldd-tooltip', () => {
@@ -58,9 +67,11 @@ describe('nldd-tooltip – show/hide', () => {
 	it('wordt zichtbaar bij mouseenter op trigger', async () => {
 		el = await fixture<NLDDTooltip>('<nldd-tooltip text="Test"><button>Trigger</button></nldd-tooltip>');
 		await waitForUpdate(el);
+		instantShow(el);
 
 		const trigger = el.querySelector('button')!;
 		trigger.dispatchEvent(new MouseEvent('mouseenter', { bubbles: true }));
+		await new Promise(resolve => setTimeout(resolve, 0));
 		await waitForUpdate(el);
 
 		expect(isTooltipVisible(el)).toBe(true);
@@ -80,9 +91,11 @@ describe('nldd-tooltip – show/hide', () => {
 	it('wordt verborgen bij mouseleave', async () => {
 		el = await fixture<NLDDTooltip>('<nldd-tooltip text="Test"><button>Trigger</button></nldd-tooltip>');
 		await waitForUpdate(el);
+		instantShow(el);
 
 		const trigger = el.querySelector('button')!;
 		trigger.dispatchEvent(new MouseEvent('mouseenter', { bubbles: true }));
+		await new Promise(resolve => setTimeout(resolve, 0));
 		await waitForUpdate(el);
 		trigger.dispatchEvent(new MouseEvent('mouseleave', { bubbles: true }));
 		await new Promise(resolve => setTimeout(resolve, 250));
@@ -93,9 +106,11 @@ describe('nldd-tooltip – show/hide', () => {
 	it('blijft zichtbaar bij tooltip hover', async () => {
 		el = await fixture<NLDDTooltip>('<nldd-tooltip text="Test"><button>Trigger</button></nldd-tooltip>');
 		await waitForUpdate(el);
+		instantShow(el);
 
 		const trigger = el.querySelector('button')!;
 		trigger.dispatchEvent(new MouseEvent('mouseenter', { bubbles: true }));
+		await new Promise(resolve => setTimeout(resolve, 0));
 		await waitForUpdate(el);
 
 		trigger.dispatchEvent(new MouseEvent('mouseleave', { bubbles: true }));
@@ -109,9 +124,11 @@ describe('nldd-tooltip – show/hide', () => {
 	it('Escape sluit de tooltip', async () => {
 		el = await fixture<NLDDTooltip>('<nldd-tooltip text="Test"><button>Trigger</button></nldd-tooltip>');
 		await waitForUpdate(el);
+		instantShow(el);
 
 		const trigger = el.querySelector('button')!;
 		trigger.dispatchEvent(new MouseEvent('mouseenter', { bubbles: true }));
+		await new Promise(resolve => setTimeout(resolve, 0));
 		await waitForUpdate(el);
 		expect(isTooltipVisible(el)).toBe(true);
 
@@ -123,9 +140,11 @@ describe('nldd-tooltip – show/hide', () => {
 	it('toont niet bij lege text', async () => {
 		el = await fixture<NLDDTooltip>('<nldd-tooltip text=""><button>Trigger</button></nldd-tooltip>');
 		await waitForUpdate(el);
+		instantShow(el);
 
 		const trigger = el.querySelector('button')!;
 		trigger.dispatchEvent(new MouseEvent('mouseenter', { bubbles: true }));
+		await new Promise(resolve => setTimeout(resolve, 0));
 		await waitForUpdate(el);
 
 		expect(isTooltipVisible(el)).toBe(false);

--- a/src/components/content/tooltip/tooltip.test.ts
+++ b/src/components/content/tooltip/tooltip.test.ts
@@ -217,4 +217,35 @@ describe('nldd-tooltip – aria-describedby', () => {
 		cleanup(el);
 		expect(document.getElementById(id)).toBeNull();
 	});
+
+	it('verwijdert aria-describedby en de description span wanneer disabled flipt naar true', async () => {
+		// Same intent as hiding the visual popover: when disabled, screen
+		// readers shouldn't keep announcing the tooltip text either. Primary
+		// use-case is `?disabled=${!isShort}` in document-tab-bar where the
+		// full label is already inline.
+		el = await fixture<NLDDTooltip>('<nldd-tooltip text="Test"><button>T</button></nldd-tooltip>');
+		await waitForUpdate(el);
+		const trigger = el.querySelector('button')!;
+		const id = trigger.getAttribute('aria-describedby')!;
+		expect(id).toBeTruthy();
+		expect(document.getElementById(id)).not.toBeNull();
+
+		el.disabled = true;
+		await waitForUpdate(el);
+		expect(trigger.hasAttribute('aria-describedby')).toBe(false);
+		expect(document.getElementById(id)).toBeNull();
+	});
+
+	it('herstelt aria-describedby wanneer disabled terug naar false flipt', async () => {
+		el = await fixture<NLDDTooltip>('<nldd-tooltip text="Test" disabled><button>T</button></nldd-tooltip>');
+		await waitForUpdate(el);
+		const trigger = el.querySelector('button')!;
+		expect(trigger.hasAttribute('aria-describedby')).toBe(false);
+
+		el.disabled = false;
+		await waitForUpdate(el);
+		const id = trigger.getAttribute('aria-describedby');
+		expect(id).toBeTruthy();
+		expect(document.getElementById(id!)?.textContent).toBe('Test');
+	});
 });

--- a/src/components/content/tooltip/tooltip.ts
+++ b/src/components/content/tooltip/tooltip.ts
@@ -46,6 +46,14 @@ type Placement = 'top' | 'bottom' | 'left' | 'right';
 let tooltipCounter = 0;
 const coarsePointerQuery = matchMedia('(pointer: coarse)');
 
+// Defaults mirror the values in tooltip.styles.ts. Used as fallback when the
+// CSS variable is unset or non-numeric — most often in SSR / early-load
+// environments where styles haven't reached the element yet. Without the
+// fallback, parseInt('') returns NaN and setTimeout silently coerces it to
+// 0ms, so the tooltip would show instantly. Keep these in sync with CSS.
+const DEFAULT_SHOW_DELAY_MS = 700;
+const DEFAULT_HIDE_DELAY_MS = 50;
+
 @customElement('nldd-tooltip')
 export class NLDDTooltip extends LitElement {
 	static override styles = tooltipStyles;
@@ -181,7 +189,8 @@ export class NLDDTooltip extends LitElement {
 		// holds the delay. Read the same `--_show-delay` token so the value
 		// stays consumer-tunable from CSS.
 		if (this._showTimeout) clearTimeout(this._showTimeout);
-		const showDelay = parseInt(getComputedStyle(this).getPropertyValue('--_show-delay'), 10);
+		const parsedShow = parseInt(getComputedStyle(this).getPropertyValue('--_show-delay'), 10);
+		const showDelay = Number.isFinite(parsedShow) ? parsedShow : DEFAULT_SHOW_DELAY_MS;
 		this._showTimeout = setTimeout(() => {
 			this._showTimeout = null;
 			this._focusVisible = false;
@@ -218,7 +227,8 @@ export class NLDDTooltip extends LitElement {
 		if (this._hideTimeout) {
 			clearTimeout(this._hideTimeout);
 		}
-		const hideDelay = parseInt(getComputedStyle(this).getPropertyValue('--_hide-delay'), 10);
+		const parsedHide = parseInt(getComputedStyle(this).getPropertyValue('--_hide-delay'), 10);
+		const hideDelay = Number.isFinite(parsedHide) ? parsedHide : DEFAULT_HIDE_DELAY_MS;
 		this._hideTimeout = setTimeout(() => {
 			this._visible = false;
 			this._hideTimeout = null;

--- a/src/components/content/tooltip/tooltip.ts
+++ b/src/components/content/tooltip/tooltip.ts
@@ -5,13 +5,22 @@
  * Gebruikt `display: contents` zodat het de layout van het child niet beïnvloedt.
  *
  * @element nldd-tooltip
- * @attr {string} text - Tooltip tekst
- * @attr {string} placement - Positie: 'top' | 'bottom' | 'left' | 'right' (standaard: 'bottom'; op touch devices automatisch 'top')
+ * @attr {string}  text      - Tooltip tekst
+ * @attr {string}  placement - Positie: 'top' | 'bottom' | 'left' | 'right' (standaard: 'bottom'; op touch devices automatisch 'top')
+ * @attr {boolean} disabled  - Wanneer true wordt de tooltip nooit getoond.
+ *                              Hover/focus events op de trigger worden
+ *                              genegeerd; een al zichtbare tooltip wordt
+ *                              direct verborgen. Voor consumers die het
+ *                              tooltip-gedrag conditioneel willen schakelen
+ *                              (bv. alleen tonen wanneer tekst getrunceerd is).
  *
  * @slot - Het element waarop de tooltip wordt getoond
  *
- * @note Gebruikt position: fixed + floating-ui strategy: 'fixed'. Positionering kan
- * breken wanneer een voorouder-element transform, filter of will-change heeft.
+ * @note Rendert via de native Popover API (`popover="manual"`) in de top
+ * layer. Daardoor escape de tooltip alle ancestor stacking contexts en
+ * `overflow: hidden` clipping — geen z-index gevechten meer met overlay-
+ * containers, panes of transform-containers. Positionering blijft via
+ * Floating UI met `strategy: 'fixed'`.
  *
  * @note aria-describedby werkt alleen wanneer het trigger element in de light DOM staat.
  * Bij web components als trigger (met eigen shadow DOM) is de koppeling een bekende
@@ -47,6 +56,9 @@ export class NLDDTooltip extends LitElement {
 	@property({ type: String, reflect: true })
 	placement: Placement = 'bottom';
 
+	@property({ type: Boolean, reflect: true })
+	disabled = false;
+
 	private get _effectivePlacement(): Placement {
 		return this.placement;
 	}
@@ -59,6 +71,7 @@ export class NLDDTooltip extends LitElement {
 
 	private _tooltipId = `nldd-tooltip-${++tooltipCounter}`;
 	private _hideTimeout: ReturnType<typeof setTimeout> | null = null;
+	private _showTimeout: ReturnType<typeof setTimeout> | null = null;
 	private _descriptionEl: HTMLSpanElement | null = null;
 	private _currentTrigger: Element | null = null;
 	private _boundSlotChange = () => this._syncAriaDescribedBy();
@@ -77,11 +90,23 @@ export class NLDDTooltip extends LitElement {
 	}
 
 	override updated(changed: PropertyValues): void {
-		if (changed.has('_visible') && this._visible) {
-			this._updatePosition();
+		if (changed.has('_visible')) {
+			const tooltip = this._getTooltipElement();
+			if (tooltip) {
+				if (this._visible) {
+					if (!tooltip.matches(':popover-open')) tooltip.showPopover();
+					this._updatePosition();
+				} else if (tooltip.matches(':popover-open')) {
+					tooltip.hidePopover();
+				}
+			}
 		}
 		if (changed.has('text')) {
 			this._syncAriaDescribedBy();
+		}
+		if (changed.has('disabled') && this.disabled && this._visible) {
+			this._visible = false;
+			this._focusVisible = false;
 		}
 	}
 
@@ -136,17 +161,28 @@ export class NLDDTooltip extends LitElement {
 	}
 
 	_handleTriggerEnter(): void {
+		if (this.disabled) return;
 		if (!this.text) return;
 		if (coarsePointerQuery.matches) return;
 		if (this._hideTimeout) {
 			clearTimeout(this._hideTimeout);
 			this._hideTimeout = null;
 		}
-		this._focusVisible = false;
-		this._visible = true;
+		// Pointer-hover show delay: schedule via JS now that the visibility
+		// transition is binary (popover open/closed) and the CSS no longer
+		// holds the delay. Read the same `--_show-delay` token so the value
+		// stays consumer-tunable from CSS.
+		if (this._showTimeout) clearTimeout(this._showTimeout);
+		const showDelay = parseInt(getComputedStyle(this).getPropertyValue('--_show-delay'), 10);
+		this._showTimeout = setTimeout(() => {
+			this._showTimeout = null;
+			this._focusVisible = false;
+			this._visible = true;
+		}, showDelay);
 	}
 
 	_handleFocusIn(): void {
+		if (this.disabled) return;
 		if (!this.text) return;
 		// Touch taps can focus elements with explicit `tabindex` (e.g. tab-bar's
 		// roving-tabindex pattern on iOS, Android `<button>` focus-on-tap).
@@ -156,11 +192,21 @@ export class NLDDTooltip extends LitElement {
 			clearTimeout(this._hideTimeout);
 			this._hideTimeout = null;
 		}
+		// Focus-triggered show: no delay (keyboard intent is explicit).
+		if (this._showTimeout) {
+			clearTimeout(this._showTimeout);
+			this._showTimeout = null;
+		}
 		this._focusVisible = true;
 		this._visible = true;
 	}
 
 	_handleTriggerLeave(): void {
+		// Cancel a scheduled show — leaving before delay elapsed means no show.
+		if (this._showTimeout) {
+			clearTimeout(this._showTimeout);
+			this._showTimeout = null;
+		}
 		if (this._hideTimeout) {
 			clearTimeout(this._hideTimeout);
 		}
@@ -227,6 +273,10 @@ export class NLDDTooltip extends LitElement {
 		if (this._hideTimeout) {
 			clearTimeout(this._hideTimeout);
 			this._hideTimeout = null;
+		}
+		if (this._showTimeout) {
+			clearTimeout(this._showTimeout);
+			this._showTimeout = null;
 		}
 		// Clean up aria-describedby on trigger and remove description span from body
 		this._currentTrigger?.removeAttribute('aria-describedby');

--- a/src/components/content/tooltip/tooltip.ts
+++ b/src/components/content/tooltip/tooltip.ts
@@ -106,7 +106,7 @@ export class NLDDTooltip extends LitElement {
 				}
 			}
 		}
-		if (changed.has('text')) {
+		if (changed.has('text') || changed.has('disabled')) {
 			this._syncAriaDescribedBy();
 		}
 		if (changed.has('disabled') && this.disabled) {
@@ -137,7 +137,12 @@ export class NLDDTooltip extends LitElement {
 			return;
 		}
 
-		if (this.text) {
+		// Suppress the description when disabled — same intent as hiding the
+		// visual popover. Without this, screen readers would still announce
+		// the redundant tooltip text (the primary use-case for `disabled` is
+		// `?disabled=${!isShort}` in document-tab-bar, where the full label is
+		// already visible inline).
+		if (this.text && !this.disabled) {
 			if (!this._descriptionEl) {
 				this._descriptionEl = document.createElement('span');
 				this._descriptionEl.id = this._tooltipId;

--- a/src/components/content/tooltip/tooltip.ts
+++ b/src/components/content/tooltip/tooltip.ts
@@ -104,9 +104,17 @@ export class NLDDTooltip extends LitElement {
 		if (changed.has('text')) {
 			this._syncAriaDescribedBy();
 		}
-		if (changed.has('disabled') && this.disabled && this._visible) {
-			this._visible = false;
-			this._focusVisible = false;
+		if (changed.has('disabled') && this.disabled) {
+			// Cancel any pending show — without this the timer fires after
+			// disabled is set and re-opens the tooltip.
+			if (this._showTimeout) {
+				clearTimeout(this._showTimeout);
+				this._showTimeout = null;
+			}
+			if (this._visible) {
+				this._visible = false;
+				this._focusVisible = false;
+			}
 		}
 	}
 

--- a/src/components/content/tooltip/tooltip.ts
+++ b/src/components/content/tooltip/tooltip.ts
@@ -74,9 +74,6 @@ export class NLDDTooltip extends LitElement {
 	@state()
 	_visible = false;
 
-	@state()
-	_focusVisible = false;
-
 	private _tooltipId = `nldd-tooltip-${++tooltipCounter}`;
 	private _hideTimeout: ReturnType<typeof setTimeout> | null = null;
 	private _showTimeout: ReturnType<typeof setTimeout> | null = null;
@@ -119,10 +116,7 @@ export class NLDDTooltip extends LitElement {
 				clearTimeout(this._showTimeout);
 				this._showTimeout = null;
 			}
-			if (this._visible) {
-				this._visible = false;
-				this._focusVisible = false;
-			}
+			if (this._visible) this._visible = false;
 		}
 	}
 
@@ -193,7 +187,6 @@ export class NLDDTooltip extends LitElement {
 		const showDelay = Number.isFinite(parsedShow) ? parsedShow : DEFAULT_SHOW_DELAY_MS;
 		this._showTimeout = setTimeout(() => {
 			this._showTimeout = null;
-			this._focusVisible = false;
 			this._visible = true;
 		}, showDelay);
 	}
@@ -214,7 +207,6 @@ export class NLDDTooltip extends LitElement {
 			clearTimeout(this._showTimeout);
 			this._showTimeout = null;
 		}
-		this._focusVisible = true;
 		this._visible = true;
 	}
 
@@ -258,10 +250,7 @@ export class NLDDTooltip extends LitElement {
 	}
 
 	private _handleKeyDown = (e: KeyboardEvent): void => {
-		if (e.key === 'Escape' && this._visible) {
-			this._visible = false;
-			this._focusVisible = false;
-		}
+		if (e.key === 'Escape' && this._visible) this._visible = false;
 	};
 
 	private async _updatePosition(): Promise<void> {

--- a/src/components/forms/form-actions/form-actions.styles.ts
+++ b/src/components/forms/form-actions/form-actions.styles.ts
@@ -25,7 +25,9 @@ export const formActionsStyles = css`
 	}
 
 	:host([label-alignment='left']) .form-actions,
-	:host([label-alignment='right']) .form-actions {
+	:host([label-alignment='right']) .form-actions,
+	:host(:not([label-alignment])[form-label-alignment='left']) .form-actions,
+	:host(:not([label-alignment])[form-label-alignment='right']) .form-actions {
 		@container (min-width: 641px) {
 			flex-direction: row;
 			align-items: start;
@@ -34,7 +36,9 @@ export const formActionsStyles = css`
 	}
 
 	:host([label-alignment='left']) .form-actions::before,
-	:host([label-alignment='right']) .form-actions::before {
+	:host([label-alignment='right']) .form-actions::before,
+	:host(:not([label-alignment])[form-label-alignment='left']) .form-actions::before,
+	:host(:not([label-alignment])[form-label-alignment='right']) .form-actions::before {
 		@container (min-width: 641px) {
 			content: '';
 			flex-grow: 0;

--- a/src/components/forms/form-actions/form-actions.ts
+++ b/src/components/forms/form-actions/form-actions.ts
@@ -9,10 +9,11 @@
  * zou staan.
  *
  * Erft `label-alignment` automatisch over van een wrappende `<nldd-form>`:
- * de form mirrort z'n eigen `label-alignment` naar descendant
- * `nldd-form-actions` (en `nldd-form-field`) via een MutationObserver
- * en JS-attribuut-propagatie. Een expliciete eigen `label-alignment` op de
- * form-actions zelf wordt nooit overschreven.
+ * de form propageert z'n eigen `label-alignment` als `form-label-alignment`
+ * naar descendant `nldd-form-actions` (en `nldd-form-field`) via een
+ * MutationObserver. Een expliciete eigen `label-alignment` op de form-actions
+ * wint via CSS-cascade — de form-code raakt het `label-alignment` attribuut
+ * van de descendant nooit aan.
  *
  *     <nldd-form label-alignment="right">
  *         <nldd-form-field>...</nldd-form-field>
@@ -25,8 +26,12 @@
  *
  * @element nldd-form-actions
  *
- * @attr {string} label-alignment - 'top' (default) | 'right' | 'left'.
- *                                  Wordt geërfd van een wrappende nldd-form als niet expliciet gezet.
+ * @attr {string} label-alignment      - 'top' (default) | 'right' | 'left'.
+ *                                       Een eigen waarde wint altijd over de
+ *                                       inherited form-label-alignment.
+ * @attr {string} form-label-alignment - Door wrappende nldd-form gezet als
+ *                                       fallback. Niet zelf zetten in
+ *                                       consumer-code.
  *
  * @slot - Actie-elementen (button, button-group, etc.)
  */
@@ -42,8 +47,14 @@ export type LabelAlignment = 'top' | 'left' | 'right';
 export class NLDDFormActions extends LitElement {
 	static override styles = formActionsStyles;
 
+	/**
+	 * Default is `undefined` (and not `'top'`) so Lit doesn't reflect the
+	 * default value to the attribute on first update. Zie `nldd-form-field`
+	 * voor uitleg — dezelfde reden: form-label-alignment fallback CSS
+	 * werkt op `:not([label-alignment])`.
+	 */
 	@property({ type: String, reflect: true, attribute: 'label-alignment' })
-	labelAlignment: LabelAlignment = 'top';
+	labelAlignment: LabelAlignment | undefined = undefined;
 
 	override render() {
 		return formActionsTemplate();

--- a/src/components/forms/form-field/form-field.styles.ts
+++ b/src/components/forms/form-field/form-field.styles.ts
@@ -100,6 +100,7 @@ export const formFieldStyles = css`
 		gap: var(--primitives-space-4);
 		color: var(--semantics-content-color);
 		font: var(--primitives-font-body-md-regular-tight);
+		text-wrap: pretty;
 	}
 
 	:host([label-alignment='left']) .form-field__label,
@@ -141,6 +142,7 @@ export const formFieldStyles = css`
 	.form-field__supporting-label {
 		color: var(--semantics-content-secondary-color);
 		font: var(--primitives-font-body-xs-regular-tight);
+		text-wrap: pretty;
 	}
 
 

--- a/src/components/forms/form-field/form-field.styles.ts
+++ b/src/components/forms/form-field/form-field.styles.ts
@@ -30,7 +30,9 @@ export const formFieldStyles = css`
 	}
 
 	:host([label-alignment='left']) .form-field,
-	:host([label-alignment='right']) .form-field {
+	:host([label-alignment='right']) .form-field,
+	:host(:not([label-alignment])[form-label-alignment='left']) .form-field,
+	:host(:not([label-alignment])[form-label-alignment='right']) .form-field {
 		@container (min-width: 641px) {
 			flex-direction: row;
 			align-items: start;
@@ -48,7 +50,9 @@ export const formFieldStyles = css`
 	}
 
 	:host([label-alignment='left']) .form-field__header,
-	:host([label-alignment='right']) .form-field__header {
+	:host([label-alignment='right']) .form-field__header,
+	:host(:not([label-alignment])[form-label-alignment='left']) .form-field__header,
+	:host(:not([label-alignment])[form-label-alignment='right']) .form-field__header {
 		@container (min-width: 641px) {
 			flex-grow: 0;
 			flex-shrink: 0;
@@ -58,14 +62,16 @@ export const formFieldStyles = css`
 		}
 	}
 
-	:host([label-alignment='right']) .form-field__header {
+	:host([label-alignment='right']) .form-field__header,
+	:host(:not([label-alignment])[form-label-alignment='right']) .form-field__header {
 		@container (min-width: 641px) {
 			align-items: end;
 			text-align: right;
 		}
 	}
 
-	:host([label-alignment='left']) .form-field__header {
+	:host([label-alignment='left']) .form-field__header,
+	:host(:not([label-alignment])[form-label-alignment='left']) .form-field__header {
 		@container (min-width: 641px) {
 			align-items: start;
 			text-align: left;
@@ -77,7 +83,9 @@ export const formFieldStyles = css`
 	}
 
 	:host([label-alignment='left']) .form-field__header.is-empty,
-	:host([label-alignment='right']) .form-field__header.is-empty {
+	:host([label-alignment='right']) .form-field__header.is-empty,
+	:host(:not([label-alignment])[form-label-alignment='left']) .form-field__header.is-empty,
+	:host(:not([label-alignment])[form-label-alignment='right']) .form-field__header.is-empty {
 		@container (min-width: 641px) {
 			display: flex;
 		}
@@ -95,7 +103,9 @@ export const formFieldStyles = css`
 	}
 
 	:host([label-alignment='left']) .form-field__label,
-	:host([label-alignment='right']) .form-field__label {
+	:host([label-alignment='right']) .form-field__label,
+	:host(:not([label-alignment])[form-label-alignment='left']) .form-field__label,
+	:host(:not([label-alignment])[form-label-alignment='right']) .form-field__label {
 		@container (min-width: 641px) {
 			display: flex;
 			flex-direction: column;
@@ -103,13 +113,15 @@ export const formFieldStyles = css`
 		}
 	}
 
-	:host([label-alignment='right']) .form-field__label {
+	:host([label-alignment='right']) .form-field__label,
+	:host(:not([label-alignment])[form-label-alignment='right']) .form-field__label {
 		@container (min-width: 641px) {
 			align-items: end;
 		}
 	}
 
-	:host([label-alignment='left']) .form-field__label {
+	:host([label-alignment='left']) .form-field__label,
+	:host(:not([label-alignment])[form-label-alignment='left']) .form-field__label {
 		@container (min-width: 641px) {
 			align-items: start;
 		}

--- a/src/components/forms/form-field/form-field.ts
+++ b/src/components/forms/form-field/form-field.ts
@@ -3,8 +3,13 @@
  *
  * @element nldd-form-field
  *
- * @attr {string} label-alignment  - 'top' (default) | 'right' | 'left'
- * @attr {string} label            - Field label text. Omit for no-label layout.
+ * @attr {string} label-alignment      - 'top' (default) | 'right' | 'left'.
+ *                                       Een eigen waarde wint altijd over de
+ *                                       inherited form-label-alignment.
+ * @attr {string} form-label-alignment - Door wrappende nldd-form gezet als
+ *                                       fallback. Niet zelf zetten in
+ *                                       consumer-code.
+ * @attr {string} label                - Field label text. Omit for no-label layout.
  * @attr {string} supporting-label - Short supporting text below the label. Same typography as optional badge.
  * @attr {boolean} optional        - Shows an optional badge next to the label.
  * @attr {string} optional-label   - Text for the optional badge. Defaults to 'Optioneel'.
@@ -82,9 +87,16 @@ export class NLDDFormField extends LitElement {
 	 *  - 'left'  : 240 px column, left-aligned text
 	 *
 	 * Collapses to 'top' automatically when the container is < 640 px wide.
+	 *
+	 * Default is `undefined` (and not `'top'`) so Lit doesn't reflect the
+	 * default value to the attribute on first update. That keeps the
+	 * "no own value set" state visible to CSS as `:not([label-alignment])`,
+	 * which the form-label-alignment fallback selectors rely on. Visually
+	 * `undefined` and `'top'` render identically (no `[label-alignment]`
+	 * rules apply for either).
 	 */
 	@property({ type: String, attribute: 'label-alignment', reflect: true })
-	labelAlignment: LabelAlignment = 'top';
+	labelAlignment: LabelAlignment | undefined = undefined;
 
 	/** Label text. When empty no label is rendered but side-alignment indent is preserved. */
 	@property({ type: String })

--- a/src/components/forms/form/form.css
+++ b/src/components/forms/form/form.css
@@ -2,47 +2,28 @@
 
 nldd-form {
 	display: block;
+	container-type: inline-size;
 }
 
 nldd-form > form {
 	display: block;
 }
 
-
-/* # Vertical rhythm
-   Use margin-top on adjacent siblings (owl pattern) instead of gap, so the
-   spacing between specific element pairs can be tuned independently.
-
-   Scoped binnen nldd-form. Form-section's eigen children spacing wordt
-   in form-section.css afgehandeld; deze regels zijn voor form's directe
-   children en form-fields anywhere binnen het form. */
-
-nldd-form > form > * + *,
-nldd-form nldd-form-field + nldd-form-field {
+nldd-form > form > * + * {
 	margin-top: var(--semantics-forms-gap);
 }
 
-
-/* Tighter spacing between consecutive top-aligned form-fields. Top-aligned
-   fields are vertically tall (label stacked above input), so a tight 8px gap
-   feels right between them. Right/left-aligned fields use the default 16px.
-   On sm viewport every form-field collapses to top-alignment (via the
-   form-field's own container query), so 8px applies regardless of attribute.
-
-   640px / 641px = breakpoints.smMax / breakpoints.mdMin (zie
-   src/assets/styles/breakpoints.ts). Light-DOM CSS files kunnen geen TS
-   imports gebruiken, dus de waarde wordt hier gedupliceerd. Houd in sync
-   met breakpoints.ts en met form-field/form-actions container queries. */
-
-@media (max-width: 640px) {
-	nldd-form nldd-form-field + nldd-form-field {
+nldd-form nldd-form-field + nldd-form-field {
+	@container (max-width: 640px) {
 		margin-top: var(--semantics-forms-gap-tight);
+	}
+	@container (min-width: 641px) {
+		margin-top: var(--semantics-forms-gap);
 	}
 }
 
-@media (min-width: 641px) {
-	nldd-form nldd-form-field:not([label-alignment]) + nldd-form-field:not([label-alignment]),
-	nldd-form nldd-form-field[label-alignment='top'] + nldd-form-field[label-alignment='top'] {
+nldd-form nldd-form-field[form-label-alignment='top']:not([label-alignment='left']):not([label-alignment='right']) + nldd-form-field[form-label-alignment='top']:not([label-alignment='left']):not([label-alignment='right']) {
+	@container (min-width: 641px) {
 		margin-top: var(--semantics-forms-gap-tight);
 	}
 }

--- a/src/components/forms/form/form.css
+++ b/src/components/forms/form/form.css
@@ -22,7 +22,11 @@ nldd-form nldd-form-field + nldd-form-field {
 	}
 }
 
-nldd-form nldd-form-field[form-label-alignment='top']:not([label-alignment='left']):not([label-alignment='right']) + nldd-form-field[form-label-alignment='top']:not([label-alignment='left']):not([label-alignment='right']) {
+/* Tight gap when both fields rely on the cascaded form-label-alignment='top'
+   (no own override). An explicit `label-alignment='top'` on the form-field is
+   redundant with the default cascade and not worth the extra selector
+   complexity — set it only when overriding to 'left'/'right'. */
+nldd-form nldd-form-field[form-label-alignment='top']:not([label-alignment]) + nldd-form-field[form-label-alignment='top']:not([label-alignment]) {
 	@container (min-width: 641px) {
 		margin-top: var(--semantics-forms-gap-tight);
 	}

--- a/src/components/forms/form/form.css
+++ b/src/components/forms/form/form.css
@@ -3,6 +3,7 @@
 nldd-form {
 	display: block;
 	container-type: inline-size;
+	container-name: form;
 }
 
 nldd-form > form {
@@ -14,16 +15,16 @@ nldd-form > form > * + * {
 }
 
 nldd-form nldd-form-field + nldd-form-field {
-	@container (max-width: 640px) {
+	@container form (max-width: 640px) {
 		margin-top: var(--semantics-forms-gap-tight);
 	}
-	@container (min-width: 641px) {
+	@container form (min-width: 641px) {
 		margin-top: var(--semantics-forms-gap);
 	}
 }
 
 nldd-form nldd-form-field[form-label-alignment='top']:not([label-alignment='left']):not([label-alignment='right']) + nldd-form-field[form-label-alignment='top']:not([label-alignment='left']):not([label-alignment='right']) {
-	@container (min-width: 641px) {
+	@container form (min-width: 641px) {
 		margin-top: var(--semantics-forms-gap-tight);
 	}
 }

--- a/src/components/forms/form/form.css
+++ b/src/components/forms/form/form.css
@@ -22,11 +22,7 @@ nldd-form nldd-form-field + nldd-form-field {
 	}
 }
 
-/* Tight gap when both fields rely on the cascaded form-label-alignment='top'
-   (no own override). An explicit `label-alignment='top'` on the form-field is
-   redundant with the default cascade and not worth the extra selector
-   complexity — set it only when overriding to 'left'/'right'. */
-nldd-form nldd-form-field[form-label-alignment='top']:not([label-alignment]) + nldd-form-field[form-label-alignment='top']:not([label-alignment]) {
+nldd-form nldd-form-field[form-label-alignment='top']:not([label-alignment='left']):not([label-alignment='right']) + nldd-form-field[form-label-alignment='top']:not([label-alignment='left']):not([label-alignment='right']) {
 	@container (min-width: 641px) {
 		margin-top: var(--semantics-forms-gap-tight);
 	}

--- a/src/components/forms/form/form.test.ts
+++ b/src/components/forms/form/form.test.ts
@@ -218,8 +218,11 @@ describe('nldd-form', () => {
 				expect(f.hasAttribute('label-alignment')).toBe(false);
 			});
 			expect(actions.getAttribute('form-label-alignment')).toBe('right');
-			// form-actions reflect z'n Lit-default 'top' op label-alignment, dat is OK —
-			// de form raakt 't attribuut nooit aan, dus geen race en geen overschrijving.
+			// form-actions' labelAlignment default is `undefined`, dus Lit reflectt
+			// niets — eigen `label-alignment` blijft afwezig en de cascaded
+			// `form-label-alignment="right"` wint zonder dat de form 'm hoeft te
+			// overschrijven.
+			expect(actions.hasAttribute('label-alignment')).toBe(false);
 		});
 
 		it('overschrijft NIET een explicit eigen label-alignment van een form-field', async () => {

--- a/src/components/forms/form/form.test.ts
+++ b/src/components/forms/form/form.test.ts
@@ -200,7 +200,7 @@ describe('nldd-form', () => {
 
 
 	describe('label-alignment propagation', () => {
-		it('propageert label-alignment naar form-field en form-actions children', async () => {
+		it('propageert label-alignment naar form-field en form-actions children als form-label-alignment', async () => {
 			el = await fixture(`
 				<nldd-form label-alignment="right">
 					<nldd-form-field label="A"></nldd-form-field>
@@ -213,11 +213,13 @@ describe('nldd-form', () => {
 			const fields = el.querySelectorAll('nldd-form-field');
 			const actions = el.querySelector('nldd-form-actions')!;
 			fields.forEach(f => {
-				expect(f.getAttribute('label-alignment')).toBe('right');
-				expect((f as HTMLElement).dataset.formAlignmentInherited).toBe('true');
+				// form-label-alignment is gepropageerd; eigen label-alignment is NIET gezet
+				expect(f.getAttribute('form-label-alignment')).toBe('right');
+				expect(f.hasAttribute('label-alignment')).toBe(false);
 			});
-			expect(actions.getAttribute('label-alignment')).toBe('right');
-			expect((actions as HTMLElement).dataset.formAlignmentInherited).toBe('true');
+			expect(actions.getAttribute('form-label-alignment')).toBe('right');
+			// form-actions reflect z'n Lit-default 'top' op label-alignment, dat is OK —
+			// de form raakt 't attribuut nooit aan, dus geen race en geen overschrijving.
 		});
 
 		it('overschrijft NIET een explicit eigen label-alignment van een form-field', async () => {
@@ -232,15 +234,17 @@ describe('nldd-form', () => {
 			const inherits = el.querySelector('nldd-form-field[label="Inherits"]') as HTMLElement;
 			const own = el.querySelector('nldd-form-field[label="Own"]') as HTMLElement;
 
-			expect(inherits.getAttribute('label-alignment')).toBe('right');
-			expect(inherits.dataset.formAlignmentInherited).toBe('true');
+			// Inherited: form-label-alignment gezet, eigen label-alignment niet
+			expect(inherits.getAttribute('form-label-alignment')).toBe('right');
+			expect(inherits.hasAttribute('label-alignment')).toBe(false);
 
-			// Eigen attribute moet behouden blijven en NIET als inherited gemarkeerd zijn
+			// Eigen: label-alignment behouden; form-label-alignment óók aanwezig maar
+			// CSS-cascade laat eigen waarde winnen via :host(:not([label-alignment])[form-label-alignment=…])
 			expect(own.getAttribute('label-alignment')).toBe('top');
-			expect(own.dataset.formAlignmentInherited).toBeUndefined();
+			expect(own.getAttribute('form-label-alignment')).toBe('right');
 		});
 
-		it('past inherited children aan wanneer parent label-alignment wijzigt', async () => {
+		it('past form-label-alignment aan wanneer parent label-alignment wijzigt', async () => {
 			el = await fixture(`
 				<nldd-form label-alignment="right">
 					<nldd-form-field label="A"></nldd-form-field>
@@ -249,16 +253,16 @@ describe('nldd-form', () => {
 			await waitForUpdate(el);
 
 			const field = el.querySelector('nldd-form-field') as HTMLElement;
-			expect(field.getAttribute('label-alignment')).toBe('right');
+			expect(field.getAttribute('form-label-alignment')).toBe('right');
 
 			el.setAttribute('label-alignment', 'left');
 			await waitForUpdate(el);
 
-			expect(field.getAttribute('label-alignment')).toBe('left');
-			expect(field.dataset.formAlignmentInherited).toBe('true');
+			expect(field.getAttribute('form-label-alignment')).toBe('left');
+			expect(field.hasAttribute('label-alignment')).toBe(false);
 		});
 
-		it('verwijdert inherited attribuut wanneer parent label-alignment leegmaakt', async () => {
+		it("zet form-label-alignment terug naar 'top' wanneer parent label-alignment leegmaakt", async () => {
 			el = await fixture(`
 				<nldd-form label-alignment="right">
 					<nldd-form-field label="A"></nldd-form-field>
@@ -273,12 +277,14 @@ describe('nldd-form', () => {
 			el.removeAttribute('label-alignment');
 			await waitForUpdate(el);
 
-			// Inherited child verliest 't attribute en de marker
-			expect(inherits.hasAttribute('label-alignment')).toBe(false);
-			expect(inherits.dataset.formAlignmentInherited).toBeUndefined();
+			// form-label-alignment valt terug op de default 'top' (always-set)
+			expect(inherits.getAttribute('form-label-alignment')).toBe('top');
+			expect(own.getAttribute('form-label-alignment')).toBe('top');
 
-			// Eigen waarde blijft staan
+			// Eigen label-alignment blijft staan op de descendant die 't zelf had
 			expect(own.getAttribute('label-alignment')).toBe('top');
+			// Inherits had geen eigen label-alignment, dus die heeft 'm nog steeds niet
+			expect(inherits.hasAttribute('label-alignment')).toBe(false);
 		});
 
 		it('propageert ook naar later toegevoegde form-field children', async () => {
@@ -292,31 +298,27 @@ describe('nldd-form', () => {
 			// MutationObserver runs async — wait a microtask
 			await awaitMicrotask();
 
-			expect(field.getAttribute('label-alignment')).toBe('right');
-			expect(field.dataset.formAlignmentInherited).toBe('true');
+			expect(field.getAttribute('form-label-alignment')).toBe('right');
+			expect(field.hasAttribute('label-alignment')).toBe(false);
 		});
 
 		it('propageert ook naar later toegevoegde form-actions children', async () => {
-			// Regression: reflect:true op een Lit-component met default ='top'
-			// kan de default reflecten op de attribuut. De propagation-guard
-			// moet hier toch correct met omgaan: een dynamisch toegevoegde
-			// form-actions zonder eigen explicit alignment moet 'right'
-			// erven van de form.
+			// Form-actions reflect z'n Lit-default ='top' op label-alignment bij
+			// eerste update — maar omdat we nooit aan label-alignment komen, is
+			// er geen race meer. We zetten alleen form-label-alignment.
 			el = await fixture('<nldd-form label-alignment="right"></nldd-form>');
 			await waitForUpdate(el);
 
 			const actions = document.createElement('nldd-form-actions');
 			el.appendChild(actions);
 
-			// Wacht beide: Lit's eerste update (reflect default) én MO callback
 			await waitForUpdate(actions);
 			await awaitMicrotask();
 
-			expect(actions.getAttribute('label-alignment')).toBe('right');
-			expect(actions.dataset.formAlignmentInherited).toBe('true');
+			expect(actions.getAttribute('form-label-alignment')).toBe('right');
 		});
 
-		it('markert niets als inherited als parent geen label-alignment heeft', async () => {
+		it("zet form-label-alignment='top' als default wanneer parent geen label-alignment heeft", async () => {
 			el = await fixture(`
 				<nldd-form>
 					<nldd-form-field label="A"></nldd-form-field>
@@ -325,9 +327,10 @@ describe('nldd-form', () => {
 			await waitForUpdate(el);
 
 			const field = el.querySelector('nldd-form-field') as HTMLElement;
-			// Field reflect z'n eigen default ('top'), maar het is NIET vanuit
-			// form gepropageerd — geen inherited marker
-			expect(field.dataset.formAlignmentInherited).toBeUndefined();
+			// Always-set: descendants binnen nldd-form hebben altijd
+			// form-label-alignment, zodat downstream CSS-selectors mogen
+			// aannemen dat het attribuut aanwezig is.
+			expect(field.getAttribute('form-label-alignment')).toBe('top');
 		});
 
 		it('CSS cascade: expliciete eigen label-alignment wint over geërfde via container query', async () => {

--- a/src/components/forms/form/form.ts
+++ b/src/components/forms/form/form.ts
@@ -53,8 +53,11 @@
  * @attr {string}  autocomplete     - 'on' | 'off' (form-level autofill toggle)
  * @attr {string}  label-alignment  - Default `label-alignment` voor descendant
  *                                    nldd-form-field en nldd-form-actions
- *                                    ('top' | 'right' | 'left'). Individuele
- *                                    elementen kunnen het overrulen.
+ *                                    ('top' | 'right' | 'left'). Wordt naar
+ *                                    descendants gepropageerd als
+ *                                    `form-label-alignment`. Een eigen
+ *                                    `label-alignment` op de descendant
+ *                                    heeft voorrang via CSS-cascade.
  *
  * @prop {HTMLFormElement | null} form - The inner <form> element (read-only).
  *                                       Use voor `form.checkValidity()`,
@@ -101,7 +104,6 @@ const FORWARDED_ATTRIBUTES = [
 ] as const;
 
 const DESCENDANT_SELECTOR = 'nldd-form-field, nldd-form-actions';
-const INHERITED_MARKER = 'formAlignmentInherited';
 
 export class NLDDForm extends HTMLElement {
 	static get observedAttributes() {
@@ -198,46 +200,26 @@ export class NLDDForm extends HTMLElement {
 
 	/**
 	 * Push `label-alignment` to descendant nldd-form-field and nldd-form-actions
-	 * elements that don't have an explicit own value. We track inherited
-	 * assignments via a data-attribute so subsequent updates only touch the
-	 * elements we previously inherited to — explicit per-element overrides
-	 * are preserved.
+	 * elements as a separate `form-label-alignment` attribute, defaulting to
+	 * `'top'` when the form itself has no `label-alignment`. Descendant CSS
+	 * uses `[label-alignment="X"]` first and falls back to
+	 * `[form-label-alignment="X"]` when no own value is set, so a consumer's
+	 * explicit `label-alignment` always wins automatically — without us having
+	 * to track which elements we previously inherited to.
 	 *
-	 * **Timing-subtleties (Lit reflect-default + MutationObserver race):**
+	 * Always-setting (rather than only when the form has its own value) lets
+	 * downstream selectors assume the attribute is present on every descendant
+	 * inside an `nldd-form`, which keeps form.css's adjacent-sibling tight-gap
+	 * rule simple.
 	 *
-	 * Lit-based descendants (nldd-form-field, nldd-form-actions) reflecten hun
-	 * default `label-alignment="top"` op het attribuut wanneer hun eerste
-	 * update fired. Een naïeve `hasOwn`-check zou dan elke vers gemaakte
-	 * descendant als "explicit own value" zien en propagation skippen.
-	 *
-	 * In praktijk werkt 't omdat:
-	 * 1. Bij parsed HTML fires de form's connectedCallback VOORDAT children
-	 *    upgraden — propagation set 'right' op het attribuut, child upgrade
-	 *    leest dat als initial value (geen reflect-default-conflict).
-	 * 2. Bij dynamic appendChild fires de MutationObserver na DOM-mutation
-	 *    maar microtask-volgorde laat de propagation z'n attribuut zetten
-	 *    voordat Lit's reflection 't kan overschrijven (Lit reflect = ook
-	 *    microtask, maar de MO callback runt eerder in deze flow).
-	 *
-	 * Regression test: form.test.ts "propageert ook naar later toegevoegde
-	 * form-actions children" verifieert deze flow. Verander deze guard
-	 * niet zonder die test te draaien.
+	 * The two-attribute split also avoids the historical Lit reflect-default
+	 * vs MutationObserver timing race: we never touch `label-alignment` on
+	 * the descendant, so a freshly upgraded Lit element reflecting its default
+	 * doesn't conflict with the form's intent.
 	 */
 	private _propagateLabelAlignment(value: string | null): void {
 		const fields = this.querySelectorAll<HTMLElement>(DESCENDANT_SELECTOR);
-		fields.forEach(f => {
-			const isInherited = f.dataset[INHERITED_MARKER] === 'true';
-			const hasOwn = f.hasAttribute('label-alignment');
-			// Skip elements that have an explicit own attribute we didn't set
-			if (hasOwn && !isInherited) return;
-			if (value) {
-				f.setAttribute('label-alignment', value);
-				f.dataset[INHERITED_MARKER] = 'true';
-			} else if (isInherited) {
-				f.removeAttribute('label-alignment');
-				delete f.dataset[INHERITED_MARKER];
-			}
-		});
+		fields.forEach(f => f.setAttribute('form-label-alignment', value ?? 'top'));
 	}
 
 	private _mirrorAttributes(): void {

--- a/src/components/inputs/search-field/search-field.styles.ts
+++ b/src/components/inputs/search-field/search-field.styles.ts
@@ -6,9 +6,11 @@ export const searchFieldStyles = css`
 	/* # Host */
 
 	:host {
-		display: block;
 		--_background-color: var(--semantics-input-fields-background-color);
 		--_z-index-button-focus: 1;
+
+		display: block;
+		min-width: 0;
 		-webkit-tap-highlight-color: transparent;
 	}
 

--- a/src/components/layout/app-view/app-view.test.ts
+++ b/src/components/layout/app-view/app-view.test.ts
@@ -49,18 +49,31 @@ describe('nldd-app-view', () => {
 	});
 
 	describe('document.body background ownership', () => {
+		// Track every fixture so a mid-test failure can't leave a detached
+		// instance still listed as `_bodyBackgroundOwner` inside the module.
+		const instances: NLDDAppView[] = [];
+		async function track(html: string): Promise<NLDDAppView> {
+			const el = await fixture<NLDDAppView>(html);
+			instances.push(el);
+			return el;
+		}
+
 		afterEach(() => {
+			while (instances.length > 0) {
+				const inst = instances.pop()!;
+				if (inst.isConnected) cleanup(inst);
+			}
 			document.body.style.removeProperty('background-color');
 		});
 
 		it('writes the body background on connect', async () => {
-			el = await fixture('<nldd-app-view></nldd-app-view>');
+			el = await track('<nldd-app-view></nldd-app-view>');
 			await waitForUpdate(el);
 			expect(document.body.style.backgroundColor).not.toBe('');
 		});
 
 		it('clears the body background on disconnect when sole owner', async () => {
-			el = await fixture('<nldd-app-view></nldd-app-view>');
+			el = await track('<nldd-app-view></nldd-app-view>');
 			await waitForUpdate(el);
 			cleanup(el);
 			el = undefined as unknown as NLDDAppView;
@@ -68,9 +81,9 @@ describe('nldd-app-view', () => {
 		});
 
 		it('does not erase a surviving instance when an older one disconnects', async () => {
-			const first = await fixture<NLDDAppView>('<nldd-app-view></nldd-app-view>');
+			const first = await track('<nldd-app-view></nldd-app-view>');
 			await waitForUpdate(first);
-			const second = await fixture<NLDDAppView>('<nldd-app-view background="tinted"></nldd-app-view>');
+			const second = await track('<nldd-app-view background="tinted"></nldd-app-view>');
 			await waitForUpdate(second);
 
 			// `second` is the most recent writer; its background sits on body.

--- a/src/components/layout/app-view/app-view.test.ts
+++ b/src/components/layout/app-view/app-view.test.ts
@@ -47,4 +47,44 @@ describe('nldd-app-view', () => {
 		await waitForUpdate(el);
 		expect(el.getAttribute('background')).toBe('tinted');
 	});
+
+	describe('document.body background ownership', () => {
+		afterEach(() => {
+			document.body.style.removeProperty('background-color');
+		});
+
+		it('writes the body background on connect', async () => {
+			el = await fixture('<nldd-app-view></nldd-app-view>');
+			await waitForUpdate(el);
+			expect(document.body.style.backgroundColor).not.toBe('');
+		});
+
+		it('clears the body background on disconnect when sole owner', async () => {
+			el = await fixture('<nldd-app-view></nldd-app-view>');
+			await waitForUpdate(el);
+			cleanup(el);
+			el = undefined as unknown as NLDDAppView;
+			expect(document.body.style.backgroundColor).toBe('');
+		});
+
+		it('does not erase a surviving instance when an older one disconnects', async () => {
+			const first = await fixture<NLDDAppView>('<nldd-app-view></nldd-app-view>');
+			await waitForUpdate(first);
+			const second = await fixture<NLDDAppView>('<nldd-app-view background="tinted"></nldd-app-view>');
+			await waitForUpdate(second);
+
+			// `second` is the most recent writer; its background sits on body.
+			const ownedBySecond = document.body.style.backgroundColor;
+			expect(ownedBySecond).not.toBe('');
+
+			// Disconnecting the older instance must not clear the surviving one's
+			// background — that was the multi-instance regression.
+			cleanup(first);
+			expect(document.body.style.backgroundColor).toBe(ownedBySecond);
+
+			// Then disconnecting the actual owner clears it.
+			cleanup(second);
+			expect(document.body.style.backgroundColor).toBe('');
+		});
+	});
 });

--- a/src/components/layout/app-view/app-view.ts
+++ b/src/components/layout/app-view/app-view.ts
@@ -25,11 +25,21 @@ import { customElement, property } from 'lit/decorators.js';
 import { appViewStyles } from './app-view.styles.js';
 import { appViewTemplate } from './app-view.template.js';
 
-// Track the active app-view that owns the body-background style. Multiple
-// instances can briefly coexist (tabs, modals, tests). Only the most recently
-// connected app-view writes the background; on disconnect we only clear the
-// style if we were the owner — otherwise the surviving instance keeps theirs.
-let _bodyBackgroundOwner: NLDDAppView | null = null;
+// Track every connected app-view as a stack — the top is the current owner
+// of the body-background style. Multiple instances can briefly coexist
+// (tabs, modals, tests). Stack semantics handle disconnect order correctly:
+// the older instance's background is restored when the younger owner leaves.
+const _connectedStack: NLDDAppView[] = [];
+
+function _currentOwner(): NLDDAppView | null {
+	// Walk from the top down, skipping any entries that are no longer
+	// connected (defensive: covers test isolation gaps where an instance is
+	// removed without going through disconnectedCallback).
+	for (let i = _connectedStack.length - 1; i >= 0; i--) {
+		if (_connectedStack[i].isConnected) return _connectedStack[i];
+	}
+	return null;
+}
 
 @customElement('nldd-app-view')
 export class NLDDAppView extends LitElement {
@@ -40,32 +50,36 @@ export class NLDDAppView extends LitElement {
 
 	override connectedCallback(): void {
 		super.connectedCallback();
-		this._applyBodyBackground();
+		_connectedStack.push(this);
+		this._writeBodyBackground();
 	}
 
 	override disconnectedCallback(): void {
 		super.disconnectedCallback();
-		// Defensive: clear the stored owner not just when it's `this`, but also
-		// when the recorded owner is itself no longer in the DOM (e.g. removed
-		// without going through disconnect, or test isolation gap). Without
-		// this, a stale reference would survive across instances and the body
-		// background would never be released.
-		if (_bodyBackgroundOwner === this || (_bodyBackgroundOwner && !_bodyBackgroundOwner.isConnected)) {
+		const idx = _connectedStack.indexOf(this);
+		if (idx >= 0) _connectedStack.splice(idx, 1);
+		const owner = _currentOwner();
+		if (owner) {
+			// Re-apply whichever instance is now on top — fixes the case where
+			// a younger instance disconnects first and an older one is still
+			// in the DOM but had its background overwritten.
+			owner._writeBodyBackground();
+		} else {
 			document.body.style.removeProperty('background-color');
-			_bodyBackgroundOwner = null;
 		}
 	}
 
 	override updated(changed: PropertyValues): void {
-		if (changed.has('background')) this._applyBodyBackground();
+		if (changed.has('background') && _currentOwner() === this) {
+			this._writeBodyBackground();
+		}
 	}
 
-	private _applyBodyBackground(): void {
+	private _writeBodyBackground(): void {
 		const token = this.background === 'tinted'
 			? '--semantics-surfaces-tinted-background-color'
 			: '--semantics-surfaces-background-color';
 		document.body.style.backgroundColor = `var(${token})`;
-		_bodyBackgroundOwner = this;
 	}
 
 	override render() {

--- a/src/components/layout/app-view/app-view.ts
+++ b/src/components/layout/app-view/app-view.ts
@@ -9,13 +9,18 @@
  * All descendants read --context-parent-background-color via --_background-color automatically.
  * Individual components can override locally with their own background attribute.
  *
+ * The same background color is forced on `document.body` so that browser-
+ * chrome surfaces (iOS overscroll bounce, status bar, page-margin areas)
+ * blend with the app instead of revealing the user-agent's default white.
+ * Cleared when the app-view disconnects.
+ *
  * @element nldd-app-view
  *
  * @attr {'default'|'tinted'} background - Background color (cascades to descendants)
  *
  * @slot - Default slot for the application content
  */
-import { LitElement } from 'lit';
+import { LitElement, PropertyValues } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { appViewStyles } from './app-view.styles.js';
 import { appViewTemplate } from './app-view.template.js';
@@ -26,6 +31,27 @@ export class NLDDAppView extends LitElement {
 
 	@property({ type: String, reflect: true })
 	background: 'default' | 'tinted' = 'default';
+
+	override connectedCallback(): void {
+		super.connectedCallback();
+		this._applyBodyBackground();
+	}
+
+	override disconnectedCallback(): void {
+		super.disconnectedCallback();
+		document.body.style.removeProperty('background-color');
+	}
+
+	override updated(changed: PropertyValues): void {
+		if (changed.has('background')) this._applyBodyBackground();
+	}
+
+	private _applyBodyBackground(): void {
+		const token = this.background === 'tinted'
+			? '--semantics-surfaces-tinted-background-color'
+			: '--semantics-surfaces-background-color';
+		document.body.style.backgroundColor = `var(${token})`;
+	}
 
 	override render() {
 		return appViewTemplate(this);

--- a/src/components/layout/app-view/app-view.ts
+++ b/src/components/layout/app-view/app-view.ts
@@ -45,7 +45,12 @@ export class NLDDAppView extends LitElement {
 
 	override disconnectedCallback(): void {
 		super.disconnectedCallback();
-		if (_bodyBackgroundOwner === this) {
+		// Defensive: clear the stored owner not just when it's `this`, but also
+		// when the recorded owner is itself no longer in the DOM (e.g. removed
+		// without going through disconnect, or test isolation gap). Without
+		// this, a stale reference would survive across instances and the body
+		// background would never be released.
+		if (_bodyBackgroundOwner === this || (_bodyBackgroundOwner && !_bodyBackgroundOwner.isConnected)) {
 			document.body.style.removeProperty('background-color');
 			_bodyBackgroundOwner = null;
 		}

--- a/src/components/layout/app-view/app-view.ts
+++ b/src/components/layout/app-view/app-view.ts
@@ -25,6 +25,12 @@ import { customElement, property } from 'lit/decorators.js';
 import { appViewStyles } from './app-view.styles.js';
 import { appViewTemplate } from './app-view.template.js';
 
+// Track the active app-view that owns the body-background style. Multiple
+// instances can briefly coexist (tabs, modals, tests). Only the most recently
+// connected app-view writes the background; on disconnect we only clear the
+// style if we were the owner — otherwise the surviving instance keeps theirs.
+let _bodyBackgroundOwner: NLDDAppView | null = null;
+
 @customElement('nldd-app-view')
 export class NLDDAppView extends LitElement {
 	static override styles = appViewStyles;
@@ -39,7 +45,10 @@ export class NLDDAppView extends LitElement {
 
 	override disconnectedCallback(): void {
 		super.disconnectedCallback();
-		document.body.style.removeProperty('background-color');
+		if (_bodyBackgroundOwner === this) {
+			document.body.style.removeProperty('background-color');
+			_bodyBackgroundOwner = null;
+		}
 	}
 
 	override updated(changed: PropertyValues): void {
@@ -51,6 +60,7 @@ export class NLDDAppView extends LitElement {
 			? '--semantics-surfaces-tinted-background-color'
 			: '--semantics-surfaces-background-color';
 		document.body.style.backgroundColor = `var(${token})`;
+		_bodyBackgroundOwner = this;
 	}
 
 	override render() {

--- a/src/components/layout/card/card.styles.ts
+++ b/src/components/layout/card/card.styles.ts
@@ -25,8 +25,6 @@ export const cardStyles = css`
 		border-radius: var(--components-card-corner-radius);
 		box-shadow: var(--components-card-box-shadow);
 		overflow: hidden;
-		container-type: inline-size;
-		container-name: layout-area;
 	}
 
 

--- a/src/components/layout/card/card.ts
+++ b/src/components/layout/card/card.ts
@@ -28,6 +28,15 @@ export class NLDDCard extends LitElement {
 
 	override connectedCallback() {
 		super.connectedCallback();
+		// Set container-type/name as inline style on the host. Doing this from
+		// a `:host` rule inside the shadow DOM works in Chromium but Safari
+		// does not always recognise the host as a container for slotted
+		// descendants — a known engine inconsistency.
+		//
+		// We don't clear these on disconnect: a DOM move (disconnect →
+		// reconnect) would just re-set them, and there's no scenario where the
+		// styles being absent is meaningful. They are effectively part of the
+		// element's identity, written once and kept.
 		this.style.containerType = 'inline-size';
 		this.style.containerName = 'layout-area';
 	}

--- a/src/components/layout/card/card.ts
+++ b/src/components/layout/card/card.ts
@@ -26,6 +26,12 @@ export class NLDDCard extends LitElement {
 	@property({ type: String, attribute: 'accessible-label' })
 	accessibleLabel: string | undefined;
 
+	override connectedCallback() {
+		super.connectedCallback();
+		this.style.containerType = 'inline-size';
+		this.style.containerName = 'layout-area';
+	}
+
 	_onSlotChange = (e: Event): void => {
 		const slot = e.target as HTMLSlotElement;
 		const wrapper = slot.parentElement as HTMLElement;

--- a/src/components/layout/page-sections/full-bleed-section/full-bleed-section.styles.ts
+++ b/src/components/layout/page-sections/full-bleed-section/full-bleed-section.styles.ts
@@ -13,6 +13,8 @@ export const fullBleedSectionStyles = css`
 	   zonder layout-area dient @media als fallback. */
 
 	:host {
+		--_max-width: var(--semantics-page-sections-body-max-width);
+
 		display: flex;
 		flex-direction: column;
 		align-items: center;
@@ -23,8 +25,8 @@ export const fullBleedSectionStyles = css`
 		display: none;
 	}
 
-	:host([align="center"]) {
-		flex-grow: 1;
+	:host([full-width]) {
+		--_max-width: none;
 	}
 
 
@@ -71,6 +73,7 @@ export const fullBleedSectionStyles = css`
 		flex-direction: column;
 		flex-grow: 1;
 		width: 100%;
+		max-width: var(--_max-width);
 		gap: var(--semantics-page-sections-sm-gap);
 
 		@media (min-width: ${mdMin}) {
@@ -105,9 +108,4 @@ export const fullBleedSectionStyles = css`
 		flex-direction: column;
 		flex-grow: 1;
 	}
-
-	:host([align="center"]) .full-bleed-section__main {
-		justify-content: center;
-	}
-
 `;

--- a/src/components/layout/page-sections/full-bleed-section/full-bleed-section.styles.ts
+++ b/src/components/layout/page-sections/full-bleed-section/full-bleed-section.styles.ts
@@ -1,7 +1,9 @@
 import { css, unsafeCSS } from 'lit';
 import { breakpoints } from '../../../../assets/styles/breakpoints.js';
 
+const smMax = unsafeCSS(breakpoints.smMax);
 const mdMin = unsafeCSS(breakpoints.mdMin);
+const mdMax = unsafeCSS(breakpoints.mdMax);
 const lgMin = unsafeCSS(breakpoints.lgMin);
 
 export const fullBleedSectionStyles = css`
@@ -30,8 +32,7 @@ export const fullBleedSectionStyles = css`
 	}
 
 
-	/* # Block — sm = base; md/lg via @media (fallback) en
-	   @container layout-area (heeft voorrang binnen layout-area). */
+	/* # Block */
 
 	.full-bleed-section {
 		display: flex;
@@ -39,9 +40,12 @@ export const fullBleedSectionStyles = css`
 		flex-grow: 1;
 		width: 100%;
 		box-sizing: border-box;
-		padding-block: var(--semantics-page-sections-sm-margin-block);
 
-		@media (min-width: ${mdMin}) {
+		@media (max-width: ${smMax}) {
+			padding-block: var(--semantics-page-sections-sm-margin-block);
+		}
+
+		@media (min-width: ${mdMin}) and (max-width: ${mdMax}) {
 			padding-block: var(--semantics-page-sections-md-margin-block);
 		}
 
@@ -49,7 +53,11 @@ export const fullBleedSectionStyles = css`
 			padding-block: var(--semantics-page-sections-lg-margin-block);
 		}
 
-		@container layout-area (min-width: ${mdMin}) {
+		@container layout-area (max-width: ${smMax}) {
+			padding-block: var(--semantics-page-sections-sm-margin-block);
+		}
+
+		@container layout-area (min-width: ${mdMin}) and (max-width: ${mdMax}) {
 			padding-block: var(--semantics-page-sections-md-margin-block);
 		}
 
@@ -74,9 +82,12 @@ export const fullBleedSectionStyles = css`
 		flex-grow: 1;
 		width: 100%;
 		max-width: var(--_max-width);
-		gap: var(--semantics-page-sections-sm-gap);
 
-		@media (min-width: ${mdMin}) {
+		@media (max-width: ${smMax}) {
+			gap: var(--semantics-page-sections-sm-gap);
+		}
+
+		@media (min-width: ${mdMin}) and (max-width: ${mdMax}) {
 			gap: var(--semantics-page-sections-md-gap);
 		}
 
@@ -84,7 +95,11 @@ export const fullBleedSectionStyles = css`
 			gap: var(--semantics-page-sections-lg-gap);
 		}
 
-		@container layout-area (min-width: ${mdMin}) {
+		@container layout-area (max-width: ${smMax}) {
+			gap: var(--semantics-page-sections-sm-gap);
+		}
+
+		@container layout-area (min-width: ${mdMin}) and (max-width: ${mdMax}) {
 			gap: var(--semantics-page-sections-md-gap);
 		}
 

--- a/src/components/layout/page-sections/full-bleed-section/full-bleed-section.test.ts
+++ b/src/components/layout/page-sections/full-bleed-section/full-bleed-section.test.ts
@@ -21,11 +21,11 @@ describe('nldd-full-bleed-section', () => {
 		expect(el.shadowRoot!.querySelector('.full-bleed-section')).not.toBeNull();
 	});
 
-	it('reflects align property to attribute', async () => {
+	it('reflects full-width property to attribute', async () => {
 		el = await fixture('<nldd-full-bleed-section></nldd-full-bleed-section>');
 		await waitForUpdate(el);
-		(el as any).align = 'center';
+		(el as any).fullWidth = true;
 		await waitForUpdate(el);
-		expect(el.getAttribute('align')).toBe('center');
+		expect(el.hasAttribute('full-width')).toBe(true);
 	});
 });

--- a/src/components/layout/page-sections/full-bleed-section/full-bleed-section.ts
+++ b/src/components/layout/page-sections/full-bleed-section/full-bleed-section.ts
@@ -11,7 +11,8 @@
  * @slot - Main content
  * @slot footer - Content below the main content
  *
- * @attr {string} [align] - Set to "center" to vertically center section content
+ * @attr {boolean} [full-width] - Remove the body max-width constraint so the
+ *                                 section spans the full available width
  */
 import { LitElement } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
@@ -22,8 +23,8 @@ import { fullBleedSectionTemplate } from './full-bleed-section.template.js';
 export class NLDDFullBleedSection extends LitElement {
 	static override styles = fullBleedSectionStyles;
 
-	@property({ type: String, reflect: true })
-	align?: string;
+	@property({ type: Boolean, reflect: true, attribute: 'full-width' })
+	fullWidth = false;
 
 	_onSlotChange(e: Event) {
 		const slot = e.target as HTMLSlotElement;

--- a/src/components/layout/page-sections/one-half-one-half-section/one-half-one-half-section.styles.ts
+++ b/src/components/layout/page-sections/one-half-one-half-section/one-half-one-half-section.styles.ts
@@ -1,7 +1,9 @@
 import { css, unsafeCSS } from 'lit';
 import { breakpoints } from '../../../../assets/styles/breakpoints.js';
 
+const smMax = unsafeCSS(breakpoints.smMax);
 const mdMin = unsafeCSS(breakpoints.mdMin);
+const mdMax = unsafeCSS(breakpoints.mdMax);
 const lgMin = unsafeCSS(breakpoints.lgMin);
 
 export const oneHalfOneHalfSectionStyles = css`
@@ -30,8 +32,7 @@ export const oneHalfOneHalfSectionStyles = css`
 	}
 
 
-	/* # Block — sm = base; md/lg via @media (fallback) en
-	   @container layout-area (heeft voorrang binnen layout-area). */
+	/* # Block */
 
 	.one-half-one-half-section {
 		display: flex;
@@ -39,10 +40,13 @@ export const oneHalfOneHalfSectionStyles = css`
 		align-items: center;
 		width: 100%;
 		box-sizing: border-box;
-		padding-inline: var(--semantics-page-sections-sm-margin-inline);
-		padding-block: var(--semantics-page-sections-sm-margin-block);
 
-		@media (min-width: ${mdMin}) {
+		@media (max-width: ${smMax}) {
+			padding-inline: var(--semantics-page-sections-sm-margin-inline);
+			padding-block: var(--semantics-page-sections-sm-margin-block);
+		}
+
+		@media (min-width: ${mdMin}) and (max-width: ${mdMax}) {
 			padding-inline: var(--semantics-page-sections-md-margin-inline);
 			padding-block: var(--semantics-page-sections-md-margin-block);
 		}
@@ -52,7 +56,12 @@ export const oneHalfOneHalfSectionStyles = css`
 			padding-block: var(--semantics-page-sections-lg-margin-block);
 		}
 
-		@container layout-area (min-width: ${mdMin}) {
+		@container layout-area (max-width: ${smMax}) {
+			padding-inline: var(--semantics-page-sections-sm-margin-inline);
+			padding-block: var(--semantics-page-sections-sm-margin-block);
+		}
+
+		@container layout-area (min-width: ${mdMin}) and (max-width: ${mdMax}) {
 			padding-inline: var(--semantics-page-sections-md-margin-inline);
 			padding-block: var(--semantics-page-sections-md-margin-block);
 		}
@@ -71,9 +80,12 @@ export const oneHalfOneHalfSectionStyles = css`
 		flex-direction: column;
 		width: 100%;
 		max-width: var(--_max-width);
-		gap: var(--semantics-page-sections-sm-gap);
 
-		@media (min-width: ${mdMin}) {
+		@media (max-width: ${smMax}) {
+			gap: var(--semantics-page-sections-sm-gap);
+		}
+
+		@media (min-width: ${mdMin}) and (max-width: ${mdMax}) {
 			gap: var(--semantics-page-sections-md-gap);
 		}
 
@@ -81,7 +93,11 @@ export const oneHalfOneHalfSectionStyles = css`
 			gap: var(--semantics-page-sections-lg-gap);
 		}
 
-		@container layout-area (min-width: ${mdMin}) {
+		@container layout-area (max-width: ${smMax}) {
+			gap: var(--semantics-page-sections-sm-gap);
+		}
+
+		@container layout-area (min-width: ${mdMin}) and (max-width: ${mdMax}) {
 			gap: var(--semantics-page-sections-md-gap);
 		}
 
@@ -96,9 +112,12 @@ export const oneHalfOneHalfSectionStyles = css`
 	.one-half-one-half-section__columns {
 		display: flex;
 		flex-wrap: wrap;
-		gap: var(--semantics-page-sections-sm-gap);
 
-		@media (min-width: ${mdMin}) {
+		@media (max-width: ${smMax}) {
+			gap: var(--semantics-page-sections-sm-gap);
+		}
+
+		@media (min-width: ${mdMin}) and (max-width: ${mdMax}) {
 			gap: var(--semantics-page-sections-md-gap);
 		}
 
@@ -106,7 +125,11 @@ export const oneHalfOneHalfSectionStyles = css`
 			gap: var(--semantics-page-sections-lg-gap);
 		}
 
-		@container layout-area (min-width: ${mdMin}) {
+		@container layout-area (max-width: ${smMax}) {
+			gap: var(--semantics-page-sections-sm-gap);
+		}
+
+		@container layout-area (min-width: ${mdMin}) and (max-width: ${mdMax}) {
 			gap: var(--semantics-page-sections-md-gap);
 		}
 

--- a/src/components/layout/page-sections/one-half-one-half-section/one-half-one-half-section.styles.ts
+++ b/src/components/layout/page-sections/one-half-one-half-section/one-half-one-half-section.styles.ts
@@ -13,6 +13,8 @@ export const oneHalfOneHalfSectionStyles = css`
 	   zonder layout-area dient @media als fallback. */
 
 	:host {
+		--_max-width: var(--semantics-page-sections-body-max-width);
+
 		display: flex;
 		flex-direction: column;
 		align-items: center;
@@ -21,6 +23,10 @@ export const oneHalfOneHalfSectionStyles = css`
 
 	:host([hidden]) {
 		display: none;
+	}
+
+	:host([full-width]) {
+		--_max-width: none;
 	}
 
 
@@ -64,7 +70,7 @@ export const oneHalfOneHalfSectionStyles = css`
 		display: flex;
 		flex-direction: column;
 		width: 100%;
-		max-width: var(--semantics-page-sections-body-max-width);
+		max-width: var(--_max-width);
 		gap: var(--semantics-page-sections-sm-gap);
 
 		@media (min-width: ${mdMin}) {

--- a/src/components/layout/page-sections/one-half-one-half-section/one-half-one-half-section.ts
+++ b/src/components/layout/page-sections/one-half-one-half-section/one-half-one-half-section.ts
@@ -12,15 +12,21 @@
  * @slot left - Left column (1/2)
  * @slot right - Right column (1/2)
  * @slot footer - Content below the columns
+ *
+ * @attr {boolean} [full-width] - Remove the body max-width constraint so the
+ *                                 section spans the full available width
  */
 import { LitElement } from 'lit';
-import { customElement } from 'lit/decorators.js';
+import { customElement, property } from 'lit/decorators.js';
 import { oneHalfOneHalfSectionStyles } from './one-half-one-half-section.styles.js';
 import { oneHalfOneHalfSectionTemplate } from './one-half-one-half-section.template.js';
 
 @customElement('nldd-one-half-one-half-section')
 export class NLDDOneHalfOneHalfSection extends LitElement {
 	static override styles = oneHalfOneHalfSectionStyles;
+
+	@property({ type: Boolean, reflect: true, attribute: 'full-width' })
+	fullWidth = false;
 
 	override render() {
 		return oneHalfOneHalfSectionTemplate(this);

--- a/src/components/layout/page-sections/one-third-two-thirds-section/one-third-two-thirds-section.styles.ts
+++ b/src/components/layout/page-sections/one-third-two-thirds-section/one-third-two-thirds-section.styles.ts
@@ -1,7 +1,9 @@
 import { css, unsafeCSS } from 'lit';
 import { breakpoints } from '../../../../assets/styles/breakpoints.js';
 
+const smMax = unsafeCSS(breakpoints.smMax);
 const mdMin = unsafeCSS(breakpoints.mdMin);
+const mdMax = unsafeCSS(breakpoints.mdMax);
 const lgMin = unsafeCSS(breakpoints.lgMin);
 
 export const oneThirdTwoThirdsSectionStyles = css`
@@ -30,8 +32,7 @@ export const oneThirdTwoThirdsSectionStyles = css`
 	}
 
 
-	/* # Block — sm = base; md/lg via @media (fallback) en
-	   @container layout-area (heeft voorrang binnen layout-area). */
+	/* # Block */
 
 	.one-third-two-thirds-section {
 		display: flex;
@@ -39,10 +40,13 @@ export const oneThirdTwoThirdsSectionStyles = css`
 		align-items: center;
 		width: 100%;
 		box-sizing: border-box;
-		padding-inline: var(--semantics-page-sections-sm-margin-inline);
-		padding-block: var(--semantics-page-sections-sm-margin-block);
 
-		@media (min-width: ${mdMin}) {
+		@media (max-width: ${smMax}) {
+			padding-inline: var(--semantics-page-sections-sm-margin-inline);
+			padding-block: var(--semantics-page-sections-sm-margin-block);
+		}
+
+		@media (min-width: ${mdMin}) and (max-width: ${mdMax}) {
 			padding-inline: var(--semantics-page-sections-md-margin-inline);
 			padding-block: var(--semantics-page-sections-md-margin-block);
 		}
@@ -52,7 +56,12 @@ export const oneThirdTwoThirdsSectionStyles = css`
 			padding-block: var(--semantics-page-sections-lg-margin-block);
 		}
 
-		@container layout-area (min-width: ${mdMin}) {
+		@container layout-area (max-width: ${smMax}) {
+			padding-inline: var(--semantics-page-sections-sm-margin-inline);
+			padding-block: var(--semantics-page-sections-sm-margin-block);
+		}
+
+		@container layout-area (min-width: ${mdMin}) and (max-width: ${mdMax}) {
 			padding-inline: var(--semantics-page-sections-md-margin-inline);
 			padding-block: var(--semantics-page-sections-md-margin-block);
 		}
@@ -71,9 +80,12 @@ export const oneThirdTwoThirdsSectionStyles = css`
 		flex-direction: column;
 		width: 100%;
 		max-width: var(--_max-width);
-		gap: var(--semantics-page-sections-sm-gap);
 
-		@media (min-width: ${mdMin}) {
+		@media (max-width: ${smMax}) {
+			gap: var(--semantics-page-sections-sm-gap);
+		}
+
+		@media (min-width: ${mdMin}) and (max-width: ${mdMax}) {
 			gap: var(--semantics-page-sections-md-gap);
 		}
 
@@ -81,7 +93,11 @@ export const oneThirdTwoThirdsSectionStyles = css`
 			gap: var(--semantics-page-sections-lg-gap);
 		}
 
-		@container layout-area (min-width: ${mdMin}) {
+		@container layout-area (max-width: ${smMax}) {
+			gap: var(--semantics-page-sections-sm-gap);
+		}
+
+		@container layout-area (min-width: ${mdMin}) and (max-width: ${mdMax}) {
 			gap: var(--semantics-page-sections-md-gap);
 		}
 
@@ -96,9 +112,12 @@ export const oneThirdTwoThirdsSectionStyles = css`
 	.one-third-two-thirds-section__columns {
 		display: flex;
 		flex-wrap: wrap;
-		gap: var(--semantics-page-sections-sm-gap);
 
-		@media (min-width: ${mdMin}) {
+		@media (max-width: ${smMax}) {
+			gap: var(--semantics-page-sections-sm-gap);
+		}
+
+		@media (min-width: ${mdMin}) and (max-width: ${mdMax}) {
 			gap: var(--semantics-page-sections-md-gap);
 		}
 
@@ -106,7 +125,11 @@ export const oneThirdTwoThirdsSectionStyles = css`
 			gap: var(--semantics-page-sections-lg-gap);
 		}
 
-		@container layout-area (min-width: ${mdMin}) {
+		@container layout-area (max-width: ${smMax}) {
+			gap: var(--semantics-page-sections-sm-gap);
+		}
+
+		@container layout-area (min-width: ${mdMin}) and (max-width: ${mdMax}) {
 			gap: var(--semantics-page-sections-md-gap);
 		}
 

--- a/src/components/layout/page-sections/one-third-two-thirds-section/one-third-two-thirds-section.styles.ts
+++ b/src/components/layout/page-sections/one-third-two-thirds-section/one-third-two-thirds-section.styles.ts
@@ -13,6 +13,8 @@ export const oneThirdTwoThirdsSectionStyles = css`
 	   zonder layout-area dient @media als fallback. */
 
 	:host {
+		--_max-width: var(--semantics-page-sections-body-max-width);
+
 		display: flex;
 		flex-direction: column;
 		align-items: center;
@@ -21,6 +23,10 @@ export const oneThirdTwoThirdsSectionStyles = css`
 
 	:host([hidden]) {
 		display: none;
+	}
+
+	:host([full-width]) {
+		--_max-width: none;
 	}
 
 
@@ -64,7 +70,7 @@ export const oneThirdTwoThirdsSectionStyles = css`
 		display: flex;
 		flex-direction: column;
 		width: 100%;
-		max-width: var(--semantics-page-sections-body-max-width);
+		max-width: var(--_max-width);
 		gap: var(--semantics-page-sections-sm-gap);
 
 		@media (min-width: ${mdMin}) {

--- a/src/components/layout/page-sections/one-third-two-thirds-section/one-third-two-thirds-section.ts
+++ b/src/components/layout/page-sections/one-third-two-thirds-section/one-third-two-thirds-section.ts
@@ -12,15 +12,21 @@
  * @slot - Right column (2/3), alternative for slot="right"
  * @slot right - Right column (2/3)
  * @slot footer - Content below the columns
+ *
+ * @attr {boolean} [full-width] - Remove the body max-width constraint so the
+ *                                 section spans the full available width
  */
 import { LitElement } from 'lit';
-import { customElement } from 'lit/decorators.js';
+import { customElement, property } from 'lit/decorators.js';
 import { oneThirdTwoThirdsSectionStyles } from './one-third-two-thirds-section.styles.js';
 import { oneThirdTwoThirdsSectionTemplate } from './one-third-two-thirds-section.template.js';
 
 @customElement('nldd-one-third-two-thirds-section')
 export class NLDDOneThirdTwoThirdsSection extends LitElement {
 	static override styles = oneThirdTwoThirdsSectionStyles;
+
+	@property({ type: Boolean, reflect: true, attribute: 'full-width' })
+	fullWidth = false;
 
 	override render() {
 		return oneThirdTwoThirdsSectionTemplate(this);

--- a/src/components/layout/page-sections/simple-section/simple-section.styles.ts
+++ b/src/components/layout/page-sections/simple-section/simple-section.styles.ts
@@ -15,6 +15,8 @@ export const simpleSectionStyles = css`
 	   zonder layout-area dient @media als fallback. */
 
 	:host {
+		--_max-width: var(--semantics-page-sections-body-max-width);
+
 		display: flex;
 		flex-direction: column;
 		align-items: center;
@@ -25,10 +27,13 @@ export const simpleSectionStyles = css`
 		display: none;
 	}
 
-	:host([align="center"]),
 	:host(:last-child),
 	:host(.is-last) {
 		flex-grow: 1;
+	}
+
+	:host([full-width]) {
+		--_max-width: none;
 	}
 
 
@@ -88,7 +93,7 @@ export const simpleSectionStyles = css`
 		flex-direction: column;
 		flex-grow: 1;
 		width: 100%;
-		max-width: var(--semantics-page-sections-body-max-width);
+		max-width: var(--_max-width);
 
 		@media (max-width: ${smMax}) {
 			gap: var(--semantics-page-sections-sm-gap);
@@ -129,9 +134,5 @@ export const simpleSectionStyles = css`
 		display: flex;
 		flex-direction: column;
 		flex-grow: 1;
-	}
-
-	:host([align="center"]) .simple-section__main {
-		justify-content: center;
 	}
 `;

--- a/src/components/layout/page-sections/simple-section/simple-section.styles.ts
+++ b/src/components/layout/page-sections/simple-section/simple-section.styles.ts
@@ -1,6 +1,7 @@
 import { css, unsafeCSS } from 'lit';
 import { breakpoints } from '../../../../assets/styles/breakpoints.js';
 
+const smMax = unsafeCSS(breakpoints.smMax);
 const mdMin = unsafeCSS(breakpoints.mdMin);
 const lgMin = unsafeCSS(breakpoints.lgMin);
 
@@ -51,6 +52,11 @@ export const simpleSectionStyles = css`
 			padding-block: var(--semantics-page-sections-lg-margin-block);
 		}
 
+		@container layout-area (max-width: ${smMax}) {
+			padding-inline: var(--semantics-page-sections-sm-margin-inline);
+			padding-block: var(--semantics-page-sections-sm-margin-block);
+		}
+
 		@container layout-area (min-width: ${mdMin}) {
 			padding-inline: var(--semantics-page-sections-md-margin-inline);
 			padding-block: var(--semantics-page-sections-md-margin-block);
@@ -86,6 +92,10 @@ export const simpleSectionStyles = css`
 
 		@media (min-width: ${lgMin}) {
 			gap: var(--semantics-page-sections-lg-gap);
+		}
+
+		@container layout-area (max-width: ${unsafeCSS(breakpoints.smMax)}) {
+			gap: var(--semantics-page-sections-sm-gap);
 		}
 
 		@container layout-area (min-width: ${mdMin}) {

--- a/src/components/layout/page-sections/simple-section/simple-section.styles.ts
+++ b/src/components/layout/page-sections/simple-section/simple-section.styles.ts
@@ -24,7 +24,9 @@ export const simpleSectionStyles = css`
 		display: none;
 	}
 
-	:host([align="center"]) {
+	:host([align="center"]),
+	:host(:last-child),
+	:host(.is-last) {
 		flex-grow: 1;
 	}
 

--- a/src/components/layout/page-sections/simple-section/simple-section.styles.ts
+++ b/src/components/layout/page-sections/simple-section/simple-section.styles.ts
@@ -3,6 +3,7 @@ import { breakpoints } from '../../../../assets/styles/breakpoints.js';
 
 const smMax = unsafeCSS(breakpoints.smMax);
 const mdMin = unsafeCSS(breakpoints.mdMin);
+const mdMax = unsafeCSS(breakpoints.mdMax);
 const lgMin = unsafeCSS(breakpoints.lgMin);
 
 export const simpleSectionStyles = css`
@@ -31,8 +32,7 @@ export const simpleSectionStyles = css`
 	}
 
 
-	/* # Block — sm = base; md/lg via @media (fallback) en
-	   @container layout-area (heeft voorrang binnen layout-area). */
+	/* # Block */
 
 	.simple-section {
 		display: flex;
@@ -41,10 +41,13 @@ export const simpleSectionStyles = css`
 		align-items: center;
 		width: 100%;
 		box-sizing: border-box;
-		padding-inline: var(--semantics-page-sections-sm-margin-inline);
-		padding-block: var(--semantics-page-sections-sm-margin-block);
 
-		@media (min-width: ${mdMin}) {
+		@media (max-width: ${smMax}) {
+			padding-inline: var(--semantics-page-sections-sm-margin-inline);
+			padding-block: var(--semantics-page-sections-sm-margin-block);
+		}
+
+		@media (min-width: ${mdMin}) and (max-width: ${mdMax}) {
 			padding-inline: var(--semantics-page-sections-md-margin-inline);
 			padding-block: var(--semantics-page-sections-md-margin-block);
 		}
@@ -59,7 +62,7 @@ export const simpleSectionStyles = css`
 			padding-block: var(--semantics-page-sections-sm-margin-block);
 		}
 
-		@container layout-area (min-width: ${mdMin}) {
+		@container layout-area (min-width: ${mdMin}) and (max-width: ${mdMax}) {
 			padding-inline: var(--semantics-page-sections-md-margin-inline);
 			padding-block: var(--semantics-page-sections-md-margin-block);
 		}
@@ -86,9 +89,12 @@ export const simpleSectionStyles = css`
 		flex-grow: 1;
 		width: 100%;
 		max-width: var(--semantics-page-sections-body-max-width);
-		gap: var(--semantics-page-sections-sm-gap);
 
-		@media (min-width: ${mdMin}) {
+		@media (max-width: ${smMax}) {
+			gap: var(--semantics-page-sections-sm-gap);
+		}
+
+		@media (min-width: ${mdMin}) and (max-width: ${mdMax}) {
 			gap: var(--semantics-page-sections-md-gap);
 		}
 
@@ -96,11 +102,11 @@ export const simpleSectionStyles = css`
 			gap: var(--semantics-page-sections-lg-gap);
 		}
 
-		@container layout-area (max-width: ${unsafeCSS(breakpoints.smMax)}) {
+		@container layout-area (max-width: ${smMax}) {
 			gap: var(--semantics-page-sections-sm-gap);
 		}
 
-		@container layout-area (min-width: ${mdMin}) {
+		@container layout-area (min-width: ${mdMin}) and (max-width: ${mdMax}) {
 			gap: var(--semantics-page-sections-md-gap);
 		}
 

--- a/src/components/layout/page-sections/simple-section/simple-section.test.ts
+++ b/src/components/layout/page-sections/simple-section/simple-section.test.ts
@@ -21,11 +21,11 @@ describe('nldd-simple-section', () => {
 		expect(el.shadowRoot!.querySelector('.simple-section')).not.toBeNull();
 	});
 
-	it('reflects align property to attribute', async () => {
+	it('reflects full-width property to attribute', async () => {
 		el = await fixture('<nldd-simple-section></nldd-simple-section>');
 		await waitForUpdate(el);
-		(el as any).align = 'center';
+		(el as any).fullWidth = true;
 		await waitForUpdate(el);
-		expect(el.getAttribute('align')).toBe('center');
+		expect(el.hasAttribute('full-width')).toBe(true);
 	});
 });

--- a/src/components/layout/page-sections/simple-section/simple-section.ts
+++ b/src/components/layout/page-sections/simple-section/simple-section.ts
@@ -11,7 +11,8 @@
  * @slot - Main content
  * @slot footer - Content below the main content
  *
- * @attr {string} [align] - Set to "center" to vertically center section content
+ * @attr {boolean} [full-width] - Remove the body max-width constraint so the
+ *                                 section spans the full available width
  */
 import { LitElement } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
@@ -22,8 +23,8 @@ import { simpleSectionTemplate } from './simple-section.template.js';
 export class NLDDSimpleSection extends LitElement {
 	static override styles = simpleSectionStyles;
 
-	@property({ type: String, reflect: true })
-	align?: string;
+	@property({ type: Boolean, reflect: true, attribute: 'full-width' })
+	fullWidth = false;
 
 	_onSlotChange(e: Event) {
 		const slot = e.target as HTMLSlotElement;

--- a/src/components/layout/page-sections/two-thirds-one-third-section/two-thirds-one-third-section.styles.ts
+++ b/src/components/layout/page-sections/two-thirds-one-third-section/two-thirds-one-third-section.styles.ts
@@ -13,6 +13,8 @@ export const twoThirdsOneThirdSectionStyles = css`
 	   zonder layout-area dient @media als fallback. */
 
 	:host {
+		--_max-width: var(--semantics-page-sections-body-max-width);
+
 		display: flex;
 		flex-direction: column;
 		align-items: center;
@@ -21,6 +23,10 @@ export const twoThirdsOneThirdSectionStyles = css`
 
 	:host([hidden]) {
 		display: none;
+	}
+
+	:host([full-width]) {
+		--_max-width: none;
 	}
 
 
@@ -64,7 +70,7 @@ export const twoThirdsOneThirdSectionStyles = css`
 		display: flex;
 		flex-direction: column;
 		width: 100%;
-		max-width: var(--semantics-page-sections-body-max-width);
+		max-width: var(--_max-width);
 		gap: var(--semantics-page-sections-sm-gap);
 
 		@media (min-width: ${mdMin}) {

--- a/src/components/layout/page-sections/two-thirds-one-third-section/two-thirds-one-third-section.styles.ts
+++ b/src/components/layout/page-sections/two-thirds-one-third-section/two-thirds-one-third-section.styles.ts
@@ -1,7 +1,9 @@
 import { css, unsafeCSS } from 'lit';
 import { breakpoints } from '../../../../assets/styles/breakpoints.js';
 
+const smMax = unsafeCSS(breakpoints.smMax);
 const mdMin = unsafeCSS(breakpoints.mdMin);
+const mdMax = unsafeCSS(breakpoints.mdMax);
 const lgMin = unsafeCSS(breakpoints.lgMin);
 
 export const twoThirdsOneThirdSectionStyles = css`
@@ -30,8 +32,7 @@ export const twoThirdsOneThirdSectionStyles = css`
 	}
 
 
-	/* # Block — sm = base; md/lg via @media (fallback) en
-	   @container layout-area (heeft voorrang binnen layout-area). */
+	/* # Block */
 
 	.two-thirds-one-third-section {
 		display: flex;
@@ -39,10 +40,13 @@ export const twoThirdsOneThirdSectionStyles = css`
 		align-items: center;
 		width: 100%;
 		box-sizing: border-box;
-		padding-inline: var(--semantics-page-sections-sm-margin-inline);
-		padding-block: var(--semantics-page-sections-sm-margin-block);
 
-		@media (min-width: ${mdMin}) {
+		@media (max-width: ${smMax}) {
+			padding-inline: var(--semantics-page-sections-sm-margin-inline);
+			padding-block: var(--semantics-page-sections-sm-margin-block);
+		}
+
+		@media (min-width: ${mdMin}) and (max-width: ${mdMax}) {
 			padding-inline: var(--semantics-page-sections-md-margin-inline);
 			padding-block: var(--semantics-page-sections-md-margin-block);
 		}
@@ -52,7 +56,12 @@ export const twoThirdsOneThirdSectionStyles = css`
 			padding-block: var(--semantics-page-sections-lg-margin-block);
 		}
 
-		@container layout-area (min-width: ${mdMin}) {
+		@container layout-area (max-width: ${smMax}) {
+			padding-inline: var(--semantics-page-sections-sm-margin-inline);
+			padding-block: var(--semantics-page-sections-sm-margin-block);
+		}
+
+		@container layout-area (min-width: ${mdMin}) and (max-width: ${mdMax}) {
 			padding-inline: var(--semantics-page-sections-md-margin-inline);
 			padding-block: var(--semantics-page-sections-md-margin-block);
 		}
@@ -71,9 +80,12 @@ export const twoThirdsOneThirdSectionStyles = css`
 		flex-direction: column;
 		width: 100%;
 		max-width: var(--_max-width);
-		gap: var(--semantics-page-sections-sm-gap);
 
-		@media (min-width: ${mdMin}) {
+		@media (max-width: ${smMax}) {
+			gap: var(--semantics-page-sections-sm-gap);
+		}
+
+		@media (min-width: ${mdMin}) and (max-width: ${mdMax}) {
 			gap: var(--semantics-page-sections-md-gap);
 		}
 
@@ -81,7 +93,11 @@ export const twoThirdsOneThirdSectionStyles = css`
 			gap: var(--semantics-page-sections-lg-gap);
 		}
 
-		@container layout-area (min-width: ${mdMin}) {
+		@container layout-area (max-width: ${smMax}) {
+			gap: var(--semantics-page-sections-sm-gap);
+		}
+
+		@container layout-area (min-width: ${mdMin}) and (max-width: ${mdMax}) {
 			gap: var(--semantics-page-sections-md-gap);
 		}
 
@@ -96,9 +112,12 @@ export const twoThirdsOneThirdSectionStyles = css`
 	.two-thirds-one-third-section__columns {
 		display: flex;
 		flex-wrap: wrap;
-		gap: var(--semantics-page-sections-sm-gap);
 
-		@media (min-width: ${mdMin}) {
+		@media (max-width: ${smMax}) {
+			gap: var(--semantics-page-sections-sm-gap);
+		}
+
+		@media (min-width: ${mdMin}) and (max-width: ${mdMax}) {
 			gap: var(--semantics-page-sections-md-gap);
 		}
 
@@ -106,7 +125,11 @@ export const twoThirdsOneThirdSectionStyles = css`
 			gap: var(--semantics-page-sections-lg-gap);
 		}
 
-		@container layout-area (min-width: ${mdMin}) {
+		@container layout-area (max-width: ${smMax}) {
+			gap: var(--semantics-page-sections-sm-gap);
+		}
+
+		@container layout-area (min-width: ${mdMin}) and (max-width: ${mdMax}) {
 			gap: var(--semantics-page-sections-md-gap);
 		}
 
@@ -124,5 +147,4 @@ export const twoThirdsOneThirdSectionStyles = css`
 		flex: 1;
 		min-width: var(--primitives-area-280);
 	}
-
 `;

--- a/src/components/layout/page-sections/two-thirds-one-third-section/two-thirds-one-third-section.ts
+++ b/src/components/layout/page-sections/two-thirds-one-third-section/two-thirds-one-third-section.ts
@@ -12,15 +12,21 @@
  * @slot left - Left column (2/3)
  * @slot right - Right column (1/3)
  * @slot footer - Content below the columns
+ *
+ * @attr {boolean} [full-width] - Remove the body max-width constraint so the
+ *                                 section spans the full available width
  */
 import { LitElement } from 'lit';
-import { customElement } from 'lit/decorators.js';
+import { customElement, property } from 'lit/decorators.js';
 import { twoThirdsOneThirdSectionStyles } from './two-thirds-one-third-section.styles.js';
 import { twoThirdsOneThirdSectionTemplate } from './two-thirds-one-third-section.template.js';
 
 @customElement('nldd-two-thirds-one-third-section')
 export class NLDDTwoThirdsOneThirdSection extends LitElement {
 	static override styles = twoThirdsOneThirdSectionStyles;
+
+	@property({ type: Boolean, reflect: true, attribute: 'full-width' })
+	fullWidth = false;
 
 	override render() {
 		return twoThirdsOneThirdSectionTemplate(this);

--- a/src/components/layout/page/page.stories.ts
+++ b/src/components/layout/page/page.stories.ts
@@ -171,7 +171,7 @@ export const GecentreerdeDialoog = {
 	render: () => html`
 	<nldd-page sticky-header sticky-footer style="height: 400px;">
 		${header}
-		<nldd-simple-section align="center">
+		<nldd-simple-section>
 			<nldd-inline-dialog
 				icon="search"
 				text="Geen resultaten"

--- a/src/components/layout/page/page.styles.ts
+++ b/src/components/layout/page/page.styles.ts
@@ -61,7 +61,7 @@ export const pageStyles = css`
 
 	:host([sticky-header]) .page__header {
 		position: absolute;
-		top: 0;
+		top: var(--context-bar-split-view-top-bars-height, 0px);
 		left: 0;
 		right: 0;
 		z-index: 1;

--- a/src/components/layout/page/page.styles.ts
+++ b/src/components/layout/page/page.styles.ts
@@ -42,13 +42,21 @@ export const pageStyles = css`
 	}
 
 
+	/* # Block */
+
+	.page {
+		display: flex;
+		flex-direction: column;
+		flex-grow: 1;
+		min-height: 0;
+	}
+
+
 	/* # Header */
 
 	.page__header {
 		flex-shrink: 0;
 		position: relative;
-		container-type: inline-size;
-		container-name: layout-area;
 	}
 
 	:host([sticky-header]) .page__header {
@@ -99,8 +107,6 @@ export const pageStyles = css`
 		display: flex;
 		flex-direction: column;
 		flex-grow: 1;
-		container-type: inline-size;
-		container-name: layout-area;
 	}
 
 
@@ -109,8 +115,6 @@ export const pageStyles = css`
 	.page__footer {
 		flex-shrink: 0;
 		position: relative;
-		container-type: inline-size;
-		container-name: layout-area;
 	}
 
 	:host([sticky-footer]) .page__footer {

--- a/src/components/layout/page/page.styles.ts
+++ b/src/components/layout/page/page.styles.ts
@@ -15,8 +15,6 @@ export const pageStyles = css`
 		overflow-y: auto;
 		overflow-x: hidden;
 		background-color: var(--_background-color);
-		padding-top: var(--context-bar-split-view-top-bars-height, 0px);
-		padding-bottom: var(--context-bar-split-view-bottom-bars-height, 0px);
 	}
 
 	/* Overflow hidden prevents content from escaping the scroll wrapper.
@@ -61,7 +59,7 @@ export const pageStyles = css`
 
 	:host([sticky-header]) .page__header {
 		position: absolute;
-		top: var(--context-bar-split-view-top-bars-height, 0px);
+		top: 0;
 		left: 0;
 		right: 0;
 		z-index: 1;

--- a/src/components/layout/page/page.template.ts
+++ b/src/components/layout/page/page.template.ts
@@ -3,16 +3,18 @@ import type { NLDDPage } from './page.js';
 
 export function pageTemplate(component: NLDDPage): TemplateResult {
 	return html`
-		<header class="page__header ${component._scrolled ? 'is-scrolled' : ''}">
-			<slot name="header"></slot>
-		</header>
-		<div class="page__scroll">
-			<main class="page__main">
-				<slot></slot>
-			</main>
-			<footer class="page__footer">
-				<slot name="footer"></slot>
-			</footer>
+		<div class="page">
+			<header class="page__header ${component._scrolled ? 'is-scrolled' : ''}">
+				<slot name="header"></slot>
+			</header>
+			<div class="page__scroll">
+				<main class="page__main">
+					<slot></slot>
+				</main>
+				<footer class="page__footer">
+					<slot name="footer"></slot>
+				</footer>
+			</div>
 		</div>
 	`;
 }

--- a/src/components/layout/page/page.test.ts
+++ b/src/components/layout/page/page.test.ts
@@ -48,4 +48,51 @@ describe('nldd-page', () => {
 		expect(scroll.style.paddingTop).not.toBe('');
 	});
 
+	describe('is-last main slot marker', () => {
+		it('marks the last visible main child with is-last', async () => {
+			el = await fixture(`
+				<nldd-page>
+					<div id="a">A</div>
+					<div id="b">B</div>
+					<div id="c">C</div>
+				</nldd-page>
+			`);
+			await waitForUpdate(el);
+
+			expect(el.querySelector('#a')!.classList.contains('is-last')).toBe(false);
+			expect(el.querySelector('#b')!.classList.contains('is-last')).toBe(false);
+			expect(el.querySelector('#c')!.classList.contains('is-last')).toBe(true);
+		});
+
+		it('skips hidden children when picking the last', async () => {
+			el = await fixture(`
+				<nldd-page>
+					<div id="a">A</div>
+					<div id="b">B</div>
+					<div id="c" hidden>C</div>
+				</nldd-page>
+			`);
+			await waitForUpdate(el);
+
+			expect(el.querySelector('#b')!.classList.contains('is-last')).toBe(true);
+			expect(el.querySelector('#c')!.classList.contains('is-last')).toBe(false);
+		});
+
+		it('ignores siblings in named slots', async () => {
+			el = await fixture(`
+				<nldd-page>
+					<div id="a">A</div>
+					<div id="b">B</div>
+					<div id="footer" slot="footer">Footer</div>
+				</nldd-page>
+			`);
+			await waitForUpdate(el);
+
+			// `footer` is in a named slot — it should not appear in the main-slot
+			// last-pick and thus must not carry is-last.
+			expect(el.querySelector('#b')!.classList.contains('is-last')).toBe(true);
+			expect(el.querySelector('#footer')!.classList.contains('is-last')).toBe(false);
+		});
+	});
+
 });

--- a/src/components/layout/page/page.ts
+++ b/src/components/layout/page/page.ts
@@ -55,6 +55,13 @@ export class NLDDPage extends LitElement {
 
 	override connectedCallback() {
 		super.connectedCallback();
+		// Set container-type/name as inline style on the host element. Doing
+		// this from a `:host` rule inside the shadow DOM works in Chromium
+		// but Safari does not always recognise the host as a container for
+		// slotted descendants — a known engine inconsistency. Inline on the
+		// light-DOM host avoids it entirely.
+		this.style.containerType = 'inline-size';
+		this.style.containerName = 'layout-area';
 		if (this.hasUpdated) {
 			this._setupScrollListener();
 			if (this.stickyHeader) this._setupHeaderObserver();

--- a/src/components/layout/page/page.ts
+++ b/src/components/layout/page/page.ts
@@ -40,6 +40,7 @@ export class NLDDPage extends LitElement {
 
 	private _scrollTarget: EventTarget | null = null;
 	private _headerObserver: ResizeObserver | null = null;
+	private _mainSlot: HTMLSlotElement | null = null;
 
 	get scrollTarget(): HTMLElement {
 		return (this.stickyHeader ? (this._scrollEl ?? this) : this);
@@ -72,11 +73,13 @@ export class NLDDPage extends LitElement {
 		super.disconnectedCallback();
 		this._teardownScrollListener();
 		this._teardownHeaderObserver();
+		this._teardownMainSlotListener();
 	}
 
 	override firstUpdated() {
 		this._setupScrollListener();
 		if (this.stickyHeader) this._setupHeaderObserver();
+		this._setupMainSlotListener();
 	}
 
 	override updated(changed: PropertyValues) {
@@ -130,6 +133,36 @@ export class NLDDPage extends LitElement {
 	private _onScroll = () => {
 		const target = (this.stickyHeader ? this._scrollEl : this) as HTMLElement;
 		this._scrolled = target.scrollTop > 0;
+	};
+
+	// Mark the last visible main-slot child with `is-last`, so section-style
+	// components can grow to fill remaining vertical space without coupling
+	// to specific tag types or relying on light-DOM `:last-child` (which
+	// breaks when slot="footer" siblings are present). Same shape as
+	// nldd-list's _updateItems().
+	private _setupMainSlotListener() {
+		this._teardownMainSlotListener();
+		const slot = this.shadowRoot?.querySelector<HTMLSlotElement>('slot:not([name])') ?? null;
+		this._mainSlot = slot;
+		if (!slot) return;
+		slot.addEventListener('slotchange', this._updateMainItems);
+		this._updateMainItems();
+	}
+
+	private _teardownMainSlotListener() {
+		if (this._mainSlot) {
+			this._mainSlot.removeEventListener('slotchange', this._updateMainItems);
+			this._mainSlot = null;
+		}
+	}
+
+	private _updateMainItems = () => {
+		const slot = this._mainSlot;
+		if (!slot) return;
+		const items = slot.assignedElements() as HTMLElement[];
+		const visible = items.filter(el => !el.hasAttribute('hidden'));
+		const last = visible[visible.length - 1];
+		items.forEach(el => el.classList.toggle('is-last', el === last));
 	};
 
 	override render() {

--- a/src/components/layout/popover/popover.styles.ts
+++ b/src/components/layout/popover/popover.styles.ts
@@ -68,6 +68,14 @@ export const popoverStyles = css`
 			}
 		}
 
+		:host::backdrop {
+			background-color: var(--semantics-overlays-backdrop-color);
+		}
+
+		:host([sm-full-height]) {
+			height: calc(100dvh - var(--semantics-sheets-bottom-top-inset));
+		}
+
 	}
 
 

--- a/src/components/layout/popover/popover.styles.ts
+++ b/src/components/layout/popover/popover.styles.ts
@@ -2,6 +2,7 @@ import { css, unsafeCSS } from 'lit';
 import { breakpoints } from '../../../assets/styles/breakpoints.js';
 
 const smMax = unsafeCSS(breakpoints.smMax);
+const mdMin = unsafeCSS(breakpoints.mdMin);
 
 export const popoverStyles = css`
 
@@ -10,20 +11,38 @@ export const popoverStyles = css`
 
 	:host {
 		--_max-height: calc(100vh - var(--semantics-overlays-inset) * 2);
-		position: absolute;
-		inset: unset;
+
 		margin: 0;
 		padding: 0;
 		border: none;
 		background-color: var(--semantics-surfaces-background-color);
-		border-radius: var(--semantics-overlays-corner-radius);
 		box-shadow: var(--semantics-overlays-box-shadow);
-		width: var(--components-popover-default-width);
-		max-width: calc(100vw - var(--semantics-overlays-inset) * 2);
-		max-height: var(--_max-height);
 		overflow: auto;
 		outline: none;
 		isolation: isolate;
+
+		@media (max-width: ${smMax}) {
+			position: fixed;
+			inset: auto 0 0 0;
+			width: 100%;
+			max-width: 100%;
+			max-height: calc(100dvh - var(--semantics-sheets-bottom-top-inset));
+			border-radius: var(--semantics-overlays-corner-radius) var(--semantics-overlays-corner-radius) 0 0;
+			transform: translateY(100%);
+			transition:
+				transform var(--semantics-sheets-bottom-animation-duration) var(--primitives-transition-easing-default),
+				display var(--semantics-sheets-bottom-animation-duration) allow-discrete,
+				overlay var(--semantics-sheets-bottom-animation-duration) allow-discrete;
+		}
+
+		@media (min-width: ${mdMin}) {
+			position: absolute;
+			inset: unset;
+			border-radius: var(--semantics-overlays-corner-radius);
+			width: var(--components-popover-default-width);
+			max-width: calc(100vw - var(--semantics-overlays-inset) * 2);
+			max-height: var(--_max-height);
+		}
 	}
 
 	:host([hidden]) {
@@ -41,41 +60,26 @@ export const popoverStyles = css`
 	}
 
 
-	/* # Responsive: sm viewport — bottom sheet */
-
-	@media (max-width: ${smMax}) {
-		:host {
-			position: fixed;
-			inset: auto 0 0 0;
-			width: 100%;
-			max-width: 100%;
-			max-height: calc(100dvh - var(--semantics-sheets-bottom-top-inset));
-			border-radius: var(--semantics-overlays-corner-radius) var(--semantics-overlays-corner-radius) 0 0;
-			transform: translateY(100%);
-			transition:
-				transform var(--semantics-sheets-bottom-animation-duration) var(--primitives-transition-easing-default),
-				display var(--semantics-sheets-bottom-animation-duration) allow-discrete,
-				overlay var(--semantics-sheets-bottom-animation-duration) allow-discrete;
-		}
-
-		:host(:popover-open) {
+	:host(:popover-open) {
+		@media (max-width: ${smMax}) {
 			transform: translateY(0);
-		}
 
-		@starting-style {
-			:host(:popover-open) {
+			@starting-style {
 				transform: translateY(100%);
 			}
 		}
+	}
 
-		:host::backdrop {
+	:host::backdrop {
+		@media (max-width: ${smMax}) {
 			background-color: var(--semantics-overlays-backdrop-color);
 		}
+	}
 
-		:host([sm-full-height]) {
+	:host([sm-full-height]) {
+		@media (max-width: ${smMax}) {
 			height: calc(100dvh - var(--semantics-sheets-bottom-top-inset));
 		}
-
 	}
 
 
@@ -85,8 +89,8 @@ export const popoverStyles = css`
 	   toekomstige desktop-viewport animaties automatisch worden
 	   gedeactiveerd voor users met prefers-reduced-motion. */
 
-	@media (prefers-reduced-motion: reduce) {
-		:host {
+	:host {
+		@media (prefers-reduced-motion: reduce) {
 			transition: none;
 		}
 	}

--- a/src/components/layout/popover/popover.test.ts
+++ b/src/components/layout/popover/popover.test.ts
@@ -477,4 +477,97 @@ describe('nldd-popover', () => {
 			expect(document.activeElement).toBe(popover);
 		});
 	});
+
+
+	describe('position overrides (centered + edge attrs)', () => {
+		// Force md/lg viewport so the sm bottom-sheet branch isn't taken.
+		// reposition() reads `_smQuery.matches`, which we override to false.
+		function asMd(popover: NLDDPopover) {
+			(popover as unknown as { _smQuery: MediaQueryList })._smQuery = {
+				matches: false,
+				addEventListener: () => {},
+				removeEventListener: () => {},
+			} as unknown as MediaQueryList;
+		}
+
+		it('centered=true centreert beide assen via translate(-50%, -50%)', async () => {
+			const wrapper = await fixture(`
+				<div>
+					<button id="trigger-centered">Trigger</button>
+					<nldd-popover anchor="trigger-centered" accessible-label="Test" centered></nldd-popover>
+				</div>
+			`);
+			el = wrapper;
+			const popover = wrapper.querySelector('nldd-popover') as NLDDPopover;
+			asMd(popover);
+			await waitForUpdate(popover);
+
+			popover.show();
+			await waitForUpdate(popover);
+
+			expect(popover.style.top).toBe('50%');
+			expect(popover.style.left).toBe('50%');
+			expect(popover.style.transform).toContain('-50%');
+			expect(popover.style.transform).toContain(', -50%');
+		});
+
+		it('centered + top="0" → horizontaal gecentreerd, top-aligned', async () => {
+			const wrapper = await fixture(`
+				<div>
+					<button id="trigger-centered-top">Trigger</button>
+					<nldd-popover anchor="trigger-centered-top" accessible-label="Test" centered top="0"></nldd-popover>
+				</div>
+			`);
+			el = wrapper;
+			const popover = wrapper.querySelector('nldd-popover') as NLDDPopover;
+			asMd(popover);
+			await waitForUpdate(popover);
+
+			popover.show();
+			await waitForUpdate(popover);
+
+			expect(popover.style.top).toBe('0px');
+			expect(popover.style.left).toBe('50%');
+			// Y-as gebruikt geen translate; X-as wel. (jsdom normaliseert "0" naar "0px".)
+			expect(popover.style.transform).toMatch(/translate\(-50%,\s*0(px)?\)/);
+		});
+
+		it('expliciete edge attrs zonder centered worden ingeklemd', async () => {
+			const wrapper = await fixture(`
+				<div>
+					<button id="trigger-edge">Trigger</button>
+					<nldd-popover anchor="trigger-edge" accessible-label="Test" top="10px" right="20px"></nldd-popover>
+				</div>
+			`);
+			el = wrapper;
+			const popover = wrapper.querySelector('nldd-popover') as NLDDPopover;
+			asMd(popover);
+			await waitForUpdate(popover);
+
+			popover.show();
+			await waitForUpdate(popover);
+
+			expect(popover.style.top).toBe('10px');
+			expect(popover.style.right).toBe('20px');
+			// Geen transform — geen as werd gecenterd.
+			expect(popover.style.transform).toBe('');
+		});
+
+		it('sm-full-height attribuut wordt op de host gereflecteerd', async () => {
+			el = await fixture('<nldd-popover accessible-label="Test" sm-full-height></nldd-popover>');
+			await waitForUpdate(el);
+			expect(el.hasAttribute('sm-full-height')).toBe(true);
+		});
+
+		it('top/left/right/bottom defaulten naar undefined — geen lege reflectie', async () => {
+			el = await fixture('<nldd-popover accessible-label="Test"></nldd-popover>');
+			await waitForUpdate(el);
+			// Voorheen reflecteerde Lit een lege string als top="" enzovoort op
+			// elke popover. Met undefined-default mag het attribuut afwezig zijn.
+			expect(el.hasAttribute('top')).toBe(false);
+			expect(el.hasAttribute('left')).toBe(false);
+			expect(el.hasAttribute('right')).toBe(false);
+			expect(el.hasAttribute('bottom')).toBe(false);
+		});
+	});
 });

--- a/src/components/layout/popover/popover.ts
+++ b/src/components/layout/popover/popover.ts
@@ -423,7 +423,18 @@ export class NLDDPopover extends LitElement {
 	// — Event handlers ————————————————————————————————————————————————————————
 
 	private _handleViewportChange = (): void => {
-		if (this._isOpen) this.reposition();
+		// Track the breakpoint even while closed — otherwise the next show()
+		// would see a "crossing" (current vs stale `_wasOnSm`) that didn't
+		// actually happen during an open state, and the spurious
+		// `transition: none` would suppress the opening animation. When open,
+		// reposition() owns the update (it needs the pre-change value to
+		// compute crossedBreakpoint correctly), so we only sync here when
+		// the popover is closed.
+		if (this._isOpen) {
+			this.reposition();
+		} else {
+			this._wasOnSm = this._smQuery?.matches ?? false;
+		}
 	};
 
 	private _handleDocumentClick = (event: MouseEvent): void => {

--- a/src/components/layout/popover/popover.ts
+++ b/src/components/layout/popover/popover.ts
@@ -102,17 +102,21 @@ export class NLDDPopover extends LitElement {
 	@property({ type: String, reflect: true })
 	width: string | undefined;
 
+	// Default `undefined` (not '') so Lit doesn't reflect an empty value:
+	// `<nldd-popover>` would otherwise carry `top="" left="" right="" bottom=""`
+	// in the DOM, which is noisy and could trip `[top]` attribute selectors in
+	// consumer stylesheets. The hasOverride checks treat both as falsy.
 	@property({ type: String, reflect: true })
-	top = '';
+	top: string | undefined = undefined;
 
 	@property({ type: String, reflect: true })
-	left = '';
+	left: string | undefined = undefined;
 
 	@property({ type: String, reflect: true })
-	right = '';
+	right: string | undefined = undefined;
 
 	@property({ type: String, reflect: true })
-	bottom = '';
+	bottom: string | undefined = undefined;
 
 	@property({ type: Boolean, reflect: true })
 	centered = false;

--- a/src/components/layout/popover/popover.ts
+++ b/src/components/layout/popover/popover.ts
@@ -274,6 +274,18 @@ export class NLDDPopover extends LitElement {
 		else this.show();
 	}
 
+	/**
+	 * Restore the inline transition after a breakpoint-suppressed tick. Force
+	 * a layout flush first (`void offsetHeight`) so the just-applied position
+	 * styles commit before transitions resume — otherwise the cleared
+	 * `transition: ''` would re-enable animations on those exact properties
+	 * and you'd still see the slide we were trying to suppress.
+	 */
+	private _restoreTransition(): void {
+		void this.offsetHeight;
+		this.style.transition = '';
+	}
+
 	/** Herberekent positie t.o.v. anchor. Wordt automatisch aangeroepen bij openen. */
 	async reposition(): Promise<void> {
 		if (!this._isOpen) return;
@@ -284,6 +296,7 @@ export class NLDDPopover extends LitElement {
 		// and the sm `translateY(...)` bottom-sheet transform — producing
 		// a visible left/right slide on resize. We only suppress on the
 		// crossing tick; user-driven open/close on sm continues to animate.
+		// Each path below calls _restoreTransition() before returning.
 		const isSm = this._smQuery?.matches ?? false;
 		const crossedBreakpoint = isSm !== this._wasOnSm;
 		this._wasOnSm = isSm;
@@ -299,10 +312,7 @@ export class NLDDPopover extends LitElement {
 			this.style.removeProperty('bottom');
 			this.style.removeProperty('transform');
 			this.style.removeProperty('--_max-height');
-			if (crossedBreakpoint) {
-				void this.offsetHeight;
-				this.style.transition = '';
-			}
+			if (crossedBreakpoint) this._restoreTransition();
 			return;
 		}
 
@@ -334,10 +344,7 @@ export class NLDDPopover extends LitElement {
 			} else {
 				this.style.removeProperty('transform');
 			}
-			if (crossedBreakpoint) {
-				void this.offsetHeight;
-				this.style.transition = '';
-			}
+			if (crossedBreakpoint) this._restoreTransition();
 			return;
 		}
 
@@ -370,14 +377,7 @@ export class NLDDPopover extends LitElement {
 			top: `${y}px`,
 		});
 
-		// Mirror the cleanup the sm and override paths do — without this, a
-		// breakpoint-crossing tick that lands in the Floating UI path leaves
-		// `transition: none` stuck inline. Today md+ has no popover transitions
-		// so it's invisible; tomorrow it'd silently break any added animation.
-		if (crossedBreakpoint) {
-			void this.offsetHeight;
-			this.style.transition = '';
-		}
+		if (crossedBreakpoint) this._restoreTransition();
 	}
 
 	// — Anchor ————————————————————————————————————————————————————————————————

--- a/src/components/layout/popover/popover.ts
+++ b/src/components/layout/popover/popover.ts
@@ -369,6 +369,15 @@ export class NLDDPopover extends LitElement {
 			left: `${x}px`,
 			top: `${y}px`,
 		});
+
+		// Mirror the cleanup the sm and override paths do — without this, a
+		// breakpoint-crossing tick that lands in the Floating UI path leaves
+		// `transition: none` stuck inline. Today md+ has no popover transitions
+		// so it's invisible; tomorrow it'd silently break any added animation.
+		if (crossedBreakpoint) {
+			void this.offsetHeight;
+			this.style.transition = '';
+		}
 	}
 
 	// — Anchor ————————————————————————————————————————————————————————————————

--- a/src/components/layout/popover/popover.ts
+++ b/src/components/layout/popover/popover.ts
@@ -23,18 +23,21 @@
  * @attr {string}  anchor          - ID van het trigger-element voor positionering
  * @attr {string}  placement       - Floating UI placement (default: 'bottom-start')
  * @attr {string}  width           - Expliciete width (default: 320px via --components-popover-default-width)
- * @attr {string}  position-top    - Optionele expliciete top-positie als CSS-
- *                                    length (bv. '0', '24px', '10vh'). Wanneer
- *                                    gezet (samen met position-left of alleen)
+ * @attr {string}  top             - CSS top-positie. Wanneer gezet (alleen of
+ *                                    samen met andere edge-attrs of `centered`)
  *                                    wordt Floating UI's anchor-positionering
  *                                    overgeslagen — de popover staat dan vrij
  *                                    op het scherm. De `anchor` blijft wel
- *                                    nodig voor ARIA-koppeling
- *                                    (aria-expanded/aria-haspopup/aria-controls
- *                                    op de trigger). Geen effect op sm
- *                                    (bottom-sheet rule wint).
- * @attr {string}  position-left   - Optionele expliciete left-positie als CSS-
- *                                    length. Zie position-top voor semantiek.
+ *                                    nodig voor ARIA-koppeling op de trigger.
+ *                                    Geen effect op sm (bottom-sheet wint).
+ * @attr {string}  left            - CSS left-positie. Zie `top` voor semantiek.
+ * @attr {string}  right           - CSS right-positie. Zie `top` voor semantiek.
+ * @attr {string}  bottom          - CSS bottom-positie. Zie `top` voor semantiek.
+ * @attr {boolean} centered        - Centreert beide assen op de viewport. Per
+ *                                    as overrideable: `centered top="0"` =
+ *                                    horizontaal gecentreerd, top-aligned.
+ *                                    Mirrort CSS `place-items: center` met
+ *                                    `align-items`/`justify-items` overrides.
  * @attr {boolean} sm-full-height  - Op sm-viewport (waar de popover als
  *                                    bottom-sheet rendert) de volledige
  *                                    beschikbare hoogte vullen i.p.v. te
@@ -99,11 +102,20 @@ export class NLDDPopover extends LitElement {
 	@property({ type: String, reflect: true })
 	width: string | undefined;
 
-	@property({ type: String, reflect: true, attribute: 'position-top' })
-	positionTop = '';
+	@property({ type: String, reflect: true })
+	top = '';
 
-	@property({ type: String, reflect: true, attribute: 'position-left' })
-	positionLeft = '';
+	@property({ type: String, reflect: true })
+	left = '';
+
+	@property({ type: String, reflect: true })
+	right = '';
+
+	@property({ type: String, reflect: true })
+	bottom = '';
+
+	@property({ type: Boolean, reflect: true })
+	centered = false;
 
 	@property({ type: Boolean, reflect: true, attribute: 'sm-full-height' })
 	smFullHeight = false;
@@ -125,6 +137,7 @@ export class NLDDPopover extends LitElement {
 	/** Cleanup-functie van Floating UI's autoUpdate, alleen actief tijdens open. */
 	private _cleanupAutoUpdate: (() => void) | null = null;
 	private _smQuery: MediaQueryList | null = null;
+	private _wasOnSm = false;
 	private _previousAnchorEl: Element | null = null;
 
 	get open(): boolean {
@@ -142,6 +155,7 @@ export class NLDDPopover extends LitElement {
 		this.addEventListener('keydown', this._handleKeydown);
 		document.addEventListener('click', this._handleDocumentClick);
 		this._smQuery = window.matchMedia(`(max-width: ${breakpoints.smMax})`);
+		this._wasOnSm = this._smQuery.matches;
 		this._smQuery.addEventListener('change', this._handleViewportChange);
 		// Initialiseer aria-expanded/aria-haspopup op de anchor zodat SR de
 		// trigger-knop direct als toggle-control aankondigt — niet pas na de
@@ -201,11 +215,17 @@ export class NLDDPopover extends LitElement {
 		if (changed.has('anchor') || changed.has('anchorElement')) {
 			this._updateAnchorAria(this._isOpen);
 		}
-		// Position-override changes at runtime: re-apply (or clear) inline
-		// top/left zodat de popover meebewegt met dynamische waardes.
-		if (changed.has('positionTop') || changed.has('positionLeft')) {
-			if (!this.positionTop) this.style.removeProperty('top');
-			if (!this.positionLeft) this.style.removeProperty('left');
+		// Position-override changes at runtime: re-apply or clear inline edges
+		// + transform zodat de popover meebewegt met dynamische waardes.
+		if (
+			changed.has('top') || changed.has('left')
+			|| changed.has('right') || changed.has('bottom')
+			|| changed.has('centered')
+		) {
+			if (!this.top && !this.centered) this.style.removeProperty('top');
+			if (!this.left && !this.centered) this.style.removeProperty('left');
+			if (!this.right) this.style.removeProperty('right');
+			if (!this.bottom) this.style.removeProperty('bottom');
 			if (this._isOpen) this.reposition();
 		}
 	}
@@ -254,13 +274,31 @@ export class NLDDPopover extends LitElement {
 	async reposition(): Promise<void> {
 		if (!this._isOpen) return;
 
+		// Suppress transitions when crossing the sm/md breakpoint. Without
+		// this, the bottom-sheet's `transition: transform ...` rule animates
+		// the swap between the centered-md `translate(-50%, 0)` transform
+		// and the sm `translateY(...)` bottom-sheet transform — producing
+		// a visible left/right slide on resize. We only suppress on the
+		// crossing tick; user-driven open/close on sm continues to animate.
+		const isSm = this._smQuery?.matches ?? false;
+		const crossedBreakpoint = isSm !== this._wasOnSm;
+		this._wasOnSm = isSm;
+		if (crossedBreakpoint) this.style.transition = 'none';
+
 		// On sm viewport the popover renders as a bottom sheet via CSS; clear
 		// any inline positioning Floating UI may have set previously so the
 		// CSS rules take effect.
-		if (this._smQuery?.matches) {
-			this.style.removeProperty('left');
+		if (isSm) {
 			this.style.removeProperty('top');
+			this.style.removeProperty('left');
+			this.style.removeProperty('right');
+			this.style.removeProperty('bottom');
+			this.style.removeProperty('transform');
 			this.style.removeProperty('--_max-height');
+			if (crossedBreakpoint) {
+				void this.offsetHeight;
+				this.style.transition = '';
+			}
 			return;
 		}
 
@@ -268,9 +306,34 @@ export class NLDDPopover extends LitElement {
 		// consumer-specified coordinates. Anchor blijft nodig voor ARIA maar
 		// niet voor positionering — denk aan een vrij geplaatste search-popover
 		// die bovenaan-gecentreerd hoort, niet onder z'n trigger.
-		if (this.positionTop || this.positionLeft) {
-			if (this.positionTop) this.style.setProperty('top', this.positionTop);
-			if (this.positionLeft) this.style.setProperty('left', this.positionLeft);
+		//
+		// `centered` centreert beide assen (left/top: 50%; transform: translate
+		// -50% per as). Een expliciete edge-attr (top/left/right/bottom)
+		// overschrijft die as, dus `centered top="0"` = horizontaal gecentreerd
+		// + top-aligned. Mirrort CSS `place-items: center` met overrides.
+		const hasOverride = this.top || this.left || this.right || this.bottom || this.centered;
+		if (hasOverride) {
+			const yCenter = this.centered && !this.top && !this.bottom;
+			const xCenter = this.centered && !this.left && !this.right;
+
+			if (this.top) this.style.setProperty('top', this.top);
+			else if (yCenter) this.style.setProperty('top', '50%');
+			if (this.bottom) this.style.setProperty('bottom', this.bottom);
+
+			if (this.left) this.style.setProperty('left', this.left);
+			else if (xCenter) this.style.setProperty('left', '50%');
+			if (this.right) this.style.setProperty('right', this.right);
+
+			if (xCenter || yCenter) {
+				this.style.setProperty('transform',
+					`translate(${xCenter ? '-50%' : '0'}, ${yCenter ? '-50%' : '0'})`);
+			} else {
+				this.style.removeProperty('transform');
+			}
+			if (crossedBreakpoint) {
+				void this.offsetHeight;
+				this.style.transition = '';
+			}
 			return;
 		}
 

--- a/src/components/layout/popover/popover.ts
+++ b/src/components/layout/popover/popover.ts
@@ -103,6 +103,8 @@ export class NLDDPopover extends LitElement {
 
 	override connectedCallback(): void {
 		super.connectedCallback();
+		this.style.containerType = 'inline-size';
+		this.style.containerName = 'layout-area';
 		if (!this.hasAttribute('popover')) this.setAttribute('popover', '');
 		if (!this.hasAttribute('tabindex')) this.setAttribute('tabindex', '-1');
 		if (!this.hasAttribute('role')) this.setAttribute('role', 'dialog');

--- a/src/components/layout/popover/popover.ts
+++ b/src/components/layout/popover/popover.ts
@@ -20,9 +20,30 @@
  *
  * @element nldd-popover
  *
- * @attr {string} anchor           - ID van het trigger-element voor positionering
- * @attr {string} placement        - Floating UI placement (default: 'bottom-start')
- * @attr {string} width            - Expliciete width (default: 320px via --components-popover-default-width)
+ * @attr {string}  anchor          - ID van het trigger-element voor positionering
+ * @attr {string}  placement       - Floating UI placement (default: 'bottom-start')
+ * @attr {string}  width           - Expliciete width (default: 320px via --components-popover-default-width)
+ * @attr {string}  position-top    - Optionele expliciete top-positie als CSS-
+ *                                    length (bv. '0', '24px', '10vh'). Wanneer
+ *                                    gezet (samen met position-left of alleen)
+ *                                    wordt Floating UI's anchor-positionering
+ *                                    overgeslagen — de popover staat dan vrij
+ *                                    op het scherm. De `anchor` blijft wel
+ *                                    nodig voor ARIA-koppeling
+ *                                    (aria-expanded/aria-haspopup/aria-controls
+ *                                    op de trigger). Geen effect op sm
+ *                                    (bottom-sheet rule wint).
+ * @attr {string}  position-left   - Optionele expliciete left-positie als CSS-
+ *                                    length. Zie position-top voor semantiek.
+ * @attr {boolean} sm-full-height  - Op sm-viewport (waar de popover als
+ *                                    bottom-sheet rendert) de volledige
+ *                                    beschikbare hoogte vullen i.p.v. te
+ *                                    krimpen naar content. Geen effect op
+ *                                    md+ (anchored modus). Opt-in voor
+ *                                    content-heavy use cases zoals zoek-
+ *                                    resultaten of lange detail-views; volgt
+ *                                    Apple/Material conventie van content-
+ *                                    sized als default.
  * @attr {string} accessible-label - (verplicht) Toegankelijke naam (aria-label).
  *                                    Valt terug op de i18n default ('Popover')
  *                                    als niet gezet — geef altijd een unieke,
@@ -77,6 +98,15 @@ export class NLDDPopover extends LitElement {
 
 	@property({ type: String, reflect: true })
 	width: string | undefined;
+
+	@property({ type: String, reflect: true, attribute: 'position-top' })
+	positionTop = '';
+
+	@property({ type: String, reflect: true, attribute: 'position-left' })
+	positionLeft = '';
+
+	@property({ type: Boolean, reflect: true, attribute: 'sm-full-height' })
+	smFullHeight = false;
 
 	@property({ type: String, attribute: 'accessible-label' })
 	accessibleLabel = '';
@@ -171,6 +201,13 @@ export class NLDDPopover extends LitElement {
 		if (changed.has('anchor') || changed.has('anchorElement')) {
 			this._updateAnchorAria(this._isOpen);
 		}
+		// Position-override changes at runtime: re-apply (or clear) inline
+		// top/left zodat de popover meebewegt met dynamische waardes.
+		if (changed.has('positionTop') || changed.has('positionLeft')) {
+			if (!this.positionTop) this.style.removeProperty('top');
+			if (!this.positionLeft) this.style.removeProperty('left');
+			if (this._isOpen) this.reposition();
+		}
 	}
 
 	// — i18n ——————————————————————————————————————————————————————————————————
@@ -224,6 +261,16 @@ export class NLDDPopover extends LitElement {
 			this.style.removeProperty('left');
 			this.style.removeProperty('top');
 			this.style.removeProperty('--_max-height');
+			return;
+		}
+
+		// Position-override: skip Floating UI and place the popover at the
+		// consumer-specified coordinates. Anchor blijft nodig voor ARIA maar
+		// niet voor positionering — denk aan een vrij geplaatste search-popover
+		// die bovenaan-gecentreerd hoort, niet onder z'n trigger.
+		if (this.positionTop || this.positionLeft) {
+			if (this.positionTop) this.style.setProperty('top', this.positionTop);
+			if (this.positionLeft) this.style.setProperty('left', this.positionLeft);
 			return;
 		}
 

--- a/src/components/layout/sheet/sheet.ts
+++ b/src/components/layout/sheet/sheet.ts
@@ -77,6 +77,8 @@ export class NLDDSheet extends LitElement {
 
 	override connectedCallback(): void {
 		super.connectedCallback();
+		this.style.containerType = 'inline-size';
+		this.style.containerName = 'layout-area';
 		// Listen for dismiss events bubbling up from nldd-top-title-bar
 		this.addEventListener('dismiss', this._handleDismiss);
 	}

--- a/src/components/layout/split-views/bar-split-view/bar-split-view.styles.ts
+++ b/src/components/layout/split-views/bar-split-view/bar-split-view.styles.ts
@@ -1,7 +1,4 @@
-import { css, unsafeCSS } from 'lit';
-import { breakpoints } from '../../../../assets/styles/breakpoints.js';
-
-const smMax = unsafeCSS(breakpoints.smMax);
+import { css } from 'lit';
 
 export const barSplitViewStyles = css`
 
@@ -10,8 +7,6 @@ export const barSplitViewStyles = css`
 
 	:host {
 		--_background-color: var(--context-parent-background-color, var(--semantics-surfaces-background-color));
-		--context-bar-split-view-top-bars-height: 0px;
-		--context-bar-split-view-bottom-bars-height: 0px;
 
 		display: flex;
 		flex-direction: column;
@@ -43,7 +38,6 @@ export const barSplitViewStyles = css`
 		flex: 1;
 		min-height: 0;
 		min-width: 0;
-		position: relative;
 	}
 
 
@@ -55,13 +49,6 @@ export const barSplitViewStyles = css`
 		flex-shrink: 0;
 		min-width: 0;
 		overflow: hidden;
-
-		@media (max-width: ${smMax}) {
-			position: absolute;
-			left: 0;
-			right: 0;
-			z-index: 2;
-	}
 	}
 
 
@@ -81,38 +68,6 @@ export const barSplitViewStyles = css`
 		min-height: 0;
 		min-width: 0;
 		overflow: hidden;
-
-		@media (max-width: ${smMax}) {
-			&::before {
-				content: '';
-				position: absolute;
-				top: 0;
-				left: 0;
-				right: 0;
-				z-index: 1;
-				height: calc(var(--context-bar-split-view-top-bars-height) + var(--primitives-space-32));
-				background: linear-gradient(
-					to bottom,
-					color-mix(in srgb, var(--_background-color) 95%, transparent) var(--context-bar-split-view-top-bars-height),
-					transparent);
-				pointer-events: none;
-			}
-
-			&::after {
-				content: '';
-				position: absolute;
-				bottom: 0;
-				left: 0;
-				right: 0;
-				z-index: 1;
-				height: calc(var(--context-bar-split-view-bottom-bars-height) + var(--primitives-space-32));
-				background: linear-gradient(
-					to top,
-					color-mix(in srgb, var(--_background-color) 95%, transparent) var(--context-bar-split-view-bottom-bars-height),
-					transparent);
-				pointer-events: none;
-			}
-	}
 	}
 
 

--- a/src/components/layout/split-views/bar-split-view/bar-split-view.styles.ts
+++ b/src/components/layout/split-views/bar-split-view/bar-split-view.styles.ts
@@ -9,15 +9,15 @@ export const barSplitViewStyles = css`
 	/* # Host */
 
 	:host {
+		--_background-color: var(--context-parent-background-color, var(--semantics-surfaces-background-color));
+		--context-bar-split-view-top-bars-height: 0px;
+		--context-bar-split-view-bottom-bars-height: 0px;
+
 		display: flex;
 		flex-direction: column;
 		width: 100%;
 		height: 100%;
 		background-color: var(--_background-color);
-
-		--_background-color: var(--context-parent-background-color, var(--semantics-surfaces-background-color));
-		--context-bar-split-view-top-bars-height: 0px;
-		--context-bar-split-view-bottom-bars-height: 0px;
 	}
 
 	:host([background="default"]) {

--- a/src/components/layout/split-views/bar-split-view/bar-split-view.styles.ts
+++ b/src/components/layout/split-views/bar-split-view/bar-split-view.styles.ts
@@ -55,15 +55,13 @@ export const barSplitViewStyles = css`
 		flex-shrink: 0;
 		min-width: 0;
 		overflow: hidden;
-		container-type: inline-size;
-		container-name: layout-area;
 
 		@media (max-width: ${smMax}) {
 			position: absolute;
 			left: 0;
 			right: 0;
 			z-index: 2;
-		}
+	}
 	}
 
 
@@ -83,8 +81,6 @@ export const barSplitViewStyles = css`
 		min-height: 0;
 		min-width: 0;
 		overflow: hidden;
-		container-type: inline-size;
-		container-name: layout-area;
 
 		@media (max-width: ${smMax}) {
 			&::before {
@@ -116,7 +112,7 @@ export const barSplitViewStyles = css`
 					transparent);
 				pointer-events: none;
 			}
-		}
+	}
 	}
 
 

--- a/src/components/layout/split-views/bar-split-view/bar-split-view.template.ts
+++ b/src/components/layout/split-views/bar-split-view/bar-split-view.template.ts
@@ -1,6 +1,5 @@
 import { html, TemplateResult, nothing } from 'lit';
 import { classMap } from 'lit/directives/class-map.js';
-import { styleMap } from 'lit/directives/style-map.js';
 import type { NLDDBarSplitView } from './bar-split-view.js';
 import '../split-view-divider/split-view-divider.js';
 
@@ -13,20 +12,17 @@ export function barSplitViewTemplate(component: NLDDBarSplitView): TemplateResul
 			${sorted.map((el, index) => {
 				const isMain = el.slot === 'main';
 				const isLast = index === sorted.length - 1;
-
-				// Inline position is only applied to bars on sm viewports
-				const barStyles = !isMain && isSm
-					? component._smTopBars.has(el)
-						? { top: `${component._smOffsets.get(el) ?? 0}px` }
-						: { bottom: `${component._smOffsets.get(el) ?? 0}px` }
-					: {};
+				const next = sorted[index + 1];
+				const showDivider = !isSm
+					&& !isLast
+					&& !el.hasAttribute('no-divider')
+					&& !next?.hasAttribute('no-divider');
 
 				return html`
-					<div class=${classMap({ 'bar-split-view__main': isMain, 'bar-split-view__bar': !isMain })}
-						style=${styleMap(barStyles)}>
+					<div class=${classMap({ 'bar-split-view__main': isMain, 'bar-split-view__bar': !isMain })}>
 						<slot name=${el.slot}></slot>
 					</div>
-					${!isSm && !isLast ? html`
+					${showDivider ? html`
 						<div class="bar-split-view__divider">
 							<nldd-split-view-divider orientation="horizontal"></nldd-split-view-divider>
 						</div>

--- a/src/components/layout/split-views/bar-split-view/bar-split-view.test.ts
+++ b/src/components/layout/split-views/bar-split-view/bar-split-view.test.ts
@@ -206,4 +206,61 @@ describe('nldd-bar-split-view', () => {
 		const slotNames = slots.map(s => s.getAttribute('name'));
 		expect(slotNames).toContain('mobile-bar');
 	});
+
+	describe('no-divider attribute', () => {
+		it('suppresses the divider after a bar marked no-divider', async () => {
+			el = await fixture(`
+				<nldd-bar-split-view>
+					<div slot="toolbar" no-divider>Toolbar</div>
+					<div slot="document-tabs">Tabs</div>
+					<div slot="main">Main</div>
+				</nldd-bar-split-view>
+			`);
+			await setBreakpoint(el, 'md');
+			// Without no-divider we'd get 2 dividers (toolbar↓tabs, tabs↓main).
+			// no-divider on toolbar removes the toolbar↓tabs seam, leaving 1.
+			expect(el.shadowRoot!.querySelectorAll('.bar-split-view__divider').length).toBe(1);
+		});
+
+		it('suppresses both adjacent seams when a middle bar is marked', async () => {
+			el = await fixture(`
+				<nldd-bar-split-view>
+					<div slot="toolbar">Toolbar</div>
+					<div slot="document-tabs" no-divider>Tabs</div>
+					<div slot="main">Main</div>
+				</nldd-bar-split-view>
+			`);
+			await setBreakpoint(el, 'md');
+			// "No divider next to this bar" — both toolbar↓tabs and tabs↓main
+			// are suppressed because tabs has no-divider.
+			expect(el.shadowRoot!.querySelectorAll('.bar-split-view__divider').length).toBe(0);
+		});
+
+		it('marking either side of a single seam suffices to remove it', async () => {
+			el = await fixture(`
+				<nldd-bar-split-view>
+					<div slot="main">Main</div>
+					<div slot="status" no-divider>Status</div>
+				</nldd-bar-split-view>
+			`);
+			await setBreakpoint(el, 'md');
+			// Single seam main↓status removed because status has no-divider.
+			expect(el.shadowRoot!.querySelectorAll('.bar-split-view__divider').length).toBe(0);
+		});
+
+		it('keeps unaffected dividers when only one seam is suppressed', async () => {
+			el = await fixture(`
+				<nldd-bar-split-view>
+					<div slot="toolbar" no-divider>Toolbar</div>
+					<div slot="document-tabs">Tabs</div>
+					<div slot="main">Main</div>
+					<div slot="status">Status</div>
+				</nldd-bar-split-view>
+			`);
+			await setBreakpoint(el, 'md');
+			// 4 panes → 3 seams. no-divider on toolbar removes the toolbar↓tabs
+			// seam; the tabs↓main and main↓status seams remain.
+			expect(el.shadowRoot!.querySelectorAll('.bar-split-view__divider').length).toBe(2);
+		});
+	});
 });

--- a/src/components/layout/split-views/bar-split-view/bar-split-view.ts
+++ b/src/components/layout/split-views/bar-split-view/bar-split-view.ts
@@ -5,14 +5,8 @@
  * Each child determines its order per breakpoint via sm-order, md-order, and lg-order.
  * Children without order attributes are sorted by DOM order.
  *
- * On sm viewports, bars are absolutely positioned over the main area:
- * bars before main (based on order) stack from top to bottom,
- * bars after main stack from bottom to top. On md and lg, all panels
- * are in normal flow with a divider between each adjacent pair.
- *
- * CSS custom properties on the host for consumers like nldd-page:
- *   --context-bar-split-view-top-bars-height
- *   --context-bar-split-view-bottom-bars-height
+ * All bars are in normal flow at every breakpoint and stack vertically with
+ * dividers between them on md and lg. Dividers are suppressed on sm.
  *
  * ## Slot names
  * Give each bar a unique slot name (e.g. slot="toolbar", slot="status-bar").
@@ -20,8 +14,7 @@
  * The main panel always uses slot="main".
  *
  * ## Background color
- * Sets --context-parent-background-color, which cascades to all descendants
- * including nldd-page and the fade overlays.
+ * Sets --context-parent-background-color, which cascades to all descendants.
  *
  * @element nldd-bar-split-view
  *
@@ -31,6 +24,11 @@
  * @attr {'sm'|'md'|'lg'} above - Show this panel from this breakpoint and larger
  * @attr {'sm'|'md'|'lg'} below - Show this panel up to and including this breakpoint
  * @attr {'sm'|'md'|'lg'} only  - Show this panel only at this breakpoint
+ *
+ * Divider control per child:
+ * @attr no-divider - Suppress dividers adjacent to this bar. Setting it on
+ *                    either side of a seam removes that divider — handy for
+ *                    grouping a toolbar and tab-bar into one visual unit.
  *
  * @slot main  - Central panel for primary content
  * @slot *     - Any other unique slot name creates a bar panel
@@ -56,36 +54,20 @@ export class NLDDBarSplitView extends LitElement {
 
 	// null until connectedCallback measures the viewport. Before measurement the
 	// template falls back to DOM order with dividers — no breakpoint-specific
-	// sorting or mobile overlay behaviour is applied.
+	// sorting is applied.
 	@state()
 	_currentBreakpoint: BreakpointOrUnmeasured = null;
 
-	// Bars that sit above main in the sm sort order. Used as a membership test in
-	// the template: bars not in this Set are implicitly bottom bars. Only populated
-	// on sm viewports — on md/lg bars are in normal flow and need no offset.
-	_smTopBars = new Set<Element>();
-
-	// Computed top or bottom pixel offset for every bar on sm viewports. Holds both
-	// top-bar and bottom-bar values in the same Map — the template uses _smTopBars
-	// to know which CSS property (top vs bottom) to apply the value to. Cleared on
-	// md/lg where absolute positioning is not used.
-	_smOffsets = new Map<Element, number>();
-
 	private _observer: MutationObserver | null = null;
 	private _resizeObserver: ResizeObserver | null = null;
-	private _childResizeObserver: ResizeObserver | null = null;
 
 	override connectedCallback() {
 		super.connectedCallback();
 
 		this._currentBreakpoint = this._getBreakpoint(this.getBoundingClientRect().width);
 
-		this._observer = new MutationObserver(() => {
-			this._observeChildren();
-			this._updateLayout();
-			this.requestUpdate();
-		});
-		this._observer.observe(this, { childList: true, attributes: true, attributeFilter: ['above', 'below', 'only', 'sm-order', 'md-order', 'lg-order'], subtree: false });
+		this._observer = new MutationObserver(() => this.requestUpdate());
+		this._observer.observe(this, { childList: true, attributes: true, attributeFilter: ['above', 'below', 'only', 'sm-order', 'md-order', 'lg-order', 'no-divider'], subtree: false });
 
 		this._resizeObserver = new ResizeObserver(() => {
 			const bp = this._getBreakpoint(this.getBoundingClientRect().width);
@@ -93,12 +75,8 @@ export class NLDDBarSplitView extends LitElement {
 				this._currentBreakpoint = bp;
 				this.requestUpdate();
 			}
-			this._updateLayout();
 		});
 		this._resizeObserver.observe(this);
-
-		this._childResizeObserver = new ResizeObserver(() => this._updateLayout());
-		this._observeChildren();
 	}
 
 	override disconnectedCallback() {
@@ -107,8 +85,6 @@ export class NLDDBarSplitView extends LitElement {
 		this._observer = null;
 		this._resizeObserver?.disconnect();
 		this._resizeObserver = null;
-		this._childResizeObserver?.disconnect();
-		this._childResizeObserver = null;
 	}
 
 	private _getBreakpoint(width: number): Breakpoint {
@@ -152,61 +128,6 @@ export class NLDDBarSplitView extends LitElement {
 			const bVal = b.hasAttribute(attr) ? parseInt(b.getAttribute(attr)!) : all.indexOf(b);
 			return aVal - bVal;
 		});
-	}
-
-	private _observeChildren() {
-		this._childResizeObserver?.disconnect();
-		for (const child of Array.from(this.children)) {
-			this._childResizeObserver?.observe(child);
-		}
-	}
-
-	private _updateLayout() {
-		const width = this.getBoundingClientRect().width;
-
-		if (width > smMaxPx) {
-			this.style.removeProperty('--context-bar-split-view-top-bars-height');
-			this.style.removeProperty('--context-bar-split-view-bottom-bars-height');
-			this._smTopBars = new Set();
-			this._smOffsets = new Map();
-			return;
-		}
-
-		const sorted = this._getSortedChildren();
-		const mainIndex = sorted.findIndex(el => el.slot === 'main');
-
-		// Bars before main stack downward from the top; bars after main stack upward from the bottom
-		const topBars = mainIndex > 0 ? sorted.slice(0, mainIndex) : [];
-		const bottomBars = mainIndex >= 0 ? sorted.slice(mainIndex + 1) : sorted;
-
-		this._smTopBars = new Set(topBars);
-
-		const newOffsets = new Map<Element, number>();
-
-		let topOffset = 0;
-		for (const el of topBars) {
-			newOffsets.set(el, topOffset);
-			topOffset += el.getBoundingClientRect().height;
-		}
-
-		let bottomOffset = 0;
-		for (const el of [...bottomBars].reverse()) {
-			newOffsets.set(el, bottomOffset);
-			bottomOffset += el.getBoundingClientRect().height;
-		}
-
-		this._smOffsets = newOffsets;
-
-		const prevTop = this.style.getPropertyValue('--context-bar-split-view-top-bars-height');
-		const prevBottom = this.style.getPropertyValue('--context-bar-split-view-bottom-bars-height');
-		const nextTop = `${topOffset}px`;
-		const nextBottom = `${bottomOffset}px`;
-
-		if (prevTop !== nextTop || prevBottom !== nextBottom) {
-			this.style.setProperty('--context-bar-split-view-top-bars-height', nextTop);
-			this.style.setProperty('--context-bar-split-view-bottom-bars-height', nextBottom);
-			this.requestUpdate();
-		}
 	}
 
 	override render() {

--- a/src/components/layout/split-views/navigation-split-view/navigation-split-view.styles.ts
+++ b/src/components/layout/split-views/navigation-split-view/navigation-split-view.styles.ts
@@ -54,8 +54,7 @@ export const navigationSplitViewStyles = css`
 		min-height: 0;
 		min-width: var(--_sidebar-min-width);
 		overflow: hidden;
-		container-type: inline-size;
-		container-name: layout-area;
+
 	}
 
 
@@ -68,8 +67,7 @@ export const navigationSplitViewStyles = css`
 		min-height: 0;
 		min-width: var(--_secondary-sidebar-min-width);
 		overflow: hidden;
-		container-type: inline-size;
-		container-name: layout-area;
+
 	}
 
 
@@ -82,8 +80,7 @@ export const navigationSplitViewStyles = css`
 		min-height: 0;
 		min-width: var(--_main-min-width);
 		overflow: hidden;
-		container-type: inline-size;
-		container-name: layout-area;
+
 	}
 
 
@@ -110,8 +107,6 @@ export const navigationSplitViewStyles = css`
 		min-height: 0;
 		min-width: var(--_inspector-min-width);
 		overflow: hidden;
-		container-type: inline-size;
-		container-name: layout-area;
 
 		/* Suppress dismiss button — inspector is always dismissable as a sheet, not inline */
 		--context-dismiss-button-display: none;
@@ -148,29 +143,29 @@ export const navigationSplitViewStyles = css`
 
 		@media (min-width: ${lgMin}) {
 			width: var(--semantics-sheets-side-lg-width);
-		}
+	}
 
 		&:focus-visible:not(.is-pointer-focus) {
 			box-shadow: var(--semantics-focus-ring-box-shadow), var(--semantics-overlays-box-shadow);
 			outline: var(--semantics-focus-ring-outline);
 			outline-offset: var(--semantics-focus-ring-outline-offset);
-		}
+	}
 
 		&:not([open]) {
 			display: none;
-		}
+	}
 
 		&::backdrop {
 			background: var(--semantics-overlays-backdrop-color);
-		}
+	}
 
 		&[open] {
 			animation: navigation-split-view-inspector-slide-in var(--semantics-sheets-side-animation-duration) var(--primitives-transition-easing-default) both;
-		}
+	}
 
 		&.is-closing {
 			animation: navigation-split-view-inspector-slide-out var(--semantics-sheets-side-animation-duration) var(--primitives-transition-easing-default) both;
-		}
+	}
 	}
 
 	.navigation-split-view__inspector-sheet-body {
@@ -212,29 +207,29 @@ export const navigationSplitViewStyles = css`
 
 		@media (min-width: ${lgMin}) {
 			width: var(--semantics-sheets-side-lg-width);
-		}
+	}
 
 		&:focus-visible:not(.is-pointer-focus) {
 			box-shadow: var(--semantics-focus-ring-box-shadow), var(--semantics-overlays-box-shadow);
 			outline: var(--semantics-focus-ring-outline);
 			outline-offset: var(--semantics-focus-ring-outline-offset);
-		}
+	}
 
 		&:not([open]) {
 			display: none;
-		}
+	}
 
 		&::backdrop {
 			background: var(--semantics-overlays-backdrop-color);
-		}
+	}
 
 		&[open] {
 			animation: navigation-split-view-sidebar-slide-in var(--semantics-sheets-side-animation-duration) var(--primitives-transition-easing-default) both;
-		}
+	}
 
 		&.is-closing {
 			animation: navigation-split-view-sidebar-slide-out var(--semantics-sheets-side-animation-duration) var(--primitives-transition-easing-default) both;
-		}
+	}
 	}
 
 	.navigation-split-view__sidebar-sheet-body {
@@ -277,7 +272,7 @@ export const navigationSplitViewStyles = css`
 			&.is-closing {
 				animation: navigation-split-view-slide-out-bottom var(--semantics-sheets-bottom-animation-duration) var(--primitives-transition-easing-default) both;
 			}
-		}
+	}
 
 		.navigation-split-view__sidebar-sheet {
 			inset: auto 0 0 0;
@@ -294,7 +289,7 @@ export const navigationSplitViewStyles = css`
 			&.is-closing {
 				animation: navigation-split-view-slide-out-bottom var(--semantics-sheets-bottom-animation-duration) var(--primitives-transition-easing-default) both;
 			}
-		}
+	}
 	}
 
 
@@ -306,7 +301,7 @@ export const navigationSplitViewStyles = css`
 		.navigation-split-view__sidebar-sheet[open],
 		.navigation-split-view__sidebar-sheet.is-closing {
 			animation: none;
-		}
+	}
 	}
 
 

--- a/src/components/layout/split-views/navigation-split-view/navigation-split-view.styles.ts
+++ b/src/components/layout/split-views/navigation-split-view/navigation-split-view.styles.ts
@@ -89,6 +89,7 @@ export const navigationSplitViewStyles = css`
 	:host(.full-stack) .navigation-split-view__secondary-sidebar-pane,
 	:host(.full-stack) .navigation-split-view__main-pane {
 		min-width: 0;
+		flex: 1;
 	}
 
 

--- a/src/components/layout/split-views/navigation-split-view/navigation-split-view.styles.ts
+++ b/src/components/layout/split-views/navigation-split-view/navigation-split-view.styles.ts
@@ -2,6 +2,8 @@ import { css, unsafeCSS } from 'lit';
 import { breakpoints } from '../../../../assets/styles/breakpoints.js';
 
 const smMax = unsafeCSS(breakpoints.smMax);
+const mdMin = unsafeCSS(breakpoints.mdMin);
+const mdMax = unsafeCSS(breakpoints.mdMax);
 const lgMin = unsafeCSS(breakpoints.lgMin);
 
 export const navigationSplitViewStyles = css`
@@ -10,16 +12,16 @@ export const navigationSplitViewStyles = css`
 	/* # Host */
 
 	:host {
-		display: flex;
-		width: 100%;
-		height: 100%;
-		background-color: var(--_background-color);
-
 		--_sidebar-min-width: var(--primitives-area-320); /* Pane min-width — read by JS via getComputedStyle in firstUpdated */
 		--_secondary-sidebar-min-width: var(--primitives-area-320); /* Pane min-width — read by JS via getComputedStyle in firstUpdated */
 		--_main-min-width: var(--primitives-area-480); /* Pane min-width — read by JS via getComputedStyle in firstUpdated */
 		--_inspector-min-width: var(--primitives-area-320); /* Pane min-width — read by JS via getComputedStyle in firstUpdated */
 		--_background-color: var(--context-parent-background-color, var(--semantics-surfaces-background-color));
+
+		display: flex;
+		width: 100%;
+		height: 100%;
+		background-color: var(--_background-color);
 	}
 
 	:host([background="default"]) {
@@ -54,7 +56,6 @@ export const navigationSplitViewStyles = css`
 		min-height: 0;
 		min-width: var(--_sidebar-min-width);
 		overflow: hidden;
-
 	}
 
 
@@ -67,7 +68,6 @@ export const navigationSplitViewStyles = css`
 		min-height: 0;
 		min-width: var(--_secondary-sidebar-min-width);
 		overflow: hidden;
-
 	}
 
 
@@ -80,7 +80,6 @@ export const navigationSplitViewStyles = css`
 		min-height: 0;
 		min-width: var(--_main-min-width);
 		overflow: hidden;
-
 	}
 
 
@@ -101,15 +100,15 @@ export const navigationSplitViewStyles = css`
 	}
 
 	.navigation-split-view__inspector-pane {
+		/* Suppress dismiss button — inspector is always dismissable as a sheet, not inline */
+		--context-dismiss-button-display: none;
+
 		display: flex;
 		flex-direction: column;
 		flex-shrink: 0;
 		min-height: 0;
 		min-width: var(--_inspector-min-width);
 		overflow: hidden;
-
-		/* Suppress dismiss button — inspector is always dismissable as a sheet, not inline */
-		--context-dismiss-button-display: none;
 	}
 
 
@@ -136,36 +135,63 @@ export const navigationSplitViewStyles = css`
 		overflow: hidden;
 		position: fixed;
 		outline: none;
-		inset: var(--semantics-overlays-inset) var(--semantics-overlays-inset) var(--semantics-overlays-inset) auto;
-		width: var(--semantics-sheets-side-md-width);
-		height: calc(100dvh - var(--semantics-overlays-inset) * 2);
-		border-radius: var(--semantics-overlays-corner-radius);
+
+		@media (max-width: ${smMax}) {
+			inset: auto 0 0 0;
+			width: 100%;
+			max-width: 100%;
+			height: auto;
+			max-height: calc(100dvh - var(--semantics-sheets-bottom-top-inset));
+			border-radius: var(--semantics-overlays-corner-radius) var(--semantics-overlays-corner-radius) 0 0;
+		}
+
+		@media (min-width: ${mdMin}) and (max-width: ${mdMax}) {
+			inset: var(--semantics-overlays-inset) var(--semantics-overlays-inset) var(--semantics-overlays-inset) auto;
+			width: var(--semantics-sheets-side-md-width);
+			height: calc(100dvh - var(--semantics-overlays-inset) * 2);
+			border-radius: var(--semantics-overlays-corner-radius);
+		}
 
 		@media (min-width: ${lgMin}) {
+			inset: var(--semantics-overlays-inset) var(--semantics-overlays-inset) var(--semantics-overlays-inset) auto;
 			width: var(--semantics-sheets-side-lg-width);
-	}
+			height: calc(100dvh - var(--semantics-overlays-inset) * 2);
+			border-radius: var(--semantics-overlays-corner-radius);
+		}
 
 		&:focus-visible:not(.is-pointer-focus) {
 			box-shadow: var(--semantics-focus-ring-box-shadow), var(--semantics-overlays-box-shadow);
 			outline: var(--semantics-focus-ring-outline);
 			outline-offset: var(--semantics-focus-ring-outline-offset);
-	}
+		}
 
 		&:not([open]) {
 			display: none;
-	}
+		}
 
 		&::backdrop {
 			background: var(--semantics-overlays-backdrop-color);
-	}
+		}
 
 		&[open] {
-			animation: navigation-split-view-inspector-slide-in var(--semantics-sheets-side-animation-duration) var(--primitives-transition-easing-default) both;
-	}
+			@media (max-width: ${smMax}) {
+				animation: navigation-split-view-slide-in-bottom var(--semantics-sheets-bottom-animation-duration) var(--primitives-transition-easing-default) both;
+			}
+
+			@media (min-width: ${mdMin}) {
+				animation: navigation-split-view-inspector-slide-in var(--semantics-sheets-side-animation-duration) var(--primitives-transition-easing-default) both;
+			}
+		}
 
 		&.is-closing {
-			animation: navigation-split-view-inspector-slide-out var(--semantics-sheets-side-animation-duration) var(--primitives-transition-easing-default) both;
-	}
+			@media (max-width: ${smMax}) {
+				animation: navigation-split-view-slide-out-bottom var(--semantics-sheets-bottom-animation-duration) var(--primitives-transition-easing-default) both;
+			}
+
+			@media (min-width: ${mdMin}) {
+				animation: navigation-split-view-inspector-slide-out var(--semantics-sheets-side-animation-duration) var(--primitives-transition-easing-default) both;
+			}
+		}
 	}
 
 	.navigation-split-view__inspector-sheet-body {
@@ -200,47 +226,74 @@ export const navigationSplitViewStyles = css`
 		overflow: hidden;
 		position: fixed;
 		outline: none;
-		inset: var(--semantics-overlays-inset) auto var(--semantics-overlays-inset) var(--semantics-overlays-inset);
-		width: var(--semantics-sheets-side-md-width);
-		height: calc(100dvh - var(--semantics-overlays-inset) * 2);
-		border-radius: var(--semantics-overlays-corner-radius);
+
+		@media (max-width: ${smMax}) {
+			inset: auto 0 0 0;
+			width: 100%;
+			max-width: 100%;
+			height: auto;
+			max-height: calc(100dvh - var(--semantics-sheets-bottom-top-inset));
+			border-radius: var(--semantics-overlays-corner-radius) var(--semantics-overlays-corner-radius) 0 0;
+		}
+
+		@media (min-width: ${mdMin}) and (max-width: ${mdMax}) {
+			inset: var(--semantics-overlays-inset) auto var(--semantics-overlays-inset) var(--semantics-overlays-inset);
+			width: var(--semantics-sheets-side-md-width);
+			height: calc(100dvh - var(--semantics-overlays-inset) * 2);
+			border-radius: var(--semantics-overlays-corner-radius);
+		}
 
 		@media (min-width: ${lgMin}) {
+			inset: var(--semantics-overlays-inset) auto var(--semantics-overlays-inset) var(--semantics-overlays-inset);
 			width: var(--semantics-sheets-side-lg-width);
-	}
+			height: calc(100dvh - var(--semantics-overlays-inset) * 2);
+			border-radius: var(--semantics-overlays-corner-radius);
+		}
 
 		&:focus-visible:not(.is-pointer-focus) {
 			box-shadow: var(--semantics-focus-ring-box-shadow), var(--semantics-overlays-box-shadow);
 			outline: var(--semantics-focus-ring-outline);
 			outline-offset: var(--semantics-focus-ring-outline-offset);
-	}
+		}
 
 		&:not([open]) {
 			display: none;
-	}
+		}
 
 		&::backdrop {
 			background: var(--semantics-overlays-backdrop-color);
-	}
+		}
 
 		&[open] {
-			animation: navigation-split-view-sidebar-slide-in var(--semantics-sheets-side-animation-duration) var(--primitives-transition-easing-default) both;
-	}
+			@media (max-width: ${smMax}) {
+				animation: navigation-split-view-slide-in-bottom var(--semantics-sheets-bottom-animation-duration) var(--primitives-transition-easing-default) both;
+			}
+
+			@media (min-width: ${mdMin}) {
+				animation: navigation-split-view-sidebar-slide-in var(--semantics-sheets-side-animation-duration) var(--primitives-transition-easing-default) both;
+			}
+		}
 
 		&.is-closing {
-			animation: navigation-split-view-sidebar-slide-out var(--semantics-sheets-side-animation-duration) var(--primitives-transition-easing-default) both;
-	}
+			@media (max-width: ${smMax}) {
+				animation: navigation-split-view-slide-out-bottom var(--semantics-sheets-bottom-animation-duration) var(--primitives-transition-easing-default) both;
+			}
+
+			@media (min-width: ${mdMin}) {
+				animation: navigation-split-view-sidebar-slide-out var(--semantics-sheets-side-animation-duration) var(--primitives-transition-easing-default) both;
+			}
+		}
 	}
 
 	.navigation-split-view__sidebar-sheet-body {
+		/* Show dismiss button inside sidebar sheet */
+		--context-dismiss-button-display: block;
+
 		display: flex;
 		flex-direction: column;
 		flex-grow: 1;
 		min-height: 0;
 		width: 100%;
-
-		/* Show dismiss button inside sidebar sheet */
-		--context-dismiss-button-display: block;
 	}
 
 
@@ -256,42 +309,6 @@ export const navigationSplitViewStyles = css`
 		to { transform: translateY(100%); }
 	}
 
-	@media (max-width: ${smMax}) {
-		.navigation-split-view__inspector-sheet {
-			inset: auto 0 0 0;
-			width: 100%;
-			max-width: 100%;
-			height: auto;
-			max-height: calc(100dvh - var(--semantics-sheets-bottom-top-inset));
-			border-radius: var(--semantics-overlays-corner-radius) var(--semantics-overlays-corner-radius) 0 0;
-
-			&[open] {
-				animation: navigation-split-view-slide-in-bottom var(--semantics-sheets-bottom-animation-duration) var(--primitives-transition-easing-default) both;
-			}
-
-			&.is-closing {
-				animation: navigation-split-view-slide-out-bottom var(--semantics-sheets-bottom-animation-duration) var(--primitives-transition-easing-default) both;
-			}
-	}
-
-		.navigation-split-view__sidebar-sheet {
-			inset: auto 0 0 0;
-			width: 100%;
-			max-width: 100%;
-			height: auto;
-			max-height: calc(100dvh - var(--semantics-sheets-bottom-top-inset));
-			border-radius: var(--semantics-overlays-corner-radius) var(--semantics-overlays-corner-radius) 0 0;
-
-			&[open] {
-				animation: navigation-split-view-slide-in-bottom var(--semantics-sheets-bottom-animation-duration) var(--primitives-transition-easing-default) both;
-			}
-
-			&.is-closing {
-				animation: navigation-split-view-slide-out-bottom var(--semantics-sheets-bottom-animation-duration) var(--primitives-transition-easing-default) both;
-			}
-	}
-	}
-
 
 	/* # Reduced motion */
 
@@ -301,7 +318,7 @@ export const navigationSplitViewStyles = css`
 		.navigation-split-view__sidebar-sheet[open],
 		.navigation-split-view__sidebar-sheet.is-closing {
 			animation: none;
-	}
+		}
 	}
 
 

--- a/src/components/layout/split-views/side-by-side-split-view/side-by-side-split-view.styles.ts
+++ b/src/components/layout/split-views/side-by-side-split-view/side-by-side-split-view.styles.ts
@@ -51,7 +51,6 @@ export const sideBySideSplitViewStyles = css`
 		min-height: 0;
 		min-width: var(--_pane-min-width);
 		overflow: hidden;
-
 	}
 
 	.side-by-side-split-view__pane[hidden] {

--- a/src/components/layout/split-views/side-by-side-split-view/side-by-side-split-view.styles.ts
+++ b/src/components/layout/split-views/side-by-side-split-view/side-by-side-split-view.styles.ts
@@ -51,8 +51,7 @@ export const sideBySideSplitViewStyles = css`
 		min-height: 0;
 		min-width: var(--_pane-min-width);
 		overflow: hidden;
-		container-type: inline-size;
-		container-name: layout-area;
+
 	}
 
 	.side-by-side-split-view__pane[hidden] {

--- a/src/components/layout/split-views/split-view-pane/split-view-pane.ts
+++ b/src/components/layout/split-views/split-view-pane/split-view-pane.ts
@@ -40,6 +40,12 @@ export class NLDDSplitViewPane extends LitElement {
 	@property({ type: String, reflect: true })
 	background: 'inherit' | 'default' | 'tinted' = 'inherit';
 
+	override connectedCallback() {
+		super.connectedCallback();
+		this.style.containerType = 'inline-size';
+		this.style.containerName = 'layout-area';
+	}
+
 	override render() {
 		return splitViewPaneTemplate(this);
 	}

--- a/src/components/layout/split-views/stacked-split-view/stacked-split-view.styles.ts
+++ b/src/components/layout/split-views/stacked-split-view/stacked-split-view.styles.ts
@@ -52,7 +52,6 @@ export const stackedSplitViewStyles = css`
 		min-height: var(--_pane-min-height);
 		min-width: 0;
 		overflow: hidden;
-
 	}
 
 	.stacked-split-view__pane[hidden] {

--- a/src/components/layout/split-views/stacked-split-view/stacked-split-view.styles.ts
+++ b/src/components/layout/split-views/stacked-split-view/stacked-split-view.styles.ts
@@ -52,8 +52,7 @@ export const stackedSplitViewStyles = css`
 		min-height: var(--_pane-min-height);
 		min-width: 0;
 		overflow: hidden;
-		container-type: inline-size;
-		container-name: layout-area;
+
 	}
 
 	.stacked-split-view__pane[hidden] {

--- a/src/components/layout/window/window.test.ts
+++ b/src/components/layout/window/window.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { fixture, cleanup, waitForUpdate } from '../../../test-utils.js';
 import type { NLDDWindow } from './window.js';
 import './window.js';
@@ -194,5 +194,71 @@ describe('nldd-window', () => {
 		handle.dispatchEvent(new PointerEvent('pointerup', {
 			clientX: 150, clientY: 120, pointerId: 1, bubbles: true,
 		}));
+	});
+
+	describe('centered position', () => {
+		// Force md+ viewport: _applyPositionStyles short-circuits and clears
+		// inline styles when window.matchMedia(`(max-width: ${smMax})`) matches.
+		// Stub it so the override branch is exercised regardless of test
+		// runner viewport.
+		let originalMatchMedia: typeof window.matchMedia;
+		beforeEach(() => {
+			originalMatchMedia = window.matchMedia;
+			window.matchMedia = ((query: string) => {
+				const list = originalMatchMedia.call(window, query);
+				return new Proxy(list, {
+					get(target, prop) {
+						if (prop === 'matches' && query.includes('max-width')) return false;
+						const v = (target as unknown as Record<string, unknown>)[prop as string];
+						return typeof v === 'function' ? v.bind(target) : v;
+					},
+				});
+			}) as typeof window.matchMedia;
+		});
+		afterEach(() => {
+			window.matchMedia = originalMatchMedia;
+		});
+
+		function dialogOf(window: NLDDWindow): HTMLDialogElement {
+			return window.shadowRoot!.querySelector('dialog') as HTMLDialogElement;
+		}
+
+		it('centered=true: dialog krijgt translate(-50%, -50%) op beide assen', async () => {
+			el = await fixture<NLDDWindow>('<nldd-window modeless centered></nldd-window>');
+			await waitForUpdate(el);
+			el.show();
+			await waitForUpdate(el);
+
+			const dialog = dialogOf(el);
+			expect(dialog.style.top).toBe('50%');
+			expect(dialog.style.left).toBe('50%');
+			expect(dialog.style.transform).toContain('-50%');
+			expect(dialog.style.transform).toContain(', -50%');
+		});
+
+		it('centered + bottom="0": horizontaal centered, verticaal bottom-aligned', async () => {
+			el = await fixture<NLDDWindow>('<nldd-window modeless centered bottom="0"></nldd-window>');
+			await waitForUpdate(el);
+			el.show();
+			await waitForUpdate(el);
+
+			const dialog = dialogOf(el);
+			expect(dialog.style.bottom).toBe('0px');
+			expect(dialog.style.left).toBe('50%');
+			// Y-as is niet meer gecenterd (bottom heeft voorrang); X-as wel.
+			expect(dialog.style.transform).toMatch(/translate\(-50%,\s*0(px)?\)/);
+		});
+
+		it('zonder centered en zonder edge-attrs: geen inline override', async () => {
+			el = await fixture<NLDDWindow>('<nldd-window modeless></nldd-window>');
+			await waitForUpdate(el);
+			el.show();
+			await waitForUpdate(el);
+
+			const dialog = dialogOf(el);
+			expect(dialog.style.transform).toBe('');
+			// margin: '' (empty) — UA-default centering blijft actief
+			expect(dialog.style.margin).toBe('');
+		});
 	});
 });

--- a/src/components/layout/window/window.ts
+++ b/src/components/layout/window/window.ts
@@ -101,6 +101,8 @@ export class NLDDWindow extends LitElement {
 
 	override connectedCallback(): void {
 		super.connectedCallback();
+		this.style.containerType = 'inline-size';
+		this.style.containerName = 'layout-area';
 		this.addEventListener('dismiss', this._handleDismiss);
 		this._detectDragHandle();
 		window.addEventListener('resize', this._handleResize);

--- a/src/components/layout/window/window.ts
+++ b/src/components/layout/window/window.ts
@@ -22,6 +22,11 @@
  * @attr {string}  left             - CSS left positie van de linkerrand
  * @attr {string}  right            - CSS right waarde
  * @attr {string}  bottom           - CSS bottom waarde
+ * @attr {boolean} centered         - Centreert beide assen op de viewport. Per
+ *                                     as overrideable: `centered top="0"` =
+ *                                     horizontaal gecentreerd, top-aligned.
+ *                                     Mirrort CSS `place-items: center` met
+ *                                     `align-items`/`justify-items` overrides.
  * @attr {string}  width            - CSS width (standaard: var(--components-window-default-width))
  * @attr {string}  height           - CSS height (standaard: content height)
  *
@@ -73,6 +78,9 @@ export class NLDDWindow extends LitElement {
 
 	@property({ type: String, reflect: true })
 	bottom: string | undefined;
+
+	@property({ type: Boolean, reflect: true })
+	centered = false;
 
 	@property({ type: String, reflect: true })
 	width: string | undefined;
@@ -190,19 +198,34 @@ export class NLDDWindow extends LitElement {
 			return;
 		}
 
-		const hasPosition = this.top !== undefined || this.left !== undefined || this.right !== undefined || this.bottom !== undefined;
+		const hasEdge = this.top !== undefined || this.left !== undefined || this.right !== undefined || this.bottom !== undefined;
+		const hasOverride = hasEdge || this.centered;
+
+		// `centered` centreert beide assen tenzij een edge-attr op die as gezet
+		// is. Edges hebben dus voorrang. transform: translate(-50%) per
+		// gecentreerde as zorgt dat de width-clamping (max-width) niet de
+		// centering breekt — percentage in transform is relatief aan de eigen
+		// breedte, niet de viewport.
+		const yCenter = this.centered && this.top === undefined && this.bottom === undefined;
+		const xCenter = this.centered && this.left === undefined && this.right === undefined;
 
 		// Set explicit 'auto' on opposing axis when only one side is set,
 		// to override the UA stylesheet defaults on <dialog>
-		dialog.style.top = this.top ?? (this.bottom !== undefined ? 'auto' : '');
+		dialog.style.top = this.top ?? (yCenter ? '50%' : (this.bottom !== undefined ? 'auto' : ''));
 		dialog.style.bottom = this.bottom ?? (this.top !== undefined ? 'auto' : '');
-		dialog.style.left = this.left ?? (this.right !== undefined ? 'auto' : '');
+		dialog.style.left = this.left ?? (xCenter ? '50%' : (this.right !== undefined ? 'auto' : ''));
 		dialog.style.right = this.right ?? (this.left !== undefined ? 'auto' : '');
 		dialog.style.width = this.width ?? '';
 		dialog.style.height = this.height ?? '';
 
-		// Reset margin when custom position is set; keep margin: auto for centering
-		dialog.style.margin = hasPosition ? '0' : '';
+		// Translate per gecentreerde as om center-from-edge te corrigeren.
+		dialog.style.transform = (xCenter || yCenter)
+			? `translate(${xCenter ? '-50%' : '0'}, ${yCenter ? '-50%' : '0'})`
+			: '';
+
+		// Reset margin when custom position is set; keep margin: auto for the
+		// UA-default centering (which only kicks in without explicit position).
+		dialog.style.margin = hasOverride ? '0' : '';
 	}
 
 	_handleDialogClick = (e: MouseEvent): void => {

--- a/src/components/lists-and-menus/cells/text-cell/text-cell.styles.ts
+++ b/src/components/lists-and-menus/cells/text-cell/text-cell.styles.ts
@@ -107,6 +107,7 @@ export const textCellStyles = css`
 		margin: 0;
 		align-self: stretch;
 		min-width: 0;
+		text-wrap: pretty;
 	}
 
 	:host([size='md']) .text-cell__text,

--- a/src/components/lists-and-menus/cells/text-cell/text-cell.styles.ts
+++ b/src/components/lists-and-menus/cells/text-cell/text-cell.styles.ts
@@ -84,6 +84,7 @@ export const textCellStyles = css`
 		margin: 0;
 		align-self: stretch;
 		min-width: 0;
+		overflow-wrap: anywhere;
 		color: var(--context-cell-content-color, var(--semantics-content-secondary-color));
 	}
 
@@ -107,6 +108,7 @@ export const textCellStyles = css`
 		margin: 0;
 		align-self: stretch;
 		min-width: 0;
+		overflow-wrap: anywhere;
 		text-wrap: pretty;
 	}
 
@@ -154,6 +156,7 @@ export const textCellStyles = css`
 		margin: 0;
 		align-self: stretch;
 		min-width: 0;
+		overflow-wrap: anywhere;
 		color: var(--context-cell-content-color, var(--semantics-content-secondary-color));
 	}
 

--- a/src/components/lists-and-menus/cells/title-cell/title-cell.styles.ts
+++ b/src/components/lists-and-menus/cells/title-cell/title-cell.styles.ts
@@ -100,6 +100,7 @@ export const titleCellStyles = css`
 		align-self: stretch;
 		min-width: 0;
 		color: var(--context-cell-content-color, var(--semantics-content-color));
+		text-wrap: pretty;
 	}
 
 	:host([horizontal-alignment='right']) .title-cell__title {

--- a/src/components/lists-and-menus/menu/menu.ts
+++ b/src/components/lists-and-menus/menu/menu.ts
@@ -1,6 +1,6 @@
 import { LitElement } from 'lit';
 import { property, state } from 'lit/decorators.js';
-import { computePosition, flip, shift, offset, size } from '@floating-ui/dom';
+import { computePosition, flip, shift, offset, size, autoUpdate } from '@floating-ui/dom';
 import { menuStyles, menuItemStyles, menuDividerStyles } from './menu.styles.js';
 import { menuTemplate, menuItemTemplate, menuDividerTemplate } from './menu.template.js';
 import { nlddMenuTranslations } from './menu.i18n.js';
@@ -226,6 +226,7 @@ export class NLDDMenu extends LitElement {
 
 	private _isOpen = false;
 	private _closedAt = 0;
+	private _cleanupAutoUpdate: (() => void) | null = null;
 
 	// — i18n ——————————————————————————————————————————————————————————————————
 
@@ -328,6 +329,8 @@ export class NLDDMenu extends LitElement {
 		this.removeEventListener('mouseleave', this._handleMouseleave);
 		this.removeEventListener('menu-item-focused', this._handleMenuItemFocused);
 		document.removeEventListener('click', this._handleDocumentClick);
+		this._cleanupAutoUpdate?.();
+		this._cleanupAutoUpdate = null;
 	}
 
 	// — Internal helpers ——————————————————————————————————————————————————————
@@ -537,6 +540,8 @@ export class NLDDMenu extends LitElement {
 
 		if (toggleEvent.newState !== 'open') {
 			this._closedAt = Date.now();
+			this._cleanupAutoUpdate?.();
+			this._cleanupAutoUpdate = null;
 			return;
 		}
 
@@ -548,6 +553,10 @@ export class NLDDMenu extends LitElement {
 		});
 
 		await this.reposition();
+		const anchorEl = this._getAnchorEl();
+		if (anchorEl) {
+			this._cleanupAutoUpdate = autoUpdate(anchorEl, this, () => this.reposition());
+		}
 
 		await this.updateComplete;
 		if (this.variant !== 'listbox') {

--- a/src/components/navigation/document-tab-bar/document-tab-bar.template.ts
+++ b/src/components/navigation/document-tab-bar/document-tab-bar.template.ts
@@ -75,12 +75,10 @@ export function documentTabBarItemTemplate(component: NLDDDocumentTabBarItem): T
 				: nothing}
 		</span>
 		<span class="document-tab-bar__item-short">
-			<nldd-tooltip text=${tooltipText}>
-				<span class="document-tab-bar__item-short-text">${shortTextValue}</span>
-				${shortSupportingTextValue
-					? html`<span class="document-tab-bar__item-short-supporting-text">${shortSupportingTextValue}</span>`
-					: nothing}
-			</nldd-tooltip>
+			<span class="document-tab-bar__item-short-text">${shortTextValue}</span>
+			${shortSupportingTextValue
+				? html`<span class="document-tab-bar__item-short-supporting-text">${shortSupportingTextValue}</span>`
+				: nothing}
 		</span>
 	`;
 
@@ -104,17 +102,19 @@ export function documentTabBarItemTemplate(component: NLDDDocumentTabBarItem): T
 			>${tabContent}</button>`;
 
 	return html`
-		<div class="document-tab-bar__item">
-			${tab}
-			<button class="document-tab-bar__item-dismiss-button"
-				aria-label=${component._dismissButtonAccessibilityLabel}
-				tabindex=${component.selected || component._isFallbackFocusable ? '0' : '-1'}
-				@click=${component._handleDismiss}
-			>
-				<span class="document-tab-bar__item-dismiss-icon">
-					<nldd-icon name="dismiss"></nldd-icon>
-				</span>
-			</button>
-		</div>
+		<nldd-tooltip text=${tooltipText} ?disabled=${!component._isShort}>
+			<div class="document-tab-bar__item">
+				${tab}
+				<button class="document-tab-bar__item-dismiss-button"
+					aria-label=${component._dismissButtonAccessibilityLabel}
+					tabindex=${component.selected || component._isFallbackFocusable ? '0' : '-1'}
+					@click=${component._handleDismiss}
+				>
+					<span class="document-tab-bar__item-dismiss-icon">
+						<nldd-icon name="dismiss"></nldd-icon>
+					</span>
+				</button>
+			</div>
+		</nldd-tooltip>
 	`;
 }

--- a/src/components/navigation/document-tab-bar/document-tab-bar.test.ts
+++ b/src/components/navigation/document-tab-bar/document-tab-bar.test.ts
@@ -98,6 +98,52 @@ describe('nldd-document-tab-bar-item', () => {
 
 
 /* ============================================================
+   nldd-document-tab-bar-item – short mode
+   ============================================================ */
+
+describe('nldd-document-tab-bar-item – short mode', () => {
+	let el: NLDDDocumentTabBar;
+
+	afterEach(() => {
+		if (el) cleanup(el);
+	});
+
+	function setItemWidth(item: HTMLElement, width: number) {
+		// jsdom returns 0 from getBoundingClientRect; stub it for the seam that
+		// _updateIsShort reads. Each test sets a different width.
+		Object.defineProperty(item, 'getBoundingClientRect', {
+			configurable: true,
+			value: () => ({ width, height: 0, top: 0, left: 0, right: width, bottom: 0, x: 0, y: 0, toJSON: () => ({}) }),
+		});
+	}
+
+	it('toggles _isShort and the tooltip-disabled gate via the threshold CSS var', async () => {
+		el = await fixture<NLDDDocumentTabBar>(threeTabBar());
+		await waitForUpdate(el);
+		const item = getItems(el)[0] as NLDDDocumentTabBarItem;
+
+		// Override the threshold so we don't depend on the production 200px.
+		item.style.setProperty('--_short-text-threshold', '100px');
+
+		// Below threshold → short mode active.
+		setItemWidth(item, 50);
+		(item as unknown as { _updateIsShort: () => void })._updateIsShort();
+		await waitForUpdate(item);
+		expect((item as unknown as { _isShort: boolean })._isShort).toBe(true);
+		const tooltip = item.shadowRoot!.querySelector('nldd-tooltip')!;
+		expect(tooltip.hasAttribute('disabled')).toBe(false);
+
+		// Above threshold → tooltip suppressed (full text already inline).
+		setItemWidth(item, 150);
+		(item as unknown as { _updateIsShort: () => void })._updateIsShort();
+		await waitForUpdate(item);
+		expect((item as unknown as { _isShort: boolean })._isShort).toBe(false);
+		expect(tooltip.hasAttribute('disabled')).toBe(true);
+	});
+});
+
+
+/* ============================================================
    nldd-document-tab-bar-item – events
    ============================================================ */
 

--- a/src/components/navigation/document-tab-bar/document-tab-bar.ts
+++ b/src/components/navigation/document-tab-bar/document-tab-bar.ts
@@ -81,9 +81,37 @@ export class NLDDDocumentTabBarItem extends LitElement {
 	@property({ type: String })
 	href = '';
 
+	/**
+	 * True when the parent bar has compressed the item below the
+	 * `--_short-text-threshold` (CSS), so only short-text is visible.
+	 * Used to gate the title-tooltip — in normal mode the full text +
+	 * supporting text is already inline so a tooltip would be redundant.
+	 */
+	@state()
+	_isShort = false;
+
+	private _itemResizeObserver: ResizeObserver | null = null;
+
 	override connectedCallback(): void {
 		super.connectedCallback();
 		this.setAttribute('role', 'none');
+		this._itemResizeObserver = new ResizeObserver(() => this._updateIsShort());
+		this._itemResizeObserver.observe(this);
+	}
+
+	override disconnectedCallback(): void {
+		super.disconnectedCallback();
+		this._itemResizeObserver?.disconnect();
+		this._itemResizeObserver = null;
+	}
+
+	private _updateIsShort(): void {
+		// Read threshold from CSS custom property — single source of truth
+		// shared with the @container query that toggles short-mode visuals.
+		// `--_short-text-threshold` is declared on nldd-document-tab-bar's
+		// :host and cascades to slotted items.
+		const threshold = parseFloat(getComputedStyle(this).getPropertyValue('--_short-text-threshold'));
+		this._isShort = this.getBoundingClientRect().width < threshold;
 	}
 
 	/** Set by nldd-document-tab-bar. Not part of the public API. */

--- a/src/components/navigation/document-tab-bar/document-tab-bar.ts
+++ b/src/components/navigation/document-tab-bar/document-tab-bar.ts
@@ -110,8 +110,11 @@ export class NLDDDocumentTabBarItem extends LitElement {
 		// shared with the @container query that toggles short-mode visuals.
 		// `--_short-text-threshold` is declared on nldd-document-tab-bar's
 		// :host and cascades to slotted items.
+		// Guard against NaN: when the item is used outside a tab bar the
+		// custom property is unset and `width < NaN` would silently resolve to
+		// false (safe fallback, but the explicit guard makes intent clear).
 		const threshold = parseFloat(getComputedStyle(this).getPropertyValue('--_short-text-threshold'));
-		this._isShort = this.getBoundingClientRect().width < threshold;
+		this._isShort = Number.isFinite(threshold) && this.getBoundingClientRect().width < threshold;
 	}
 
 	/** Set by nldd-document-tab-bar. Not part of the public API. */

--- a/src/components/navigation/top-title-bar/top-title-bar.ts
+++ b/src/components/navigation/top-title-bar/top-title-bar.ts
@@ -51,6 +51,7 @@ export class NLDDTopTitleBar extends LitElement {
 	private _pageElement: Element | null = null;
 	private _anchorElement: Element | null = null;
 	private _activeScrollTarget: EventTarget | null = null;
+	private _scrollTargetStyleObserver: MutationObserver | null = null;
 	private _boundOnScroll = this._onScroll.bind(this);
 
 	override connectedCallback(): void {
@@ -108,6 +109,20 @@ export class NLDDTopTitleBar extends LitElement {
 		this._activeScrollTarget = page ? page.scrollTarget : window;
 		this._activeScrollTarget.addEventListener('scroll', this._boundOnScroll, { passive: true });
 
+		// nldd-page sets padding-top on its scroll target asynchronously
+		// (ResizeObserver on the header). If our initial _onScroll runs
+		// before that, the anchor's measured position is wrong and we
+		// flash into is-compact until the user scrolls. Observe inline-
+		// style changes on the scroll target so we re-check the moment
+		// padding-top lands.
+		if (this._activeScrollTarget instanceof Element) {
+			this._scrollTargetStyleObserver = new MutationObserver(() => this._onScroll());
+			this._scrollTargetStyleObserver.observe(this._activeScrollTarget, {
+				attributes: true,
+				attributeFilter: ['style'],
+			});
+		}
+
 		// Initial check after layout is complete
 		this.updateComplete.then(() => this._onScroll());
 	}
@@ -116,6 +131,8 @@ export class NLDDTopTitleBar extends LitElement {
 		this._activeScrollTarget?.removeEventListener('scroll', this._boundOnScroll);
 		this._activeScrollTarget = null;
 		this._anchorElement = null;
+		this._scrollTargetStyleObserver?.disconnect();
+		this._scrollTargetStyleObserver = null;
 	}
 
 	private _onScroll(): void {

--- a/src/components/status-and-feedback/inline-dialog/inline-dialog.styles.ts
+++ b/src/components/status-and-feedback/inline-dialog/inline-dialog.styles.ts
@@ -8,6 +8,8 @@ export const inlineDialogStyles = css`
 	:host {
 		display: flex;
 		justify-content: center;
+		align-items: center;
+		flex-grow: 1;
 
 		--_icon-color: var(--semantics-content-color);
 	}

--- a/src/components/status-and-feedback/inline-dialog/inline-dialog.styles.ts
+++ b/src/components/status-and-feedback/inline-dialog/inline-dialog.styles.ts
@@ -55,6 +55,7 @@ export const inlineDialogStyles = css`
 		font: var(--primitives-font-body-md-bold-tight);
 		color: var(--semantics-content-color);
 		text-align: center;
+		text-wrap: pretty;
 	}
 
 	.inline-dialog__text:focus-visible {
@@ -70,6 +71,7 @@ export const inlineDialogStyles = css`
 		font: var(--primitives-font-body-sm-regular-tight);
 		color: var(--semantics-content-color);
 		text-align: center;
+		text-wrap: pretty;
 	}
 
 


### PR DESCRIPTION
## Summary

Twaalf commits aan layout-werk dat is opgekomen tijdens de regelrecht editor refactor. De grote thema's:

- **Page sections (5 varianten)**: nieuwe `full-width` boolean attribuut die de body max-width laat vervallen. `align="center"` verwijderd uit `simple-section` en `full-bleed-section` (was niet langer nodig).
- **bar-split-view simplificatie (breaking)**: bars staan nu in normal flow op alle breakpoints. Geen sm-overlap, geen fade-overlays, geen `--context-bar-split-view-{top,bottom}-bars-height` context vars meer. `nldd-page` is daarmee ook simpler. Nieuw `no-divider` per-child attribuut om bars visueel aan elkaar te plakken.
- **navigation-split-view**: full-stack-mode rekent nu correct met `flex: 1` op panes zodat ze daadwerkelijk vullen op sm.
- **top-title-bar**: MutationObserver op het scroll-target zodat compact-state ook reagereert op async padding-top updates van `nldd-page`.
- **Forms**: `data-form-alignment-inherited` marker vervangen door echte `form-label-alignment` attribuut.
- **Overlay/popover (breaking)**: unified positioning API met `centered` + edge attrs. Sm bottom-sheet polish. Position overrides.
- **Tooltip**: native popover-API gebruikt + `disabled` attr.
- **Menu**: anchor-tracking via Floating UI's `autoUpdate` zodat menu meebeweegt bij resize/scroll.
- **App-view**: forceert background color op `document.body`.
- **Typography**: `text-wrap: pretty` over alle tekst-componenten.
- **Document-tab-bar**: tooltip om hele item heen, alleen in short-mode.
- **search-field**: `min-width: 0` op host zodat het kan krimpen in flex containers.
- **List-item**: lichtere selected achtergrond in light mode (`neutral-150` → `neutral-100`).
- **CSS conventie**: branche-brede explicit-per-breakpoint refactor — geen mobile-first overrides, at-rules genest in selectors, lege regels tussen blocks.

## Test plan

- [ ] Storybook lokaal: alle 5 page-section stories met `full-width` toggle
- [ ] bar-split-view stories op sm/md/lg — bars in normal flow, dividers alleen md/lg
- [ ] regelrecht editor & library renderen correct op sm/md/lg
- [ ] Sticky-header op `nldd-page` blijft op z'n plek bij scroll
- [ ] Form-label-alignment werkt cascading via attribuut
- [ ] Selected list-item licht-genoeg te onderscheiden van hover in light mode