### PR TITLE
Storybook improvements: modal padding fix, multi-line text field, form-associated inputs

### DIFF
--- a/.claude/skills/component/SKILL.md
+++ b/.claude/skills/component/SKILL.md
@@ -252,11 +252,74 @@ export function template(component: NDD{PascalName}): TemplateResult {
 
 ### Controls conventies
 
+- **`args` staat altijd vóór `argTypes`** in de default export
 - **Args keys:** altijd camelCase (bijv. `startIcon`, `fullWidth`)
 - **`name:`** het HTML attribuut in kebab-case (bijv. `name: 'start-icon'`, `name: 'full-width'`)
 - **`table.defaultValue.summary:`** altijd invullen met de default waarde
 - **`description:`** korte Nederlandse beschrijving
 - **Icon controls:** gebruik `control: 'select'` met `options: ['', ...ICONS]` — importeer `ICONS` uit `../../content/icon/ndd-icon.ts`. Nooit een text input voor iconen.
+- **Volgorde consistent**: `args`, `argTypes`, template-destructuring en HTML-attributen in de template gebruiken dezelfde volgorde, volgens de canon hieronder.
+
+### Canonieke control volgorde
+
+Per component: pak alleen de keys die je gebruikt en zet ze in deze volgorde. De groepering is een mentaal model — de daadwerkelijke `args`/`argTypes` is een platte lijst.
+
+```
+[1. Visueel dominant]
+size, compact, variant, color, background, layout, panes,
+iconOnly, responsive, showItemLabels, inspectorAsSheet, sidebarAsSheet, noLogo
+
+[2. Sizing]
+width, minWidth, maxWidth, height, minHeight, fullWidth, rows, resize,
+itemWidth, containerSize
+
+[3. Space]
+spacing, padding, paddingInline, paddingBlock, paddingTop, paddingRight,
+paddingBottom, paddingLeft
++ smPadding…, mdPadding…, lgPadding…, layoutAreaXxxxPadding…
+
+[4. Alignment and position]
+horizontalAlignment, verticalAlignment, direction, orientation, placement,
+labelAlignment, top, right, bottom, left, child
+
+[5. Main content]
+text, supportingText, overline, label, supportingLabel, optional,
+value, placeholder, number, headingLevel,
+icon, startIcon, endIcon, containerColor,
+quote, attribution, cite, keys,
+logoTitle, logoSubtitle, logoSupportingText1, logoSupportingText2, logoHref,
+websiteTitle, websiteHref, backText, backHref, dismissText
+
+[6. Key behavior]
+control, expandable
+
+[7. A11y]
+accessibleLabel
+
+[8. Elements]
+showSearchButton, hideSpinButtons, hasDragHandle, maxItems
+
+[9. Elements content]
+showText, hideText, overflowText
+
+[10. Elements A11y]
+showAccessibleLabel, hideAccessibleLabel
+
+[11. Behavior]
+modeless, movable, stickyHeader, stickyFooter, hasContent, alwaysVisible,
+showLoadMore, lazyLoad, collapseAnchor, contentPriority
+
+[12. States]
+selected, checked, indeterminate, open, valid, invalid, masked, readonly, current, disabled
+
+[13. Requirements]
+min, max, step, total, required
+
+[14. Form]
+name, type, autocomplete, href, target, method, action, novalidate
+```
+
+**Open punt**: `type` staat onder Form (HTML input type, vaakste betekenis). Voor `segmented-control` heeft het een andere semantiek (radio/checkbox-modus); kan later via een rename naar bijv. `selectionMode` opgelost worden.
 
 ```typescript
 import { html, nothing } from 'lit';

--- a/.claude/skills/component/SKILL.md
+++ b/.claude/skills/component/SKILL.md
@@ -270,7 +270,7 @@ size, compact, variant, color, background, layout, panes,
 iconOnly, responsive, showItemLabels, inspectorAsSheet, sidebarAsSheet, noLogo
 
 [2. Sizing]
-width, minWidth, maxWidth, height, minHeight, fullWidth, rows, resize,
+resize, rows, width, minWidth, maxWidth, height, minHeight, fullWidth,
 itemWidth, containerSize
 
 [3. Space]
@@ -284,7 +284,7 @@ labelAlignment, top, right, bottom, left, child
 
 [5. Main content]
 text, supportingText, overline, label, supportingLabel, optional,
-value, placeholder, number, headingLevel,
+placeholder, number, headingLevel,
 icon, startIcon, endIcon, containerColor,
 quote, attribution, cite, keys,
 logoTitle, logoSubtitle, logoSupportingText1, logoSupportingText2, logoHref,
@@ -312,11 +312,9 @@ showLoadMore, lazyLoad, collapseAnchor, contentPriority
 [12. States]
 selected, checked, indeterminate, open, valid, invalid, masked, readonly, current, disabled
 
-[13. Requirements]
-min, max, step, total, required
-
-[14. Form]
-name, type, autocomplete, href, target, method, action, novalidate
+[13. Form]
+name, value, type, min, max, step, required, total,
+autocomplete, href, target, method, action, novalidate
 ```
 
 **Open punt**: `type` staat onder Form (HTML input type, vaakste betekenis). Voor `segmented-control` heeft het een andere semantiek (radio/checkbox-modus); kan later via een rename naar bijv. `selectionMode` opgelost worden.

--- a/package.json
+++ b/package.json
@@ -83,6 +83,10 @@
       "types": "./dist/components/inputs/text-field/text-field.d.ts",
       "default": "./dist/components/inputs/text-field/text-field.js"
     },
+    "./multi-line-text-field": {
+      "types": "./dist/components/inputs/multi-line-text-field/multi-line-text-field.d.ts",
+      "default": "./dist/components/inputs/multi-line-text-field/multi-line-text-field.js"
+    },
     "./password-field": {
       "types": "./dist/components/inputs/password-field/password-field.d.ts",
       "default": "./dist/components/inputs/password-field/password-field.js"

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -42,6 +42,7 @@ export { NLDDFormSection } from './forms/form-section/form-section.js';
 // # Input components
 
 export { NLDDTextField } from './inputs/text-field/text-field.js';
+export { NLDDMultiLineTextField } from './inputs/multi-line-text-field/multi-line-text-field.js';
 export { NLDDPasswordField } from './inputs/password-field/password-field.js';
 export { NLDDSearchField } from './inputs/search-field/search-field.js';
 export { NLDDNumberField } from './inputs/number-field/number-field.js';

--- a/src/components/inputs/checkbox/checkbox.test.ts
+++ b/src/components/inputs/checkbox/checkbox.test.ts
@@ -187,4 +187,31 @@ describe('nldd-checkbox – accessibility', () => {
 		input.focus();
 		expect(input.matches(':focus')).toBe(true);
 	});
+
+	it('participates in FormData when checked', async () => {
+		const form = await fixture<HTMLFormElement>('<form><nldd-checkbox name="tos" value="agreed" checked></nldd-checkbox></form>');
+		el = form;
+		const cb = form.querySelector('nldd-checkbox')!;
+		await waitForUpdate(cb);
+		expect(new FormData(form).get('tos')).toBe('agreed');
+	});
+
+	it('is omitted from FormData when unchecked', async () => {
+		const form = await fixture<HTMLFormElement>('<form><nldd-checkbox name="tos" value="agreed"></nldd-checkbox></form>');
+		el = form;
+		const cb = form.querySelector('nldd-checkbox')!;
+		await waitForUpdate(cb);
+		expect(new FormData(form).has('tos')).toBe(false);
+	});
+
+	it('resets to the HTML-declared initial checked state when the parent form is reset', async () => {
+		const form = await fixture<HTMLFormElement>('<form><nldd-checkbox name="tos" value="agreed" checked></nldd-checkbox></form>');
+		el = form;
+		const cb = form.querySelector<NLDDCheckbox>('nldd-checkbox')!;
+		await waitForUpdate(cb);
+		cb.checked = false;
+		await waitForUpdate(cb);
+		form.reset();
+		expect(cb.checked).toBe(true);
+	});
 });

--- a/src/components/inputs/checkbox/checkbox.ts
+++ b/src/components/inputs/checkbox/checkbox.ts
@@ -39,7 +39,7 @@ export class NLDDCheckbox extends LitElement {
 	@property({ type: String })
 	value = 'on';
 
-	@property({ type: String })
+	@property({ type: String, reflect: true })
 	name = '';
 
 	@property({ type: String, attribute: 'accessible-label' })

--- a/src/components/inputs/checkbox/checkbox.ts
+++ b/src/components/inputs/checkbox/checkbox.ts
@@ -12,14 +12,20 @@
  *
  * @fires change - Fired when the checkbox state changes; detail: { checked: boolean, value: string }
  */
-import { LitElement } from 'lit';
+import { LitElement, type PropertyValues } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { checkboxStyles } from './checkbox.styles.js';
 import { checkboxTemplate } from './checkbox.template.js';
 
 @customElement('nldd-checkbox')
 export class NLDDCheckbox extends LitElement {
+	static formAssociated = true;
+
 	static override styles = checkboxStyles;
+
+	private _internals = this.attachInternals();
+
+	private _initialChecked = false;
 
 	@property({ type: Boolean, reflect: true })
 	checked = false;
@@ -38,6 +44,29 @@ export class NLDDCheckbox extends LitElement {
 
 	@property({ type: String, attribute: 'accessible-label' })
 	accessibleLabel = '';
+
+	override firstUpdated(): void {
+		this._initialChecked = this.checked;
+	}
+
+	override updated(changed: PropertyValues): void {
+		if (changed.has('checked') || changed.has('value')) {
+			this._internals.setFormValue(this.checked ? this.value : null);
+		}
+	}
+
+	formResetCallback(): void {
+		this.checked = this._initialChecked;
+		this.indeterminate = false;
+	}
+
+	formDisabledCallback(disabled: boolean): void {
+		this.disabled = disabled;
+	}
+
+	formStateRestoreCallback(state: string | null): void {
+		this.checked = state !== null;
+	}
 
 	public toggle(): void {
 		if (this.disabled) return;

--- a/src/components/inputs/checkbox/checkbox.ts
+++ b/src/components/inputs/checkbox/checkbox.ts
@@ -64,7 +64,7 @@ export class NLDDCheckbox extends LitElement {
 		this.disabled = disabled;
 	}
 
-	formStateRestoreCallback(state: string | null): void {
+	formStateRestoreCallback(state: File | string | FormData | null): void {
 		this.checked = state !== null;
 	}
 

--- a/src/components/inputs/combo-box/combo-box.test.ts
+++ b/src/components/inputs/combo-box/combo-box.test.ts
@@ -443,4 +443,23 @@ describe('nldd-combo-box – picker pointerdown (touch close)', () => {
 		await waitForUpdate(el);
 		expect(el._isOpen).toBe(true);
 	});
+
+	it('participates in FormData via form-associated API', async () => {
+		const form = await fixture<HTMLFormElement>('<form><nldd-combo-box name="land" value="nl" accessible-label="Land"></nldd-combo-box></form>');
+		const cb = form.querySelector('nldd-combo-box')!;
+		await waitForUpdate(cb);
+		expect(new FormData(form).get('land')).toBe('nl');
+		cleanup(form);
+	});
+
+	it('resets to the HTML-declared initial value when the parent form is reset', async () => {
+		const form = await fixture<HTMLFormElement>('<form><nldd-combo-box name="land" value="nl" accessible-label="Land"></nldd-combo-box></form>');
+		const cb = form.querySelector<NLDDComboBox>('nldd-combo-box')!;
+		await waitForUpdate(cb);
+		cb.value = 'be';
+		await waitForUpdate(cb);
+		form.reset();
+		expect(cb.value).toBe('nl');
+		cleanup(form);
+	});
 });

--- a/src/components/inputs/combo-box/combo-box.test.ts
+++ b/src/components/inputs/combo-box/combo-box.test.ts
@@ -462,4 +462,16 @@ describe('nldd-combo-box – picker pointerdown (touch close)', () => {
 		expect(cb.value).toBe('nl');
 		cleanup(form);
 	});
+
+	it('formStateRestoreCallback restores both value and display label from FormData state', async () => {
+		el = await fixture<NLDDComboBox>('<nldd-combo-box accessible-label="Land"></nldd-combo-box>');
+		await waitForUpdate(el);
+		const restored = new FormData();
+		restored.append('value', 'nl');
+		restored.append('display', 'Nederland');
+		(el as unknown as { formStateRestoreCallback: (s: FormData) => void }).formStateRestoreCallback(restored);
+		await waitForUpdate(el);
+		expect((el as NLDDComboBox).value).toBe('nl');
+		expect((el as NLDDComboBox)._displayValue).toBe('Nederland');
+	});
 });

--- a/src/components/inputs/combo-box/combo-box.ts
+++ b/src/components/inputs/combo-box/combo-box.ts
@@ -170,7 +170,7 @@ export class NLDDComboBox extends LitElement {
 		this.disabled = disabled;
 	}
 
-	formStateRestoreCallback(state: string): void {
+	formStateRestoreCallback(state: File | string | FormData | null): void {
 		if (typeof state === 'string') {
 			this.value = state;
 			this._displayValue = state;

--- a/src/components/inputs/combo-box/combo-box.ts
+++ b/src/components/inputs/combo-box/combo-box.ts
@@ -90,7 +90,7 @@ export class NLDDComboBox extends LitElement {
 	@property({ type: Boolean, reflect: true })
 	disabled = false;
 
-	@property({ type: String })
+	@property({ type: String, reflect: true })
 	name = '';
 
 	/** Browser autofill hint. Use AutoFill tokens (e.g. 'country', 'organization')

--- a/src/components/inputs/combo-box/combo-box.ts
+++ b/src/components/inputs/combo-box/combo-box.ts
@@ -69,6 +69,9 @@ export class NLDDComboBox extends LitElement {
 
 	private _internals = this.attachInternals();
 
+	private _initialValue = '';
+	private _initialDisplayValue = '';
+
 	@property({ type: String })
 	value = '';
 
@@ -142,6 +145,8 @@ export class NLDDComboBox extends LitElement {
 		if (import.meta.env?.DEV && !this.accessibleLabel) {
 			console.warn('<nldd-combo-box>: No accessible-label provided. Add an accessible-label attribute for screen reader accessibility.');
 		}
+		this._initialValue = this.value;
+		this._initialDisplayValue = this._displayValue;
 	}
 
 	override updated(changedProperties: Map<string, unknown>): void {
@@ -157,8 +162,8 @@ export class NLDDComboBox extends LitElement {
 	}
 
 	formResetCallback(): void {
-		this.value = '';
-		this._displayValue = '';
+		this.value = this._initialValue;
+		this._displayValue = this._initialDisplayValue;
 	}
 
 	formDisabledCallback(disabled: boolean): void {

--- a/src/components/inputs/combo-box/combo-box.ts
+++ b/src/components/inputs/combo-box/combo-box.ts
@@ -156,8 +156,14 @@ export class NLDDComboBox extends LitElement {
 		if (changedProperties.has('width')) {
 			this.style.width = this.width || '';
 		}
-		if (changedProperties.has('value')) {
-			this._internals.setFormValue(this.value);
+		if (changedProperties.has('value') || changedProperties.has('_displayValue')) {
+			// Submit only the form value, but persist the display label in the
+			// restore state so bfcache / state restore can rehydrate the input
+			// text (e.g. value "NL" → display "Netherlands").
+			const state = new FormData();
+			state.append('value', this.value);
+			state.append('display', this._displayValue);
+			this._internals.setFormValue(this.value, state);
 		}
 	}
 
@@ -171,7 +177,11 @@ export class NLDDComboBox extends LitElement {
 	}
 
 	formStateRestoreCallback(state: File | string | FormData | null): void {
-		if (typeof state === 'string') {
+		if (state instanceof FormData) {
+			this.value = String(state.get('value') ?? '');
+			this._displayValue = String(state.get('display') ?? '');
+		} else if (typeof state === 'string') {
+			// Fallback for older session state without separate display label.
 			this.value = state;
 			this._displayValue = state;
 		}

--- a/src/components/inputs/combo-box/combo-box.ts
+++ b/src/components/inputs/combo-box/combo-box.ts
@@ -63,7 +63,11 @@ export type ComboBoxSize = 'sm' | 'md';
 
 @customElement('nldd-combo-box')
 export class NLDDComboBox extends LitElement {
+	static formAssociated = true;
+
 	static override styles = comboBoxStyles;
+
+	private _internals = this.attachInternals();
 
 	@property({ type: String })
 	value = '';
@@ -146,6 +150,25 @@ export class NLDDComboBox extends LitElement {
 		}
 		if (changedProperties.has('width')) {
 			this.style.width = this.width || '';
+		}
+		if (changedProperties.has('value')) {
+			this._internals.setFormValue(this.value);
+		}
+	}
+
+	formResetCallback(): void {
+		this.value = '';
+		this._displayValue = '';
+	}
+
+	formDisabledCallback(disabled: boolean): void {
+		this.disabled = disabled;
+	}
+
+	formStateRestoreCallback(state: string): void {
+		if (typeof state === 'string') {
+			this.value = state;
+			this._displayValue = state;
 		}
 	}
 

--- a/src/components/inputs/multi-line-text-field/multi-line-text-field.stories.ts
+++ b/src/components/inputs/multi-line-text-field/multi-line-text-field.stories.ts
@@ -53,17 +53,17 @@ export default {
 	},
 	args: {
 		size: 'md',
-		width: '',
-		rows: 3,
 		resize: 'vertical',
-		value: '',
+		rows: 3,
+		width: '',
 		placeholder: 'Schrijf hier je toelichting',
 		valid: false,
 		invalid: false,
 		readonly: false,
 		disabled: false,
-		required: false,
 		name: '',
+		value: '',
+		required: false,
 		autocomplete: '',
 	},
 	argTypes: {
@@ -73,25 +73,20 @@ export default {
 			description: 'Size variant',
 			table: { defaultValue: { summary: 'md' } },
 		},
-		width: {
-			control: 'text',
-			description: 'Optional fixed width (any CSS length, bv. "240px"). Leeg = stretch.',
-			table: { defaultValue: { summary: '' } },
-		},
-		rows: {
-			control: 'number',
-			description: 'Initiële hoogte in regels (minimum)',
-			table: { defaultValue: { summary: '3' } },
-		},
 		resize: {
 			control: 'select',
 			options: ['none', 'vertical', 'auto'],
 			description: 'Resize gedrag. "auto" laat het veld meegroeien met de inhoud.',
 			table: { defaultValue: { summary: 'vertical' } },
 		},
-		value: {
+		rows: {
+			control: 'number',
+			description: 'Initiële hoogte in regels (minimum)',
+			table: { defaultValue: { summary: '3' } },
+		},
+		width: {
 			control: 'text',
-			description: 'Veldwaarde',
+			description: 'Optional fixed width (any CSS length, bv. "240px"). Leeg = stretch.',
 			table: { defaultValue: { summary: '' } },
 		},
 		placeholder: {
@@ -119,14 +114,19 @@ export default {
 			description: 'Disabled state',
 			table: { defaultValue: { summary: false } },
 		},
+		name: {
+			control: 'text',
+			description: 'Name voor form submission',
+		},
+		value: {
+			control: 'text',
+			description: 'Veldwaarde',
+			table: { defaultValue: { summary: '' } },
+		},
 		required: {
 			control: 'boolean',
 			description: 'Required state',
 			table: { defaultValue: { summary: false } },
-		},
-		name: {
-			control: 'text',
-			description: 'Name voor form submission',
 		},
 		autocomplete: {
 			control: 'text',
@@ -136,20 +136,20 @@ export default {
 	},
 };
 
-const Template = ({ size, width, rows, resize, value, placeholder, valid, invalid, readonly, disabled, required, name, autocomplete }: Record<string, any>) => html`
+const Template = ({ size, resize, rows, width, placeholder, valid, invalid, readonly, disabled, name, value, required, autocomplete }: Record<string, any>) => html`
 	<nldd-multi-line-text-field
 		size=${size}
-		width=${width}
-		rows=${rows}
 		resize=${resize}
-		.value=${value}
+		rows=${rows}
+		width=${width}
 		.placeholder=${placeholder}
 		?valid=${valid}
 		?invalid=${invalid}
 		?readonly=${readonly}
 		?disabled=${disabled}
-		?required=${required}
 		name=${name}
+		.value=${value}
+		?required=${required}
 		autocomplete=${autocomplete}
 	></nldd-multi-line-text-field>
 `;

--- a/src/components/inputs/multi-line-text-field/multi-line-text-field.stories.ts
+++ b/src/components/inputs/multi-line-text-field/multi-line-text-field.stories.ts
@@ -1,0 +1,230 @@
+import { action } from 'storybook/actions';
+import { html } from 'lit';
+import './multi-line-text-field.js';
+import '../../forms/form/form.js';
+import '../../forms/form-field/form-field.js';
+import '../../forms/form-actions/form-actions.js';
+import '../../actions/button/button.js';
+import '../../actions/button-group/button-group.js';
+
+/**
+ * `nldd-multi-line-text-field` is een meerregelig tekstveld op basis van
+ * het native `<textarea>` element. Voor enkele regels: zie `nldd-text-field`.
+ *
+ * ### Validatie
+ * Zet `valid` of `invalid` om het bijbehorende validatie-icoon en de
+ * randkleur te tonen.
+ *
+ * ```html
+ * <nldd-multi-line-text-field valid></nldd-multi-line-text-field>
+ * <nldd-multi-line-text-field invalid></nldd-multi-line-text-field>
+ * ```
+ *
+ * ### Hoogte en resize
+ * Met `rows` zet je de initiële (en minimum) hoogte in regels. Het
+ * `resize` attribuut bepaalt hoe het veld kan groeien:
+ *
+ * - `vertical` (default): gebruiker mag verticaal slepen
+ * - `auto`: groeit automatisch mee met de inhoud (`field-sizing: content`)
+ * - `none`: vaste hoogte, geen handle
+ *
+ * ```html
+ * <nldd-multi-line-text-field resize="vertical"></nldd-multi-line-text-field>
+ * <nldd-multi-line-text-field resize="auto"></nldd-multi-line-text-field>
+ * <nldd-multi-line-text-field resize="none"></nldd-multi-line-text-field>
+ * ```
+ *
+ * ### Size
+ * Gebruik `size="sm"` voor de compacte variant. Wordt automatisch gezet
+ * door `nldd-form-field` via diens `size` attribuut.
+ */
+export default {
+	title: 'Components/Inputs/Multi-line Text Field',
+	component: 'nldd-multi-line-text-field',
+	tags: ['autodocs'],
+	parameters: {
+		componentSource: {
+			file: 'src/components/inputs/multi-line-text-field/multi-line-text-field.ts',
+			repository: 'https://github.com/MinBZK/storybook',
+		},
+		status: {
+			type: 'stable',
+		},
+	},
+	args: {
+		size: 'md',
+		width: '',
+		rows: 3,
+		resize: 'vertical',
+		value: '',
+		placeholder: 'Schrijf hier je toelichting',
+		valid: false,
+		invalid: false,
+		readonly: false,
+		disabled: false,
+		required: false,
+		name: '',
+		autocomplete: '',
+	},
+	argTypes: {
+		size: {
+			control: 'select',
+			options: ['sm', 'md'],
+			description: 'Size variant',
+			table: { defaultValue: { summary: 'md' } },
+		},
+		width: {
+			control: 'text',
+			description: 'Optional fixed width (any CSS length, bv. "240px"). Leeg = stretch.',
+			table: { defaultValue: { summary: '' } },
+		},
+		rows: {
+			control: 'number',
+			description: 'Initiële hoogte in regels (minimum)',
+			table: { defaultValue: { summary: '3' } },
+		},
+		resize: {
+			control: 'select',
+			options: ['none', 'vertical', 'auto'],
+			description: 'Resize gedrag. "auto" laat het veld meegroeien met de inhoud.',
+			table: { defaultValue: { summary: 'vertical' } },
+		},
+		value: {
+			control: 'text',
+			description: 'Veldwaarde',
+			table: { defaultValue: { summary: '' } },
+		},
+		placeholder: {
+			control: 'text',
+			description: 'Placeholdertekst',
+			table: { defaultValue: { summary: '' } },
+		},
+		valid: {
+			control: 'boolean',
+			description: 'Valid state',
+			table: { defaultValue: { summary: false } },
+		},
+		invalid: {
+			control: 'boolean',
+			description: 'Invalid state',
+			table: { defaultValue: { summary: false } },
+		},
+		readonly: {
+			control: 'boolean',
+			description: 'Readonly state',
+			table: { defaultValue: { summary: false } },
+		},
+		disabled: {
+			control: 'boolean',
+			description: 'Disabled state',
+			table: { defaultValue: { summary: false } },
+		},
+		required: {
+			control: 'boolean',
+			description: 'Required state',
+			table: { defaultValue: { summary: false } },
+		},
+		name: {
+			control: 'text',
+			description: 'Name voor form submission',
+		},
+		autocomplete: {
+			control: 'text',
+			description: 'Browser autofill hint (HTML autocomplete attribute, bv. "off")',
+			table: { defaultValue: { summary: '' } },
+		},
+	},
+};
+
+const Template = ({ size, width, rows, resize, value, placeholder, valid, invalid, readonly, disabled, required, name, autocomplete }: Record<string, any>) => html`
+	<nldd-multi-line-text-field
+		size=${size}
+		width=${width}
+		rows=${rows}
+		resize=${resize}
+		.value=${value}
+		.placeholder=${placeholder}
+		?valid=${valid}
+		?invalid=${invalid}
+		?readonly=${readonly}
+		?disabled=${disabled}
+		?required=${required}
+		name=${name}
+		autocomplete=${autocomplete}
+	></nldd-multi-line-text-field>
+`;
+
+export const Default = {
+	render: Template,
+};
+
+export const AllStates = {
+	render: () => html`
+		<div style="display: flex; flex-direction: column; gap: 1rem;">
+			<nldd-multi-line-text-field placeholder="Neutral"></nldd-multi-line-text-field>
+			<nldd-multi-line-text-field .value=${'Geldige inhoud op meerdere\nregels'} valid></nldd-multi-line-text-field>
+			<nldd-multi-line-text-field .value=${'Ongeldige inhoud op meerdere\nregels'} invalid></nldd-multi-line-text-field>
+			<nldd-multi-line-text-field .value=${'Disabled'} disabled></nldd-multi-line-text-field>
+			<nldd-multi-line-text-field .value=${'Readonly inhoud die niet bewerkt mag worden.'} readonly></nldd-multi-line-text-field>
+		</div>
+	`,
+	parameters: { controls: { disable: true } },
+};
+
+export const Sizes = {
+	render: () => html`
+		<div style="display: flex; flex-direction: column; gap: 1rem;">
+			<nldd-multi-line-text-field placeholder="Medium (md)"></nldd-multi-line-text-field>
+			<nldd-multi-line-text-field placeholder="Small (sm)" size="sm"></nldd-multi-line-text-field>
+		</div>
+	`,
+	parameters: { controls: { disable: true } },
+};
+
+export const AutoResize = {
+	render: () => html`
+		<nldd-multi-line-text-field
+			placeholder="Typ hier — het veld groeit mee met de inhoud"
+			resize="auto"
+			rows="2"
+		></nldd-multi-line-text-field>
+	`,
+	parameters: { controls: { disable: true } },
+};
+
+export const InteractiveExample = {
+	render: () => html`
+		<nldd-form label-alignment="right" novalidate>
+			<nldd-form-field label="Toelichting">
+				<nldd-multi-line-text-field
+					name="notes"
+					rows="4"
+					@input=${action('input')}
+					@change=${action('change')}
+				></nldd-multi-line-text-field>
+			</nldd-form-field>
+			<nldd-form-field label="Aanvullende opmerkingen">
+				<nldd-multi-line-text-field
+					name="comments"
+					resize="auto"
+					rows="2"
+					@input=${action('input')}
+					@change=${action('change')}
+				></nldd-multi-line-text-field>
+			</nldd-form-field>
+			<nldd-form-actions>
+				<nldd-button-group>
+					<nldd-button variant="primary" type="submit" text="Opslaan"></nldd-button>
+				</nldd-button-group>
+			</nldd-form-actions>
+		</nldd-form>
+	`,
+	parameters: {
+		controls: { disable: true },
+		docs: {
+			description: {
+				story: 'Open de browserconsole om `input` en `change` events te zien.',
+			},
+		},
+	},
+};

--- a/src/components/inputs/multi-line-text-field/multi-line-text-field.stories.ts
+++ b/src/components/inputs/multi-line-text-field/multi-line-text-field.stories.ts
@@ -117,6 +117,7 @@ export default {
 		name: {
 			control: 'text',
 			description: 'Name voor form submission',
+			table: { defaultValue: { summary: '' } },
 		},
 		value: {
 			control: 'text',

--- a/src/components/inputs/multi-line-text-field/multi-line-text-field.styles.ts
+++ b/src/components/inputs/multi-line-text-field/multi-line-text-field.styles.ts
@@ -88,8 +88,11 @@ export const multiLineTextFieldStyles = css`
 		border: none;
 		outline: none;
 		appearance: none;
-		resize: vertical;
 		padding-inline: var(--_inline-padding);
+	}
+
+	:host([resize='vertical']) .multi-line-text-field__input {
+		resize: vertical;
 	}
 
 	:host([resize='none']) .multi-line-text-field__input {

--- a/src/components/inputs/multi-line-text-field/multi-line-text-field.styles.ts
+++ b/src/components/inputs/multi-line-text-field/multi-line-text-field.styles.ts
@@ -1,0 +1,171 @@
+import { css } from 'lit';
+
+export const multiLineTextFieldStyles = css`
+
+
+	/* # Host */
+
+	:host {
+		display: block;
+		--_background-color: var(--semantics-input-fields-background-color);
+		-webkit-tap-highlight-color: transparent;
+	}
+
+	:host([size='sm']) {
+		--_inline-padding: calc(var(--semantics-controls-sm-inline-padding) - var(--semantics-input-fields-border-thickness));
+		--_icon-area-size: calc(var(--semantics-controls-sm-min-size) - var(--semantics-input-fields-border-thickness) * 2);
+	}
+
+	:host([size='md']),
+	:host(:not([size])) {
+		--_inline-padding: calc(var(--semantics-controls-md-inline-padding) - var(--semantics-input-fields-border-thickness));
+		--_icon-area-size: calc(var(--semantics-controls-md-min-size) - var(--semantics-input-fields-border-thickness) * 2);
+	}
+
+	:host([hidden]) {
+		display: none;
+	}
+
+
+	/* # Block */
+
+	.multi-line-text-field {
+		position: relative;
+		display: block;
+		box-sizing: border-box;
+		border: var(--semantics-input-fields-border);
+		background-color: var(--_background-color);
+		overflow: hidden;
+	}
+
+	:host([size='sm']) .multi-line-text-field {
+		border-radius: var(--semantics-controls-sm-corner-radius);
+	}
+
+	:host([size='md']) .multi-line-text-field,
+	:host(:not([size])) .multi-line-text-field {
+		border-radius: var(--semantics-controls-md-corner-radius);
+	}
+
+	:host([valid]) .multi-line-text-field {
+		border-color: var(--semantics-input-fields-is-valid-border-color);
+	}
+
+	:host([invalid]) .multi-line-text-field {
+		border-color: var(--semantics-input-fields-is-invalid-border-color);
+	}
+
+	:host([readonly]) .multi-line-text-field {
+		border-color: var(--semantics-input-fields-is-read-only-border-color);
+		--_background-color: var(--semantics-input-fields-is-read-only-background-color);
+	}
+
+	:host([disabled]) .multi-line-text-field {
+		opacity: var(--primitives-opacity-disabled);
+	}
+
+	.multi-line-text-field:has(textarea:-webkit-autofill),
+	.multi-line-text-field:has(textarea:autofill) {
+		--_background-color: var(--semantics-input-fields-is-autofill-background-color);
+	}
+
+	.multi-line-text-field:focus-within {
+		outline: var(--semantics-focus-ring-outline);
+		outline-offset: var(--semantics-focus-ring-outline-offset);
+		box-shadow: var(--semantics-focus-ring-box-shadow);
+	}
+
+
+	/* # Input */
+
+	.multi-line-text-field__input {
+		display: block;
+		width: 100%;
+		box-sizing: border-box;
+		margin: 0;
+		color: var(--semantics-content-color);
+		background: transparent;
+		border: none;
+		outline: none;
+		appearance: none;
+		resize: vertical;
+		padding-inline: var(--_inline-padding);
+	}
+
+	:host([resize='none']) .multi-line-text-field__input {
+		resize: none;
+	}
+
+	:host([resize='auto']) .multi-line-text-field__input {
+		resize: none;
+		field-sizing: content;
+	}
+
+	:host([size='sm']) .multi-line-text-field__input {
+		font: var(--semantics-input-fields-sm-text-font);
+		padding-block: calc((var(--semantics-controls-sm-min-size) - var(--semantics-input-fields-border-thickness) * 2 - 1lh) / 2);
+		min-height: calc(var(--semantics-controls-sm-min-size) - var(--semantics-input-fields-border-thickness) * 2);
+	}
+
+	:host([size='md']) .multi-line-text-field__input,
+	:host(:not([size])) .multi-line-text-field__input {
+		font: var(--semantics-input-fields-md-text-font);
+		padding-block: calc((var(--semantics-controls-md-min-size) - var(--semantics-input-fields-border-thickness) * 2 - 1lh) / 2);
+		min-height: calc(var(--semantics-controls-md-min-size) - var(--semantics-input-fields-border-thickness) * 2);
+	}
+
+	:host([valid]) .multi-line-text-field__input,
+	:host([invalid]) .multi-line-text-field__input {
+		padding-inline-end: var(--_icon-area-size);
+	}
+
+	:host([disabled]) .multi-line-text-field__input {
+		pointer-events: none;
+	}
+
+	.multi-line-text-field__input::placeholder {
+		color: var(--semantics-input-fields-placeholder-color);
+	}
+
+	.multi-line-text-field__input:-webkit-autofill,
+	.multi-line-text-field__input:autofill {
+		box-shadow: 0 0 0 999px var(--_background-color) inset;
+	}
+
+
+	/* # Validation icon area */
+
+	.multi-line-text-field__validation-icon-area {
+		position: absolute;
+		top: 0;
+		right: 0;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		width: var(--_icon-area-size);
+		height: var(--_icon-area-size);
+		pointer-events: none;
+	}
+
+	:host([valid]) .multi-line-text-field__validation-icon-area {
+		color: var(--semantics-input-fields-is-valid-icon-color);
+	}
+
+	:host([invalid]) .multi-line-text-field__validation-icon-area {
+		color: var(--semantics-input-fields-is-invalid-icon-color);
+	}
+
+
+	/* # Validation icon */
+
+	:host([size='sm']) .multi-line-text-field__validation-icon {
+		width: var(--semantics-input-fields-sm-validation-icon-size);
+		height: var(--semantics-input-fields-sm-validation-icon-size);
+	}
+
+	:host([size='md']) .multi-line-text-field__validation-icon,
+	:host(:not([size])) .multi-line-text-field__validation-icon {
+		width: var(--semantics-input-fields-md-validation-icon-size);
+		height: var(--semantics-input-fields-md-validation-icon-size);
+	}
+`;

--- a/src/components/inputs/multi-line-text-field/multi-line-text-field.template.ts
+++ b/src/components/inputs/multi-line-text-field/multi-line-text-field.template.ts
@@ -1,0 +1,51 @@
+import { html, nothing, TemplateResult } from 'lit';
+import type { NLDDMultiLineTextField } from './multi-line-text-field.js';
+import './../../content/icon/icon.js';
+
+function renderValidationIcon(component: NLDDMultiLineTextField): TemplateResult | typeof nothing {
+	if (component.invalid) {
+		return html`
+			<div class="multi-line-text-field__validation-icon-area">
+				<nldd-icon class="multi-line-text-field__validation-icon"
+					name="invalid"
+					aria-hidden="true"
+				></nldd-icon>
+			</div>
+		`;
+	}
+	if (component.valid) {
+		return html`
+			<div class="multi-line-text-field__validation-icon-area">
+				<nldd-icon class="multi-line-text-field__validation-icon"
+					name="valid"
+					aria-hidden="true"
+				></nldd-icon>
+			</div>
+		`;
+	}
+	return nothing;
+}
+
+export function multiLineTextFieldTemplate(component: NLDDMultiLineTextField): TemplateResult {
+	return html`
+		<div class="multi-line-text-field">
+			<textarea class="multi-line-text-field__input"
+				id=${component.inputId || nothing}
+				rows=${component.rows}
+				.value=${component.value}
+				placeholder=${component.placeholder || nothing}
+				?disabled=${component.disabled}
+				?readonly=${component.readonly}
+				?required=${component.required}
+				name=${component.name || nothing}
+				autocomplete=${component.autocomplete || nothing}
+				aria-label=${component.accessibleLabel || nothing}
+				aria-describedby=${component.errorMessageIds || nothing}
+				aria-invalid=${component.invalid ? 'true' : nothing}
+				@input=${component._handleInput}
+				@change=${component._handleChange}
+			></textarea>
+			${renderValidationIcon(component)}
+		</div>
+	`;
+}

--- a/src/components/inputs/multi-line-text-field/multi-line-text-field.template.ts
+++ b/src/components/inputs/multi-line-text-field/multi-line-text-field.template.ts
@@ -37,7 +37,6 @@ export function multiLineTextFieldTemplate(component: NLDDMultiLineTextField): T
 				?disabled=${component.disabled}
 				?readonly=${component.readonly}
 				?required=${component.required}
-				name=${component.name || nothing}
 				autocomplete=${component.autocomplete || nothing}
 				aria-label=${component.accessibleLabel || nothing}
 				aria-describedby=${component.errorMessageIds || nothing}

--- a/src/components/inputs/multi-line-text-field/multi-line-text-field.test.ts
+++ b/src/components/inputs/multi-line-text-field/multi-line-text-field.test.ts
@@ -161,14 +161,14 @@ describe('nldd-multi-line-text-field', () => {
 		expect(ml.value).toBe('Standaard');
 	});
 
-	it('past inline host width toe als width property gezet is', async () => {
+	it('applies inline host width when the width property is set', async () => {
 		el = await fixture('<nldd-multi-line-text-field width="240px"></nldd-multi-line-text-field>');
 		await waitForUpdate(el);
 		expect(el.getAttribute('width')).toBe('240px');
 		expect((el as HTMLElement).style.width).toBe('240px');
 	});
 
-	it('wist inline textarea dimensies wanneer resize op "auto" wordt gezet', async () => {
+	it('clears inline textarea dimensions when resize is set to "auto"', async () => {
 		el = await fixture('<nldd-multi-line-text-field resize="vertical"></nldd-multi-line-text-field>');
 		await waitForUpdate(el);
 		const textarea = el.shadowRoot!.querySelector('textarea')!;
@@ -181,7 +181,7 @@ describe('nldd-multi-line-text-field', () => {
 		expect(textarea.style.width).toBe('');
 	});
 
-	it('verwijdert inline host width als width leeg wordt gezet', async () => {
+	it('removes inline host width when width is set to empty', async () => {
 		el = await fixture('<nldd-multi-line-text-field width="240px"></nldd-multi-line-text-field>');
 		await waitForUpdate(el);
 		(el as any).width = '';

--- a/src/components/inputs/multi-line-text-field/multi-line-text-field.test.ts
+++ b/src/components/inputs/multi-line-text-field/multi-line-text-field.test.ts
@@ -143,29 +143,22 @@ describe('nldd-multi-line-text-field', () => {
 	});
 
 	it('participates in FormData via form-associated API', async () => {
-		const form = document.createElement('form');
-		document.body.appendChild(form);
-		el = document.createElement('nldd-multi-line-text-field');
-		el.setAttribute('name', 'notes');
-		(el as any).value = 'Eerste regel\nTweede regel';
-		form.appendChild(el);
-		await waitForUpdate(el);
-		const data = new FormData(form);
-		expect(data.get('notes')).toBe('Eerste regel\nTweede regel');
-		form.remove();
+		const form = await fixture<HTMLFormElement>('<form><nldd-multi-line-text-field name="notes" value="Eerste regel"></nldd-multi-line-text-field></form>');
+		el = form;
+		const ml = form.querySelector('nldd-multi-line-text-field')!;
+		await waitForUpdate(ml);
+		expect(new FormData(form).get('notes')).toBe('Eerste regel');
 	});
 
 	it('resets to the HTML-declared initial value when the parent form is reset', async () => {
-		const form = document.createElement('form');
-		document.body.appendChild(form);
-		form.innerHTML = '<nldd-multi-line-text-field name="notes" value="Standaard"></nldd-multi-line-text-field>';
-		el = form.querySelector('nldd-multi-line-text-field')!;
-		await waitForUpdate(el);
-		(el as any).value = 'Aangepaste tekst';
-		await waitForUpdate(el);
+		const form = await fixture<HTMLFormElement>('<form><nldd-multi-line-text-field name="notes" value="Standaard"></nldd-multi-line-text-field></form>');
+		el = form;
+		const ml = form.querySelector('nldd-multi-line-text-field')! as HTMLElement & { value: string };
+		await waitForUpdate(ml);
+		ml.value = 'Aangepaste tekst';
+		await waitForUpdate(ml);
 		form.reset();
-		expect((el as any).value).toBe('Standaard');
-		form.remove();
+		expect(ml.value).toBe('Standaard');
 	});
 
 	it('past inline host width toe als width property gezet is', async () => {

--- a/src/components/inputs/multi-line-text-field/multi-line-text-field.test.ts
+++ b/src/components/inputs/multi-line-text-field/multi-line-text-field.test.ts
@@ -142,6 +142,32 @@ describe('nldd-multi-line-text-field', () => {
 		expect(textarea.hasAttribute('aria-describedby')).toBe(false);
 	});
 
+	it('participates in FormData via form-associated API', async () => {
+		const form = document.createElement('form');
+		document.body.appendChild(form);
+		el = document.createElement('nldd-multi-line-text-field');
+		el.setAttribute('name', 'notes');
+		(el as any).value = 'Eerste regel\nTweede regel';
+		form.appendChild(el);
+		await waitForUpdate(el);
+		const data = new FormData(form);
+		expect(data.get('notes')).toBe('Eerste regel\nTweede regel');
+		form.remove();
+	});
+
+	it('resets to the HTML-declared initial value when the parent form is reset', async () => {
+		const form = document.createElement('form');
+		document.body.appendChild(form);
+		form.innerHTML = '<nldd-multi-line-text-field name="notes" value="Standaard"></nldd-multi-line-text-field>';
+		el = form.querySelector('nldd-multi-line-text-field')!;
+		await waitForUpdate(el);
+		(el as any).value = 'Aangepaste tekst';
+		await waitForUpdate(el);
+		form.reset();
+		expect((el as any).value).toBe('Standaard');
+		form.remove();
+	});
+
 	it('past inline host width toe als width property gezet is', async () => {
 		el = await fixture('<nldd-multi-line-text-field width="240px"></nldd-multi-line-text-field>');
 		await waitForUpdate(el);

--- a/src/components/inputs/multi-line-text-field/multi-line-text-field.test.ts
+++ b/src/components/inputs/multi-line-text-field/multi-line-text-field.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { fixture, cleanup, waitForUpdate } from '../../../test-utils.js';
+import './multi-line-text-field.js';
+
+describe('nldd-multi-line-text-field', () => {
+	let el: HTMLElement;
+
+	afterEach(() => {
+		if (el) cleanup(el);
+	});
+
+	it('renders without error', async () => {
+		el = await fixture('<nldd-multi-line-text-field></nldd-multi-line-text-field>');
+		await waitForUpdate(el);
+		expect(el.shadowRoot).not.toBeNull();
+	});
+
+	it('renders a native textarea', async () => {
+		el = await fixture('<nldd-multi-line-text-field></nldd-multi-line-text-field>');
+		await waitForUpdate(el);
+		expect(el.shadowRoot!.querySelector('textarea')).not.toBeNull();
+	});
+
+	it('renders valid icon when valid attribute is set', async () => {
+		el = await fixture('<nldd-multi-line-text-field valid></nldd-multi-line-text-field>');
+		await waitForUpdate(el);
+		const icon = el.shadowRoot!.querySelector('.multi-line-text-field__validation-icon-area nldd-icon');
+		expect(icon).not.toBeNull();
+		expect(icon!.getAttribute('name')).toBe('valid');
+	});
+
+	it('renders invalid icon when invalid attribute is set', async () => {
+		el = await fixture('<nldd-multi-line-text-field invalid></nldd-multi-line-text-field>');
+		await waitForUpdate(el);
+		const icon = el.shadowRoot!.querySelector('.multi-line-text-field__validation-icon-area nldd-icon');
+		expect(icon).not.toBeNull();
+		expect(icon!.getAttribute('name')).toBe('invalid');
+	});
+
+	it('does not render validation icon in neutral state', async () => {
+		el = await fixture('<nldd-multi-line-text-field></nldd-multi-line-text-field>');
+		await waitForUpdate(el);
+		const area = el.shadowRoot!.querySelector('.multi-line-text-field__validation-icon-area');
+		expect(area).toBeNull();
+	});
+
+	it('dispatches custom input event on input', async () => {
+		el = await fixture('<nldd-multi-line-text-field></nldd-multi-line-text-field>');
+		await waitForUpdate(el);
+		const handler = vi.fn();
+		el.addEventListener('input', handler);
+		const textarea = el.shadowRoot!.querySelector('textarea')!;
+		textarea.value = 'hello\nworld';
+		textarea.dispatchEvent(new Event('input', { bubbles: true, composed: true }));
+		expect(handler).toHaveBeenCalledOnce();
+		expect(handler.mock.calls[0][0].detail.value).toBe('hello\nworld');
+	});
+
+	it('dispatches custom change event on change', async () => {
+		el = await fixture('<nldd-multi-line-text-field></nldd-multi-line-text-field>');
+		await waitForUpdate(el);
+		const handler = vi.fn();
+		el.addEventListener('change', handler);
+		const textarea = el.shadowRoot!.querySelector('textarea')!;
+		textarea.value = 'committed';
+		textarea.dispatchEvent(new Event('change', { bubbles: true, composed: true }));
+		expect(handler).toHaveBeenCalledOnce();
+		expect(handler.mock.calls[0][0].detail.value).toBe('committed');
+	});
+
+	it('does not double-fire input event', async () => {
+		el = await fixture('<nldd-multi-line-text-field></nldd-multi-line-text-field>');
+		await waitForUpdate(el);
+		const handler = vi.fn();
+		el.addEventListener('input', handler);
+		const textarea = el.shadowRoot!.querySelector('textarea')!;
+		textarea.value = 'test';
+		textarea.dispatchEvent(new Event('input', { bubbles: true, composed: true }));
+		expect(handler).toHaveBeenCalledOnce();
+	});
+
+	it('reflects disabled attribute to host', async () => {
+		el = await fixture('<nldd-multi-line-text-field disabled></nldd-multi-line-text-field>');
+		await waitForUpdate(el);
+		expect(el.hasAttribute('disabled')).toBe(true);
+		const textarea = el.shadowRoot!.querySelector('textarea')!;
+		expect(textarea.disabled).toBe(true);
+	});
+
+	it('reflects readonly attribute to host', async () => {
+		el = await fixture('<nldd-multi-line-text-field readonly></nldd-multi-line-text-field>');
+		await waitForUpdate(el);
+		expect(el.hasAttribute('readonly')).toBe(true);
+		const textarea = el.shadowRoot!.querySelector('textarea')!;
+		expect(textarea.readOnly).toBe(true);
+	});
+
+	it('reflects size attribute to host', async () => {
+		el = await fixture('<nldd-multi-line-text-field size="sm"></nldd-multi-line-text-field>');
+		await waitForUpdate(el);
+		expect(el.getAttribute('size')).toBe('sm');
+	});
+
+	it('reflects resize attribute to host', async () => {
+		el = await fixture('<nldd-multi-line-text-field resize="auto"></nldd-multi-line-text-field>');
+		await waitForUpdate(el);
+		expect(el.getAttribute('resize')).toBe('auto');
+	});
+
+	it('passes rows attribute to inner textarea', async () => {
+		el = await fixture('<nldd-multi-line-text-field rows="5"></nldd-multi-line-text-field>');
+		await waitForUpdate(el);
+		const textarea = el.shadowRoot!.querySelector('textarea')!;
+		expect(textarea.rows).toBe(5);
+	});
+
+	it('defaults to rows="3"', async () => {
+		el = await fixture('<nldd-multi-line-text-field></nldd-multi-line-text-field>');
+		await waitForUpdate(el);
+		const textarea = el.shadowRoot!.querySelector('textarea')!;
+		expect(textarea.rows).toBe(3);
+	});
+
+	it('forwards accessible-label to the inner textarea', async () => {
+		el = await fixture('<nldd-multi-line-text-field accessible-label="Toelichting"></nldd-multi-line-text-field>');
+		await waitForUpdate(el);
+		const textarea = el.shadowRoot!.querySelector('textarea')!;
+		expect(textarea.getAttribute('aria-label')).toBe('Toelichting');
+	});
+
+	it('forwards error-message-ids to inner textarea aria-describedby', async () => {
+		el = await fixture('<nldd-multi-line-text-field error-message-ids="help-1 error-1"></nldd-multi-line-text-field>');
+		await waitForUpdate(el);
+		const textarea = el.shadowRoot!.querySelector('textarea')!;
+		expect(textarea.getAttribute('aria-describedby')).toBe('help-1 error-1');
+	});
+
+	it('omits aria-describedby from inner textarea when error-message-ids not set', async () => {
+		el = await fixture('<nldd-multi-line-text-field></nldd-multi-line-text-field>');
+		await waitForUpdate(el);
+		const textarea = el.shadowRoot!.querySelector('textarea')!;
+		expect(textarea.hasAttribute('aria-describedby')).toBe(false);
+	});
+
+	it('past inline host width toe als width property gezet is', async () => {
+		el = await fixture('<nldd-multi-line-text-field width="240px"></nldd-multi-line-text-field>');
+		await waitForUpdate(el);
+		expect(el.getAttribute('width')).toBe('240px');
+		expect((el as HTMLElement).style.width).toBe('240px');
+	});
+
+	it('wist inline textarea dimensies wanneer resize op "auto" wordt gezet', async () => {
+		el = await fixture('<nldd-multi-line-text-field resize="vertical"></nldd-multi-line-text-field>');
+		await waitForUpdate(el);
+		const textarea = el.shadowRoot!.querySelector('textarea')!;
+		// Simulate a manual resize: browser writes inline height on the textarea
+		textarea.style.height = '200px';
+		textarea.style.width = '300px';
+		(el as any).resize = 'auto';
+		await waitForUpdate(el);
+		expect(textarea.style.height).toBe('');
+		expect(textarea.style.width).toBe('');
+	});
+
+	it('verwijdert inline host width als width leeg wordt gezet', async () => {
+		el = await fixture('<nldd-multi-line-text-field width="240px"></nldd-multi-line-text-field>');
+		await waitForUpdate(el);
+		(el as any).width = '';
+		await waitForUpdate(el);
+		expect((el as HTMLElement).style.width).toBe('');
+	});
+});

--- a/src/components/inputs/multi-line-text-field/multi-line-text-field.ts
+++ b/src/components/inputs/multi-line-text-field/multi-line-text-field.ts
@@ -1,0 +1,150 @@
+/**
+ * Nederlandse Digitale Dienst Multi-line Text Field Component (Lit + TypeScript)
+ *
+ * @element nldd-multi-line-text-field
+ *
+ * @attr {string} value           - The textarea value
+ * @attr {string} placeholder     - Placeholder text
+ * @attr {string} input-id        - Sets the id on the native textarea. Set automatically by nldd-form-field.
+ * @attr {string} size            - 'md' (default) | 'sm'. Set automatically by nldd-form-field.
+ * @attr {boolean} invalid        - Marks the field as invalid
+ * @attr {boolean} valid          - Marks the field as valid
+ * @attr {boolean} disabled       - Disabled state
+ * @attr {string} name            - Textarea name for form submission
+ * @attr {boolean} readonly       - Readonly state
+ * @attr {boolean} required       - Required state
+ * @attr {string} autocomplete    - Autocomplete hint
+ * @attr {number} rows            - Initial visible rows (minimum height). Default: 3.
+ * @attr {string} resize          - 'none' | 'vertical' (default) | 'auto'.
+ *                                  'auto' grows with content (native field-sizing), no manual handle.
+ * @attr {string} accessible-label - Accessible label forwarded to the inner textarea. Set automatically by nldd-form-field.
+ * @attr {string} width           - Optional fixed width (any CSS length, e.g. "240px"). Default: full-width.
+ *
+ * @fires input  - When value changes
+ * @fires change - When value is committed (blur)
+ *
+ * @csspart container - The field container
+ * @csspart textarea  - The native textarea element
+ */
+import { LitElement, type PropertyValues } from 'lit';
+import { customElement, property, query } from 'lit/decorators.js';
+import { multiLineTextFieldStyles } from './multi-line-text-field.styles.js';
+import { multiLineTextFieldTemplate } from './multi-line-text-field.template.js';
+
+export type ResizeMode = 'none' | 'vertical' | 'auto';
+
+@customElement('nldd-multi-line-text-field')
+export class NLDDMultiLineTextField extends LitElement {
+	static override shadowRootOptions = {
+		...LitElement.shadowRootOptions,
+		delegatesFocus: true,
+	};
+
+	static override styles = multiLineTextFieldStyles;
+
+	@property({ type: String, reflect: true })
+	size: 'md' | 'sm' = 'md';
+
+	@property({ type: String })
+	value = '';
+
+	@property({ type: String, attribute: 'input-id' })
+	inputId = '';
+
+	@property({ type: String })
+	placeholder = '';
+
+	@property({ type: Boolean, reflect: true })
+	invalid = false;
+
+	@property({ type: Boolean, reflect: true })
+	valid = false;
+
+	@property({ type: Boolean, reflect: true })
+	disabled = false;
+
+	@property({ type: String })
+	name = '';
+
+	@property({ type: Boolean, reflect: true })
+	readonly = false;
+
+	@property({ type: Boolean, reflect: true })
+	required = false;
+
+	@property({ type: String })
+	autocomplete = '';
+
+	@property({ type: Number })
+	rows = 3;
+
+	@property({ type: String, reflect: true })
+	resize: ResizeMode = 'vertical';
+
+	/** Accessible label forwarded to the inner <textarea>. Set automatically by nldd-form-field. */
+	@property({ type: String, attribute: 'accessible-label' })
+	accessibleLabel = '';
+
+	@property({ type: String, attribute: 'error-message-ids' })
+	errorMessageIds = '';
+
+	/** Optional fixed width (any CSS length). When unset, the field stretches to fill its container. */
+	@property({ type: String, reflect: true })
+	width = '';
+
+
+	@query('.multi-line-text-field__input')
+	private _textarea!: HTMLTextAreaElement;
+
+	override updated(changed: PropertyValues): void {
+		if (changed.has('width')) {
+			this.style.width = this.width || '';
+		}
+		if (changed.has('resize') && this.resize === 'auto' && this._textarea) {
+			// Manual resize sets inline width/height on the textarea, which would
+			// override field-sizing: content. Clear them when switching to auto.
+			this._textarea.style.width = '';
+			this._textarea.style.height = '';
+		}
+	}
+
+	public _handleInput(e: Event): void {
+		e.stopPropagation();
+		const textarea = e.target as HTMLTextAreaElement;
+		this.value = textarea.value;
+		this.dispatchEvent(new CustomEvent('input', {
+			detail: { value: this.value },
+			bubbles: true,
+			composed: true,
+		}));
+	}
+
+	public _handleChange(e: Event): void {
+		e.stopPropagation();
+		const textarea = e.target as HTMLTextAreaElement;
+		this.value = textarea.value;
+		this.dispatchEvent(new CustomEvent('change', {
+			detail: { value: this.value },
+			bubbles: true,
+			composed: true,
+		}));
+	}
+
+	public focus(): void {
+		this._textarea?.focus();
+	}
+
+	public blur(): void {
+		this._textarea?.blur();
+	}
+
+	override render() {
+		return multiLineTextFieldTemplate(this);
+	}
+}
+
+declare global {
+	interface HTMLElementTagNameMap {
+		'nldd-multi-line-text-field': NLDDMultiLineTextField;
+	}
+}

--- a/src/components/inputs/multi-line-text-field/multi-line-text-field.ts
+++ b/src/components/inputs/multi-line-text-field/multi-line-text-field.ts
@@ -46,6 +46,8 @@ export class NLDDMultiLineTextField extends LitElement {
 
 	private _internals = this.attachInternals();
 
+	private _initialValue = '';
+
 	@property({ type: String, reflect: true })
 	size: 'md' | 'sm' = 'md';
 
@@ -67,7 +69,7 @@ export class NLDDMultiLineTextField extends LitElement {
 	@property({ type: Boolean, reflect: true })
 	disabled = false;
 
-	@property({ type: String })
+	@property({ type: String, reflect: true })
 	name = '';
 
 	@property({ type: Boolean, reflect: true })
@@ -100,6 +102,10 @@ export class NLDDMultiLineTextField extends LitElement {
 	@query('.multi-line-text-field__input')
 	private _textarea!: HTMLTextAreaElement;
 
+	override firstUpdated(): void {
+		this._initialValue = this.value;
+	}
+
 	override updated(changed: PropertyValues): void {
 		if (changed.has('width')) {
 			this.style.width = this.width || '';
@@ -116,7 +122,7 @@ export class NLDDMultiLineTextField extends LitElement {
 	}
 
 	formResetCallback(): void {
-		this.value = '';
+		this.value = this._initialValue;
 	}
 
 	formDisabledCallback(disabled: boolean): void {
@@ -147,14 +153,6 @@ export class NLDDMultiLineTextField extends LitElement {
 			bubbles: true,
 			composed: true,
 		}));
-	}
-
-	public focus(): void {
-		this._textarea?.focus();
-	}
-
-	public blur(): void {
-		this._textarea?.blur();
 	}
 
 	override render() {

--- a/src/components/inputs/multi-line-text-field/multi-line-text-field.ts
+++ b/src/components/inputs/multi-line-text-field/multi-line-text-field.ts
@@ -35,12 +35,16 @@ export type ResizeMode = 'none' | 'vertical' | 'auto';
 
 @customElement('nldd-multi-line-text-field')
 export class NLDDMultiLineTextField extends LitElement {
+	static formAssociated = true;
+
 	static override shadowRootOptions = {
 		...LitElement.shadowRootOptions,
 		delegatesFocus: true,
 	};
 
 	static override styles = multiLineTextFieldStyles;
+
+	private _internals = this.attachInternals();
 
 	@property({ type: String, reflect: true })
 	size: 'md' | 'sm' = 'md';
@@ -106,6 +110,21 @@ export class NLDDMultiLineTextField extends LitElement {
 			this._textarea.style.width = '';
 			this._textarea.style.height = '';
 		}
+		if (changed.has('value')) {
+			this._internals.setFormValue(this.value);
+		}
+	}
+
+	formResetCallback(): void {
+		this.value = '';
+	}
+
+	formDisabledCallback(disabled: boolean): void {
+		this.disabled = disabled;
+	}
+
+	formStateRestoreCallback(state: string): void {
+		if (typeof state === 'string') this.value = state;
 	}
 
 	public _handleInput(e: Event): void {

--- a/src/components/inputs/multi-line-text-field/multi-line-text-field.ts
+++ b/src/components/inputs/multi-line-text-field/multi-line-text-field.ts
@@ -22,9 +22,6 @@
  *
  * @fires input  - When value changes
  * @fires change - When value is committed (blur)
- *
- * @csspart container - The field container
- * @csspart textarea  - The native textarea element
  */
 import { LitElement, type PropertyValues } from 'lit';
 import { customElement, property, query } from 'lit/decorators.js';
@@ -104,6 +101,9 @@ export class NLDDMultiLineTextField extends LitElement {
 
 	override firstUpdated(): void {
 		this._initialValue = this.value;
+		if (import.meta.env?.DEV && !this.accessibleLabel && !this.inputId) {
+			console.warn('<nldd-multi-line-text-field>: No accessible-label or input-id provided. Use nldd-form-field for labeled usage, or set accessible-label for screen reader accessibility.');
+		}
 	}
 
 	override updated(changed: PropertyValues): void {
@@ -129,7 +129,7 @@ export class NLDDMultiLineTextField extends LitElement {
 		this.disabled = disabled;
 	}
 
-	formStateRestoreCallback(state: string): void {
+	formStateRestoreCallback(state: File | string | FormData | null): void {
 		if (typeof state === 'string') this.value = state;
 	}
 

--- a/src/components/inputs/number-field/number-field.test.ts
+++ b/src/components/inputs/number-field/number-field.test.ts
@@ -421,4 +421,23 @@ describe('nldd-number-field – hide-spin-buttons', () => {
 		expect(decrement).not.toBeNull();
 		expect(increment).not.toBeNull();
 	});
+
+	it('participates in FormData via form-associated API', async () => {
+		const form = await fixture<HTMLFormElement>('<form><nldd-number-field name="qty" value="5"></nldd-number-field></form>');
+		el = form;
+		const nf = form.querySelector('nldd-number-field')!;
+		await waitForUpdate(nf);
+		expect(new FormData(form).get('qty')).toBe('5');
+	});
+
+	it('resets to the HTML-declared initial value when the parent form is reset', async () => {
+		const form = await fixture<HTMLFormElement>('<form><nldd-number-field name="qty" value="3"></nldd-number-field></form>');
+		el = form;
+		const nf = form.querySelector<NLDDNumberField>('nldd-number-field')!;
+		await waitForUpdate(nf);
+		nf.value = 7;
+		await waitForUpdate(nf);
+		form.reset();
+		expect(nf.value).toBe(3);
+	});
 });

--- a/src/components/inputs/number-field/number-field.ts
+++ b/src/components/inputs/number-field/number-field.ts
@@ -63,7 +63,7 @@ export class NLDDNumberField extends LitElement {
 	@property({ type: Boolean, reflect: true })
 	disabled = false;
 
-	@property({ type: String })
+	@property({ type: String, reflect: true })
 	name = '';
 
 	@property({ type: Boolean, reflect: true, attribute: 'full-width' })

--- a/src/components/inputs/number-field/number-field.ts
+++ b/src/components/inputs/number-field/number-field.ts
@@ -123,7 +123,7 @@ export class NLDDNumberField extends LitElement {
 	formStateRestoreCallback(state: File | string | FormData | null): void {
 		if (typeof state !== 'string') return;
 		const parsed = parseFloat(state);
-		if (!isNaN(parsed)) this.value = parsed;
+		if (!isNaN(parsed)) this.value = this._clamp(parsed);
 	}
 
 	// — i18n —————————————————————————————————————————————————————————————————

--- a/src/components/inputs/number-field/number-field.ts
+++ b/src/components/inputs/number-field/number-field.ts
@@ -120,7 +120,8 @@ export class NLDDNumberField extends LitElement {
 		this.disabled = disabled;
 	}
 
-	formStateRestoreCallback(state: string): void {
+	formStateRestoreCallback(state: File | string | FormData | null): void {
+		if (typeof state !== 'string') return;
 		const parsed = parseFloat(state);
 		if (!isNaN(parsed)) this.value = parsed;
 	}

--- a/src/components/inputs/number-field/number-field.ts
+++ b/src/components/inputs/number-field/number-field.ts
@@ -43,6 +43,8 @@ export class NLDDNumberField extends LitElement {
 
 	private _internals = this.attachInternals();
 
+	private _initialValue = 0;
+
 	@property({ type: Number })
 	value = 0;
 
@@ -92,6 +94,7 @@ export class NLDDNumberField extends LitElement {
 			console.warn('<nldd-number-field>: No accessible-label provided. Add an accessible-label attribute so screen readers can announce the input\'s purpose.');
 		}
 		this._lastValidValue = this._clamp(this.value);
+		this._initialValue = this._lastValidValue;
 	}
 
 	override updated(changedProperties: Map<string, unknown>): void {
@@ -110,7 +113,7 @@ export class NLDDNumberField extends LitElement {
 	}
 
 	formResetCallback(): void {
-		this.value = 0;
+		this.value = this._initialValue;
 	}
 
 	formDisabledCallback(disabled: boolean): void {

--- a/src/components/inputs/number-field/number-field.ts
+++ b/src/components/inputs/number-field/number-field.ts
@@ -37,7 +37,11 @@ export type NumberFieldSize = 'sm' | 'md';
 
 @customElement('nldd-number-field')
 export class NLDDNumberField extends LitElement {
+	static formAssociated = true;
+
 	static override styles = numberFieldStyles;
+
+	private _internals = this.attachInternals();
 
 	@property({ type: Number })
 	value = 0;
@@ -100,6 +104,22 @@ export class NLDDNumberField extends LitElement {
 				this.removeAttribute('width');
 			}
 		}
+		if (changedProperties.has('value')) {
+			this._internals.setFormValue(String(this.value));
+		}
+	}
+
+	formResetCallback(): void {
+		this.value = 0;
+	}
+
+	formDisabledCallback(disabled: boolean): void {
+		this.disabled = disabled;
+	}
+
+	formStateRestoreCallback(state: string): void {
+		const parsed = parseFloat(state);
+		if (!isNaN(parsed)) this.value = parsed;
 	}
 
 	// — i18n —————————————————————————————————————————————————————————————————

--- a/src/components/inputs/password-field/password-field.test.ts
+++ b/src/components/inputs/password-field/password-field.test.ts
@@ -218,4 +218,23 @@ describe('nldd-password-field', () => {
 		expect(el.getAttribute('width')).toBe('240px');
 		expect((el as HTMLElement).style.width).toBe('240px');
 	});
+
+	it('participates in FormData via form-associated API', async () => {
+		const form = await fixture<HTMLFormElement>('<form><nldd-password-field name="pw" value="secret"></nldd-password-field></form>');
+		el = form;
+		const pw = form.querySelector('nldd-password-field')!;
+		await waitForUpdate(pw);
+		expect(new FormData(form).get('pw')).toBe('secret');
+	});
+
+	it('resets to the HTML-declared initial value when the parent form is reset', async () => {
+		const form = await fixture<HTMLFormElement>('<form><nldd-password-field name="pw" value="default"></nldd-password-field></form>');
+		el = form;
+		const pw = form.querySelector('nldd-password-field')! as HTMLElement & { value: string };
+		await waitForUpdate(pw);
+		pw.value = 'changed';
+		await waitForUpdate(pw);
+		form.reset();
+		expect(pw.value).toBe('default');
+	});
 });

--- a/src/components/inputs/password-field/password-field.ts
+++ b/src/components/inputs/password-field/password-field.ts
@@ -97,7 +97,7 @@ export class NLDDPasswordField extends LitElement {
 	@property({ type: Boolean, reflect: true })
 	required = false;
 
-	@property({ type: String })
+	@property({ type: String, reflect: true })
 	name = '';
 
 	@property({ type: String })

--- a/src/components/inputs/password-field/password-field.ts
+++ b/src/components/inputs/password-field/password-field.ts
@@ -26,10 +26,6 @@
  *
  * @fires input  - When the input value changes ({ detail: { value } })
  * @fires change - When the input value is committed ({ detail: { value } })
- *
- * @csspart field  - The field container
- * @csspart input  - The native input element
- * @csspart toggle - The toggle button wrapper
  */
 import { LitElement, type PropertyValues } from 'lit';
 import { customElement, property, query } from 'lit/decorators.js';
@@ -138,7 +134,7 @@ export class NLDDPasswordField extends LitElement {
 		this.disabled = disabled;
 	}
 
-	formStateRestoreCallback(state: string): void {
+	formStateRestoreCallback(state: File | string | FormData | null): void {
 		if (typeof state === 'string') this.value = state;
 	}
 

--- a/src/components/inputs/password-field/password-field.ts
+++ b/src/components/inputs/password-field/password-field.ts
@@ -38,12 +38,16 @@ import { passwordFieldTemplate } from './password-field.template.js';
 
 @customElement('nldd-password-field')
 export class NLDDPasswordField extends LitElement {
+	static formAssociated = true;
+
 	static override shadowRootOptions = {
 		...LitElement.shadowRootOptions,
 		delegatesFocus: true,
 	};
 
 	static override styles = passwordFieldStyles;
+
+	private _internals = this.attachInternals();
 
 	@property({ type: String, reflect: true })
 	size: 'md' | 'sm' = 'md';
@@ -115,6 +119,21 @@ export class NLDDPasswordField extends LitElement {
 		if (changed.has('width')) {
 			this.style.width = this.width || '';
 		}
+		if (changed.has('value')) {
+			this._internals.setFormValue(this.value);
+		}
+	}
+
+	formResetCallback(): void {
+		this.value = '';
+	}
+
+	formDisabledCallback(disabled: boolean): void {
+		this.disabled = disabled;
+	}
+
+	formStateRestoreCallback(state: string): void {
+		if (typeof state === 'string') this.value = state;
 	}
 
 	public _handleInput(e: Event): void {

--- a/src/components/inputs/password-field/password-field.ts
+++ b/src/components/inputs/password-field/password-field.ts
@@ -49,6 +49,8 @@ export class NLDDPasswordField extends LitElement {
 
 	private _internals = this.attachInternals();
 
+	private _initialValue = '';
+
 	@property({ type: String, reflect: true })
 	size: 'md' | 'sm' = 'md';
 
@@ -115,6 +117,10 @@ export class NLDDPasswordField extends LitElement {
 	@query('.password-field__input')
 	private _input!: HTMLInputElement;
 
+	override firstUpdated(): void {
+		this._initialValue = this.value;
+	}
+
 	override updated(changed: PropertyValues): void {
 		if (changed.has('width')) {
 			this.style.width = this.width || '';
@@ -125,7 +131,7 @@ export class NLDDPasswordField extends LitElement {
 	}
 
 	formResetCallback(): void {
-		this.value = '';
+		this.value = this._initialValue;
 	}
 
 	formDisabledCallback(disabled: boolean): void {

--- a/src/components/inputs/radio-button/radio-button.test.ts
+++ b/src/components/inputs/radio-button/radio-button.test.ts
@@ -106,4 +106,31 @@ describe('nldd-radio-button – change event', () => {
 		expect(detail.value).toBe('option-a');
 		expect(detail.name).toBe('group1');
 	});
+
+	it('participates in FormData when checked', async () => {
+		const form = await fixture<HTMLFormElement>('<form><nldd-radio-button name="opt" value="a" checked></nldd-radio-button></form>');
+		el = form;
+		const rb = form.querySelector('nldd-radio-button')!;
+		await waitForUpdate(rb);
+		expect(new FormData(form).get('opt')).toBe('a');
+	});
+
+	it('is omitted from FormData when unchecked', async () => {
+		const form = await fixture<HTMLFormElement>('<form><nldd-radio-button name="opt" value="a"></nldd-radio-button></form>');
+		el = form;
+		const rb = form.querySelector('nldd-radio-button')!;
+		await waitForUpdate(rb);
+		expect(new FormData(form).has('opt')).toBe(false);
+	});
+
+	it('resets to the HTML-declared initial checked state when the parent form is reset', async () => {
+		const form = await fixture<HTMLFormElement>('<form><nldd-radio-button name="opt" value="a" checked></nldd-radio-button></form>');
+		el = form;
+		const rb = form.querySelector<NLDDRadioButton>('nldd-radio-button')!;
+		await waitForUpdate(rb);
+		rb.checked = false;
+		await waitForUpdate(rb);
+		form.reset();
+		expect(rb.checked).toBe(true);
+	});
 });

--- a/src/components/inputs/radio-button/radio-button.ts
+++ b/src/components/inputs/radio-button/radio-button.ts
@@ -70,7 +70,7 @@ export class NLDDRadioButton extends LitElement {
 		this.disabled = disabled;
 	}
 
-	formStateRestoreCallback(state: string | null): void {
+	formStateRestoreCallback(state: File | string | FormData | null): void {
 		this.checked = state !== null;
 	}
 

--- a/src/components/inputs/radio-button/radio-button.ts
+++ b/src/components/inputs/radio-button/radio-button.ts
@@ -43,7 +43,7 @@ export class NLDDRadioButton extends LitElement {
 	@property({ type: Boolean, reflect: true })
 	required = false;
 
-	@property({ type: String })
+	@property({ type: String, reflect: true })
 	name = '';
 
 	@property({ type: String })

--- a/src/components/inputs/radio-button/radio-button.ts
+++ b/src/components/inputs/radio-button/radio-button.ts
@@ -19,14 +19,20 @@
  *
  * @fires change - When checked state changes; detail: { checked: boolean, value: string, name: string }
  */
-import { LitElement } from 'lit';
+import { LitElement, type PropertyValues } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { radioButtonStyles } from './radio-button.styles.js';
 import { radioButtonTemplate } from './radio-button.template.js';
 
 @customElement('nldd-radio-button')
 export class NLDDRadioButton extends LitElement {
+	static formAssociated = true;
+
 	static override styles = radioButtonStyles;
+
+	private _internals = this.attachInternals();
+
+	private _initialChecked = false;
 
 	@property({ type: Boolean, reflect: true })
 	checked = false;
@@ -45,6 +51,28 @@ export class NLDDRadioButton extends LitElement {
 
 	@property({ type: String, attribute: 'accessible-label' })
 	accessibleLabel = '';
+
+	override firstUpdated(): void {
+		this._initialChecked = this.checked;
+	}
+
+	override updated(changed: PropertyValues): void {
+		if (changed.has('checked') || changed.has('value')) {
+			this._internals.setFormValue(this.checked ? this.value : null);
+		}
+	}
+
+	formResetCallback(): void {
+		this.checked = this._initialChecked;
+	}
+
+	formDisabledCallback(disabled: boolean): void {
+		this.disabled = disabled;
+	}
+
+	formStateRestoreCallback(state: string | null): void {
+		this.checked = state !== null;
+	}
 
 	public select(): void {
 		if (this.disabled || this.checked) return;

--- a/src/components/inputs/search-field/search-field.test.ts
+++ b/src/components/inputs/search-field/search-field.test.ts
@@ -219,4 +219,23 @@ describe('nldd-search-field – dismiss', () => {
 		expect(el.getAttribute('width')).toBe('240px');
 		expect((el as HTMLElement).style.width).toBe('240px');
 	});
+
+	it('participates in FormData via form-associated API', async () => {
+		const form = await fixture<HTMLFormElement>('<form><nldd-search-field name="q" value="zoekterm"></nldd-search-field></form>');
+		el = form;
+		const sf = form.querySelector('nldd-search-field')!;
+		await waitForUpdate(sf);
+		expect(new FormData(form).get('q')).toBe('zoekterm');
+	});
+
+	it('resets to the HTML-declared initial value when the parent form is reset', async () => {
+		const form = await fixture<HTMLFormElement>('<form><nldd-search-field name="q" value="default"></nldd-search-field></form>');
+		el = form;
+		const sf = form.querySelector<NLDDSearchField>('nldd-search-field')!;
+		await waitForUpdate(sf);
+		sf.value = 'changed';
+		await waitForUpdate(sf);
+		form.reset();
+		expect(sf.value).toBe('default');
+	});
 });

--- a/src/components/inputs/search-field/search-field.ts
+++ b/src/components/inputs/search-field/search-field.ts
@@ -102,7 +102,7 @@ export class NLDDSearchField extends LitElement {
 		this.disabled = disabled;
 	}
 
-	formStateRestoreCallback(state: string): void {
+	formStateRestoreCallback(state: File | string | FormData | null): void {
 		if (typeof state === 'string') this.value = state;
 	}
 

--- a/src/components/inputs/search-field/search-field.ts
+++ b/src/components/inputs/search-field/search-field.ts
@@ -64,7 +64,7 @@ export class NLDDSearchField extends LitElement {
 	@property({ type: Boolean, reflect: true })
 	disabled = false;
 
-	@property({ type: String })
+	@property({ type: String, reflect: true })
 	name = '';
 
 	@property({ type: Boolean, reflect: true, attribute: 'show-search-button' })

--- a/src/components/inputs/search-field/search-field.ts
+++ b/src/components/inputs/search-field/search-field.ts
@@ -42,6 +42,8 @@ export class NLDDSearchField extends LitElement {
 
 	private _internals = this.attachInternals();
 
+	private _initialValue = '';
+
 	@property({ type: String })
 	value = '';
 
@@ -79,6 +81,10 @@ export class NLDDSearchField extends LitElement {
 	@query('.search-field__input')
 	_input!: HTMLInputElement;
 
+	override firstUpdated(): void {
+		this._initialValue = this.value;
+	}
+
 	override updated(changed: PropertyValues): void {
 		if (changed.has('width')) {
 			this.style.width = this.width || '';
@@ -89,7 +95,7 @@ export class NLDDSearchField extends LitElement {
 	}
 
 	formResetCallback(): void {
-		this.value = '';
+		this.value = this._initialValue;
 	}
 
 	formDisabledCallback(disabled: boolean): void {

--- a/src/components/inputs/search-field/search-field.ts
+++ b/src/components/inputs/search-field/search-field.ts
@@ -36,7 +36,11 @@ export type SearchFieldSize = 'sm' | 'md';
 
 @customElement('nldd-search-field')
 export class NLDDSearchField extends LitElement {
+	static formAssociated = true;
+
 	static override styles = searchFieldStyles;
+
+	private _internals = this.attachInternals();
 
 	@property({ type: String })
 	value = '';
@@ -79,6 +83,21 @@ export class NLDDSearchField extends LitElement {
 		if (changed.has('width')) {
 			this.style.width = this.width || '';
 		}
+		if (changed.has('value')) {
+			this._internals.setFormValue(this.value);
+		}
+	}
+
+	formResetCallback(): void {
+		this.value = '';
+	}
+
+	formDisabledCallback(disabled: boolean): void {
+		this.disabled = disabled;
+	}
+
+	formStateRestoreCallback(state: string): void {
+		if (typeof state === 'string') this.value = state;
 	}
 
 	// — i18n ——————————————————————————————————————————————————————————————————

--- a/src/components/inputs/segmented-control/segmented-control.test.ts
+++ b/src/components/inputs/segmented-control/segmented-control.test.ts
@@ -430,4 +430,37 @@ describe('nldd-segmented-control-item – tooltip', () => {
 		await waitForUpdate(el);
 		expect(el.shadowRoot!.querySelector('nldd-tooltip')).toBeNull();
 	});
+
+	it('participates in FormData via form-associated API (radio)', async () => {
+		const form = await fixture<HTMLFormElement>(`
+			<form>
+				<nldd-segmented-control value="b" name="opt" accessible-label="Optie">
+					<nldd-segmented-control-item value="a" text="Alpha"></nldd-segmented-control-item>
+					<nldd-segmented-control-item value="b" text="Beta"></nldd-segmented-control-item>
+				</nldd-segmented-control>
+			</form>
+		`);
+		el = form;
+		const sc = form.querySelector('nldd-segmented-control')!;
+		await waitForUpdate(sc);
+		expect(new FormData(form).get('opt')).toBe('b');
+	});
+
+	it('resets to the HTML-declared initial value when the parent form is reset', async () => {
+		const form = await fixture<HTMLFormElement>(`
+			<form>
+				<nldd-segmented-control value="a" name="opt" accessible-label="Optie">
+					<nldd-segmented-control-item value="a" text="Alpha"></nldd-segmented-control-item>
+					<nldd-segmented-control-item value="b" text="Beta"></nldd-segmented-control-item>
+				</nldd-segmented-control>
+			</form>
+		`);
+		el = form;
+		const sc = form.querySelector<NLDDSegmentedControl>('nldd-segmented-control')!;
+		await waitForUpdate(sc);
+		sc.value = 'b';
+		await waitForUpdate(sc);
+		form.reset();
+		expect(sc.value).toBe('a');
+	});
 });

--- a/src/components/inputs/segmented-control/segmented-control.ts
+++ b/src/components/inputs/segmented-control/segmented-control.ts
@@ -108,7 +108,14 @@ export class NLDDSegmentedControlItem extends LitElement {
 
 @customElement('nldd-segmented-control')
 export class NLDDSegmentedControl extends LitElement {
+	static formAssociated = true;
+
 	static override styles = segmentedControlStyles;
+
+	private _internals = this.attachInternals();
+
+	private _initialValue = '';
+	private _initialValues: string[] = [];
 
 	/** Selected value for radio type. */
 	@property({ type: String, reflect: true })
@@ -168,8 +175,44 @@ export class NLDDSegmentedControl extends LitElement {
 
 	override firstUpdated(): void {
 		this._syncItems();
+		this._initialValue = this.value;
+		this._initialValues = [...this.values];
+		this._syncFormValue();
 		if (import.meta.env?.DEV && !this.accessibleLabel && !this.accessibleLabelledBy) {
 			console.warn('<nldd-segmented-control>: No accessible name provided. Add an accessible-label or accessible-labelledby attribute for screen reader accessibility.');
+		}
+	}
+
+	private _syncFormValue(): void {
+		if (this.type === 'checkbox') {
+			if (this.values.length === 0 || !this.name) {
+				this._internals.setFormValue(null);
+				return;
+			}
+			// Submit each selected value under the same name (FormData.getAll)
+			const data = new FormData();
+			for (const v of this.values) data.append(this.name, v);
+			this._internals.setFormValue(data);
+		} else {
+			this._internals.setFormValue(this.value || null);
+		}
+	}
+
+	formResetCallback(): void {
+		this.value = this._initialValue;
+		this.values = [...this._initialValues];
+	}
+
+	formDisabledCallback(disabled: boolean): void {
+		this.disabled = disabled;
+	}
+
+	formStateRestoreCallback(state: FormData | string | null): void {
+		if (state === null) return;
+		if (this.type === 'checkbox' && state instanceof FormData && this.name) {
+			this.values = state.getAll(this.name).map(String);
+		} else if (typeof state === 'string') {
+			this.value = state;
 		}
 	}
 
@@ -184,6 +227,14 @@ export class NLDDSegmentedControl extends LitElement {
 			changedProperties.has('name')
 		) {
 			this._syncItems();
+		}
+		if (
+			changedProperties.has('value') ||
+			changedProperties.has('values') ||
+			changedProperties.has('type') ||
+			changedProperties.has('name')
+		) {
+			this._syncFormValue();
 		}
 		if (changedProperties.has('type')) {
 			this.setAttribute('role', this.type === 'checkbox' ? 'group' : 'radiogroup');

--- a/src/components/inputs/segmented-control/segmented-control.ts
+++ b/src/components/inputs/segmented-control/segmented-control.ts
@@ -145,7 +145,7 @@ export class NLDDSegmentedControl extends LitElement {
 	@property({ type: Boolean, reflect: true, attribute: 'full-width' })
 	fullWidth = false;
 
-	@property({ type: String })
+	@property({ type: String, reflect: true })
 	name = '';
 
 	/** Accessible name for the group (aria-label). */

--- a/src/components/inputs/segmented-control/segmented-control.ts
+++ b/src/components/inputs/segmented-control/segmented-control.ts
@@ -177,7 +177,8 @@ export class NLDDSegmentedControl extends LitElement {
 		this._syncItems();
 		this._initialValue = this.value;
 		this._initialValues = [...this.values];
-		this._syncFormValue();
+		// _syncFormValue() runs in updated() with the same changedProperties
+		// on first render — no need to call it explicitly here.
 		if (import.meta.env?.DEV && !this.accessibleLabel && !this.accessibleLabelledBy) {
 			console.warn('<nldd-segmented-control>: No accessible name provided. Add an accessible-label or accessible-labelledby attribute for screen reader accessibility.');
 		}

--- a/src/components/inputs/stepper/stepper.test.ts
+++ b/src/components/inputs/stepper/stepper.test.ts
@@ -249,4 +249,23 @@ describe('nldd-stepper – translations', () => {
 		el.translations = { 'components.stepper.decrement-action': 'Decrease' };
 		expect(el._t('components.stepper.increment-action')).toBe('Verhoog');
 	});
+
+	it('participates in FormData via form-associated API', async () => {
+		const form = await fixture<HTMLFormElement>('<form><nldd-stepper name="qty" value="5"></nldd-stepper></form>');
+		el = form;
+		const sp = form.querySelector('nldd-stepper')!;
+		await waitForUpdate(sp);
+		expect(new FormData(form).get('qty')).toBe('5');
+	});
+
+	it('resets to the HTML-declared initial value when the parent form is reset', async () => {
+		const form = await fixture<HTMLFormElement>('<form><nldd-stepper name="qty" value="3"></nldd-stepper></form>');
+		el = form;
+		const sp = form.querySelector<NLDDStepper>('nldd-stepper')!;
+		await waitForUpdate(sp);
+		sp.value = 7;
+		await waitForUpdate(sp);
+		form.reset();
+		expect(sp.value).toBe(3);
+	});
 });

--- a/src/components/inputs/stepper/stepper.ts
+++ b/src/components/inputs/stepper/stepper.ts
@@ -53,7 +53,7 @@ export class NLDDStepper extends LitElement {
 	@property({ type: String, reflect: true })
 	size: StepperSize = 'md';
 
-	@property({ type: String })
+	@property({ type: String, reflect: true })
 	name = '';
 
 	/** Override one or more translation keys. Unspecified keys fall back to Dutch. */

--- a/src/components/inputs/stepper/stepper.ts
+++ b/src/components/inputs/stepper/stepper.ts
@@ -81,7 +81,7 @@ export class NLDDStepper extends LitElement {
 	formStateRestoreCallback(state: File | string | FormData | null): void {
 		if (typeof state !== 'string') return;
 		const parsed = parseFloat(state);
-		if (!isNaN(parsed)) this.value = parsed;
+		if (!isNaN(parsed)) this.value = Math.max(this.min, Math.min(this.max, parsed));
 	}
 
 	// — i18n —————————————————————————————————————————————————————————————————

--- a/src/components/inputs/stepper/stepper.ts
+++ b/src/components/inputs/stepper/stepper.ts
@@ -14,7 +14,7 @@
  *
  * @fires change - When the value changes; detail: { value: number }
  */
-import { LitElement } from 'lit';
+import { LitElement, type PropertyValues } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { stepperStyles } from './stepper.styles.js';
 import { stepperTemplate } from './stepper.template.js';
@@ -27,7 +27,13 @@ export type StepperSize = 'xs' | 'sm' | 'md';
 
 @customElement('nldd-stepper')
 export class NLDDStepper extends LitElement {
+	static formAssociated = true;
+
 	static override styles = stepperStyles;
+
+	private _internals = this.attachInternals();
+
+	private _initialValue = 0;
 
 	@property({ type: Number })
 	value = 0;
@@ -47,9 +53,35 @@ export class NLDDStepper extends LitElement {
 	@property({ type: String, reflect: true })
 	size: StepperSize = 'md';
 
+	@property({ type: String })
+	name = '';
+
 	/** Override one or more translation keys. Unspecified keys fall back to Dutch. */
 	@property({ type: Object })
 	translations: Partial<NLDDStepperTranslations> = {};
+
+	override firstUpdated(): void {
+		this._initialValue = this.value;
+	}
+
+	override updated(changed: PropertyValues): void {
+		if (changed.has('value')) {
+			this._internals.setFormValue(String(this.value));
+		}
+	}
+
+	formResetCallback(): void {
+		this.value = this._initialValue;
+	}
+
+	formDisabledCallback(disabled: boolean): void {
+		this.disabled = disabled;
+	}
+
+	formStateRestoreCallback(state: string): void {
+		const parsed = parseFloat(state);
+		if (!isNaN(parsed)) this.value = parsed;
+	}
 
 	// — i18n —————————————————————————————————————————————————————————————————
 

--- a/src/components/inputs/stepper/stepper.ts
+++ b/src/components/inputs/stepper/stepper.ts
@@ -78,7 +78,8 @@ export class NLDDStepper extends LitElement {
 		this.disabled = disabled;
 	}
 
-	formStateRestoreCallback(state: string): void {
+	formStateRestoreCallback(state: File | string | FormData | null): void {
+		if (typeof state !== 'string') return;
 		const parsed = parseFloat(state);
 		if (!isNaN(parsed)) this.value = parsed;
 	}

--- a/src/components/inputs/switch/switch.test.ts
+++ b/src/components/inputs/switch/switch.test.ts
@@ -307,4 +307,31 @@ describe('nldd-switch – accessibility', () => {
 		await waitForUpdate(el);
 		expect(warnSpy).not.toHaveBeenCalled();
 	});
+
+	it('participates in FormData when checked', async () => {
+		const form = await fixture<HTMLFormElement>('<form><nldd-switch name="alerts" value="on" accessible-label="Meldingen" checked></nldd-switch></form>');
+		el = form;
+		const sw = form.querySelector('nldd-switch')!;
+		await waitForUpdate(sw);
+		expect(new FormData(form).get('alerts')).toBe('on');
+	});
+
+	it('is omitted from FormData when unchecked', async () => {
+		const form = await fixture<HTMLFormElement>('<form><nldd-switch name="alerts" value="on" accessible-label="Meldingen"></nldd-switch></form>');
+		el = form;
+		const sw = form.querySelector('nldd-switch')!;
+		await waitForUpdate(sw);
+		expect(new FormData(form).has('alerts')).toBe(false);
+	});
+
+	it('resets to the HTML-declared initial checked state when the parent form is reset', async () => {
+		const form = await fixture<HTMLFormElement>('<form><nldd-switch name="alerts" value="on" accessible-label="Meldingen" checked></nldd-switch></form>');
+		el = form;
+		const sw = form.querySelector<NLDDSwitch>('nldd-switch')!;
+		await waitForUpdate(sw);
+		sw.checked = false;
+		await waitForUpdate(sw);
+		form.reset();
+		expect(sw.checked).toBe(true);
+	});
 });

--- a/src/components/inputs/switch/switch.ts
+++ b/src/components/inputs/switch/switch.ts
@@ -14,7 +14,7 @@
  *
  * @fires change - When the switch state changes; detail: { checked: boolean, value: string }
  */
-import { LitElement } from 'lit';
+import { LitElement, type PropertyValues } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { switchStyles } from './switch.styles.js';
 import { switchTemplate } from './switch.template.js';
@@ -23,7 +23,14 @@ export type SwitchSize = 'xs' | 'sm';
 
 @customElement('nldd-switch')
 export class NLDDSwitch extends LitElement {
+	static formAssociated = true;
+
 	static override styles = switchStyles;
+
+	private _internals = this.attachInternals();
+
+	@property({ type: String })
+	name = '';
 
 	@property({ type: Boolean, reflect: true })
 	checked = false;
@@ -40,10 +47,31 @@ export class NLDDSwitch extends LitElement {
 	@property({ type: String })
 	value = 'on';
 
+	private _initialChecked = false;
+
 	override firstUpdated(): void {
 		if (import.meta.env?.DEV && !this.accessibleLabel) {
 			console.warn('<nldd-switch>: No accessible-label provided. Use nldd-switch-field for labeled usage, or provide an accessible-label attribute for screen reader accessibility.');
 		}
+		this._initialChecked = this.checked;
+	}
+
+	override updated(changed: PropertyValues): void {
+		if (changed.has('checked') || changed.has('value')) {
+			this._internals.setFormValue(this.checked ? this.value : null);
+		}
+	}
+
+	formResetCallback(): void {
+		this.checked = this._initialChecked;
+	}
+
+	formDisabledCallback(disabled: boolean): void {
+		this.disabled = disabled;
+	}
+
+	formStateRestoreCallback(state: string | null): void {
+		this.checked = state !== null;
 	}
 
 	// ## Swipe gesture

--- a/src/components/inputs/switch/switch.ts
+++ b/src/components/inputs/switch/switch.ts
@@ -70,7 +70,7 @@ export class NLDDSwitch extends LitElement {
 		this.disabled = disabled;
 	}
 
-	formStateRestoreCallback(state: string | null): void {
+	formStateRestoreCallback(state: File | string | FormData | null): void {
 		this.checked = state !== null;
 	}
 

--- a/src/components/inputs/switch/switch.ts
+++ b/src/components/inputs/switch/switch.ts
@@ -29,7 +29,7 @@ export class NLDDSwitch extends LitElement {
 
 	private _internals = this.attachInternals();
 
-	@property({ type: String })
+	@property({ type: String, reflect: true })
 	name = '';
 
 	@property({ type: Boolean, reflect: true })

--- a/src/components/inputs/text-field/text-field.test.ts
+++ b/src/components/inputs/text-field/text-field.test.ts
@@ -142,15 +142,16 @@ describe('nldd-text-field', () => {
 		form.remove();
 	});
 
-	it('resets value when the parent form is reset', async () => {
+	it('resets to the HTML-declared initial value when the parent form is reset', async () => {
 		const form = document.createElement('form');
 		document.body.appendChild(form);
-		el = document.createElement('nldd-text-field');
-		(el as any).value = 'Iets';
-		form.appendChild(el);
+		form.innerHTML = '<nldd-text-field name="email" value="default@example.com"></nldd-text-field>';
+		el = form.querySelector('nldd-text-field')!;
+		await waitForUpdate(el);
+		(el as any).value = 'changed@example.com';
 		await waitForUpdate(el);
 		form.reset();
-		expect((el as any).value).toBe('');
+		expect((el as any).value).toBe('default@example.com');
 		form.remove();
 	});
 

--- a/src/components/inputs/text-field/text-field.test.ts
+++ b/src/components/inputs/text-field/text-field.test.ts
@@ -129,6 +129,31 @@ describe('nldd-text-field', () => {
 		expect((el as HTMLElement).style.width).toBe('240px');
 	});
 
+	it('participates in FormData via form-associated API', async () => {
+		const form = document.createElement('form');
+		document.body.appendChild(form);
+		el = document.createElement('nldd-text-field');
+		el.setAttribute('name', 'first');
+		(el as any).value = 'Hallo';
+		form.appendChild(el);
+		await waitForUpdate(el);
+		const data = new FormData(form);
+		expect(data.get('first')).toBe('Hallo');
+		form.remove();
+	});
+
+	it('resets value when the parent form is reset', async () => {
+		const form = document.createElement('form');
+		document.body.appendChild(form);
+		el = document.createElement('nldd-text-field');
+		(el as any).value = 'Iets';
+		form.appendChild(el);
+		await waitForUpdate(el);
+		form.reset();
+		expect((el as any).value).toBe('');
+		form.remove();
+	});
+
 	it('verwijdert inline host width als width leeg wordt gezet', async () => {
 		el = await fixture('<nldd-text-field width="240px"></nldd-text-field>');
 		await waitForUpdate(el);

--- a/src/components/inputs/text-field/text-field.test.ts
+++ b/src/components/inputs/text-field/text-field.test.ts
@@ -130,29 +130,22 @@ describe('nldd-text-field', () => {
 	});
 
 	it('participates in FormData via form-associated API', async () => {
-		const form = document.createElement('form');
-		document.body.appendChild(form);
-		el = document.createElement('nldd-text-field');
-		el.setAttribute('name', 'first');
-		(el as any).value = 'Hallo';
-		form.appendChild(el);
-		await waitForUpdate(el);
-		const data = new FormData(form);
-		expect(data.get('first')).toBe('Hallo');
-		form.remove();
+		const form = await fixture<HTMLFormElement>('<form><nldd-text-field name="first" value="Hallo"></nldd-text-field></form>');
+		el = form;
+		const tf = form.querySelector('nldd-text-field')!;
+		await waitForUpdate(tf);
+		expect(new FormData(form).get('first')).toBe('Hallo');
 	});
 
 	it('resets to the HTML-declared initial value when the parent form is reset', async () => {
-		const form = document.createElement('form');
-		document.body.appendChild(form);
-		form.innerHTML = '<nldd-text-field name="email" value="default@example.com"></nldd-text-field>';
-		el = form.querySelector('nldd-text-field')!;
-		await waitForUpdate(el);
-		(el as any).value = 'changed@example.com';
-		await waitForUpdate(el);
+		const form = await fixture<HTMLFormElement>('<form><nldd-text-field name="email" value="default@example.com"></nldd-text-field></form>');
+		el = form;
+		const tf = form.querySelector('nldd-text-field')! as HTMLElement & { value: string };
+		await waitForUpdate(tf);
+		tf.value = 'changed@example.com';
+		await waitForUpdate(tf);
 		form.reset();
-		expect((el as any).value).toBe('default@example.com');
-		form.remove();
+		expect(tf.value).toBe('default@example.com');
 	});
 
 	it('verwijdert inline host width als width leeg wordt gezet', async () => {

--- a/src/components/inputs/text-field/text-field.ts
+++ b/src/components/inputs/text-field/text-field.ts
@@ -70,7 +70,7 @@ export class NLDDTextField extends LitElement {
 	@property({ type: String })
 	type: InputType = 'text';
 
-	@property({ type: String })
+	@property({ type: String, reflect: true })
 	name = '';
 
 	@property({ type: Boolean, reflect: true })

--- a/src/components/inputs/text-field/text-field.ts
+++ b/src/components/inputs/text-field/text-field.ts
@@ -33,12 +33,16 @@ export type InputType = 'text' | 'email' | 'tel' | 'url';
 
 @customElement('nldd-text-field')
 export class NLDDTextField extends LitElement {
+	static formAssociated = true;
+
 	static override shadowRootOptions = {
 		...LitElement.shadowRootOptions,
 		delegatesFocus: true,
 	};
 
 	static override styles = textFieldStyles;
+
+	private _internals = this.attachInternals();
 
 	@property({ type: String, reflect: true })
 	size: 'md' | 'sm' = 'md';
@@ -95,6 +99,21 @@ export class NLDDTextField extends LitElement {
 		if (changed.has('width')) {
 			this.style.width = this.width || '';
 		}
+		if (changed.has('value')) {
+			this._internals.setFormValue(this.value);
+		}
+	}
+
+	formResetCallback(): void {
+		this.value = '';
+	}
+
+	formDisabledCallback(disabled: boolean): void {
+		this.disabled = disabled;
+	}
+
+	formStateRestoreCallback(state: string): void {
+		if (typeof state === 'string') this.value = state;
 	}
 
 	public _handleInput(e: Event): void {

--- a/src/components/inputs/text-field/text-field.ts
+++ b/src/components/inputs/text-field/text-field.ts
@@ -44,6 +44,8 @@ export class NLDDTextField extends LitElement {
 
 	private _internals = this.attachInternals();
 
+	private _initialValue = '';
+
 	@property({ type: String, reflect: true })
 	size: 'md' | 'sm' = 'md';
 
@@ -95,6 +97,10 @@ export class NLDDTextField extends LitElement {
 	@query('.text-field__input')
 	private _input!: HTMLInputElement;
 
+	override firstUpdated(): void {
+		this._initialValue = this.value;
+	}
+
 	override updated(changed: PropertyValues): void {
 		if (changed.has('width')) {
 			this.style.width = this.width || '';
@@ -105,7 +111,7 @@ export class NLDDTextField extends LitElement {
 	}
 
 	formResetCallback(): void {
-		this.value = '';
+		this.value = this._initialValue;
 	}
 
 	formDisabledCallback(disabled: boolean): void {

--- a/src/components/inputs/text-field/text-field.ts
+++ b/src/components/inputs/text-field/text-field.ts
@@ -20,9 +20,6 @@
  *
  * @fires input  - When input value changes
  * @fires change - When input value is committed
- *
- * @csspart container - The field container
- * @csspart input     - The native input element
  */
 import { LitElement, type PropertyValues } from 'lit';
 import { customElement, property, query } from 'lit/decorators.js';
@@ -118,7 +115,7 @@ export class NLDDTextField extends LitElement {
 		this.disabled = disabled;
 	}
 
-	formStateRestoreCallback(state: string): void {
+	formStateRestoreCallback(state: File | string | FormData | null): void {
 		if (typeof state === 'string') this.value = state;
 	}
 

--- a/src/components/inputs/toggle-button/toggle-button.test.ts
+++ b/src/components/inputs/toggle-button/toggle-button.test.ts
@@ -408,4 +408,31 @@ describe('nldd-toggle-button – tooltip', () => {
 		await waitForUpdate(el);
 		expect(el.shadowRoot!.querySelector('nldd-tooltip')).toBeNull();
 	});
+
+	it('participates in FormData when type="checkbox" and selected', async () => {
+		const form = await fixture<HTMLFormElement>('<form><nldd-toggle-button type="checkbox" name="fav" value="star" text="Favoriet" selected></nldd-toggle-button></form>');
+		el = form;
+		const tb = form.querySelector('nldd-toggle-button')!;
+		await waitForUpdate(tb);
+		expect(new FormData(form).get('fav')).toBe('star');
+	});
+
+	it('is omitted from FormData when type="button" (not a form control)', async () => {
+		const form = await fixture<HTMLFormElement>('<form><nldd-toggle-button type="button" name="fav" value="star" text="Favoriet" selected></nldd-toggle-button></form>');
+		el = form;
+		const tb = form.querySelector('nldd-toggle-button')!;
+		await waitForUpdate(tb);
+		expect(new FormData(form).has('fav')).toBe(false);
+	});
+
+	it('resets to the HTML-declared initial selected state when the parent form is reset', async () => {
+		const form = await fixture<HTMLFormElement>('<form><nldd-toggle-button type="checkbox" name="fav" value="star" text="Favoriet" selected></nldd-toggle-button></form>');
+		el = form;
+		const tb = form.querySelector<NLDDToggleButton>('nldd-toggle-button')!;
+		await waitForUpdate(tb);
+		tb.selected = false;
+		await waitForUpdate(tb);
+		form.reset();
+		expect(tb.selected).toBe(true);
+	});
 });

--- a/src/components/inputs/toggle-button/toggle-button.ts
+++ b/src/components/inputs/toggle-button/toggle-button.ts
@@ -55,7 +55,7 @@ export class NLDDToggleButton extends LitElement {
 	@property({ type: String })
 	value = 'on';
 
-	@property({ type: String })
+	@property({ type: String, reflect: true })
 	name = '';
 
 	/** Button text. */

--- a/src/components/inputs/toggle-button/toggle-button.ts
+++ b/src/components/inputs/toggle-button/toggle-button.ts
@@ -107,7 +107,7 @@ export class NLDDToggleButton extends LitElement {
 		this.disabled = disabled;
 	}
 
-	formStateRestoreCallback(state: string | null): void {
+	formStateRestoreCallback(state: File | string | FormData | null): void {
 		this.selected = state !== null;
 	}
 

--- a/src/components/inputs/toggle-button/toggle-button.ts
+++ b/src/components/inputs/toggle-button/toggle-button.ts
@@ -21,7 +21,7 @@
  * @fires change - When selection changes; detail: { selected: boolean, value: string }
  */
 
-import { LitElement } from 'lit';
+import { LitElement, type PropertyValues } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { toggleButtonStyles } from './toggle-button.styles.js';
 import { toggleButtonTemplate } from './toggle-button.template.js';
@@ -32,7 +32,13 @@ export type ToggleButtonSize = 'xs' | 'sm' | 'md';
 
 @customElement('nldd-toggle-button')
 export class NLDDToggleButton extends LitElement {
+	static formAssociated = true;
+
 	static override styles = toggleButtonStyles;
+
+	private _internals = this.attachInternals();
+
+	private _initialSelected = false;
 
 	@property({ type: String, reflect: true })
 	type: ToggleButtonType = 'button';
@@ -72,7 +78,11 @@ export class NLDDToggleButton extends LitElement {
 
 	private _warnedA11y = false;
 
-	override updated(): void {
+	override firstUpdated(): void {
+		this._initialSelected = this.selected;
+	}
+
+	override updated(changed: PropertyValues): void {
 		const iconOnly = this._hasIcon && !this.text;
 		this.toggleAttribute('icon-only', iconOnly);
 		const inaccessible = iconOnly && !this.accessibleLabel;
@@ -82,6 +92,23 @@ export class NLDDToggleButton extends LitElement {
 		} else if (!inaccessible) {
 			this._warnedA11y = false;
 		}
+		if (changed.has('selected') || changed.has('value') || changed.has('type')) {
+			// Only checkbox/radio variants participate in form submission.
+			const submits = this.type === 'checkbox' || this.type === 'radio';
+			this._internals.setFormValue(submits && this.selected ? this.value : null);
+		}
+	}
+
+	formResetCallback(): void {
+		this.selected = this._initialSelected;
+	}
+
+	formDisabledCallback(disabled: boolean): void {
+		this.disabled = disabled;
+	}
+
+	formStateRestoreCallback(state: string | null): void {
+		this.selected = state !== null;
 	}
 
 	_handleButtonClick(): void {

--- a/src/components/status-and-feedback/modal-dialog/modal-dialog.test.ts
+++ b/src/components/status-and-feedback/modal-dialog/modal-dialog.test.ts
@@ -144,6 +144,11 @@ describe('nldd-modal-dialog', () => {
 		expect(document.activeElement === button).toBe(true);
 	});
 
+	// Note: getBoundingClientRect() returns all-zeros in JSDOM. The padding-click
+	// test passes because (0, 0) lies on the degenerate [0,0]×[0,0] rect; the
+	// backdrop-click test passes because (-10, -10) lies outside it. The logic
+	// is correct under real layout — these assertions exercise the in-rect /
+	// outside-rect branch boundaries, not realistic geometry.
 	it('does not close when clicking on the dialog padding', async () => {
 		el = await fixture('<nldd-modal-dialog text="Test"></nldd-modal-dialog>');
 		await waitForUpdate(el);

--- a/src/components/status-and-feedback/modal-dialog/modal-dialog.test.ts
+++ b/src/components/status-and-feedback/modal-dialog/modal-dialog.test.ts
@@ -144,6 +144,41 @@ describe('nldd-modal-dialog', () => {
 		expect(document.activeElement === button).toBe(true);
 	});
 
+	it('does not close when clicking on the dialog padding', async () => {
+		el = await fixture('<nldd-modal-dialog text="Test"></nldd-modal-dialog>');
+		await waitForUpdate(el);
+		(el as NLDDModalDialog).show();
+		const dialog = el.shadowRoot!.querySelector('dialog')!;
+		const rect = dialog.getBoundingClientRect();
+		// Click coordinates inside the dialog rect, target = dialog (i.e., on padding)
+		const event = new MouseEvent('click', {
+			bubbles: true,
+			clientX: rect.left + rect.width / 2,
+			clientY: rect.top + rect.height / 2,
+		});
+		Object.defineProperty(event, 'target', { value: dialog });
+		(el as NLDDModalDialog)._handleBackdropClick(event);
+		expect(dialog.classList.contains('is-closing')).toBe(false);
+		expect(dialog.open).toBe(true);
+	});
+
+	it('closes when clicking on the backdrop (outside dialog rect)', async () => {
+		el = await fixture('<nldd-modal-dialog text="Test"></nldd-modal-dialog>');
+		await waitForUpdate(el);
+		(el as NLDDModalDialog).show();
+		const dialog = el.shadowRoot!.querySelector('dialog')!;
+		const rect = dialog.getBoundingClientRect();
+		// Click coordinates outside the dialog rect, target = dialog (i.e., on backdrop)
+		const event = new MouseEvent('click', {
+			bubbles: true,
+			clientX: rect.left - 10,
+			clientY: rect.top - 10,
+		});
+		Object.defineProperty(event, 'target', { value: dialog });
+		(el as NLDDModalDialog)._handleBackdropClick(event);
+		expect(dialog.classList.contains('is-closing')).toBe(true);
+	});
+
 	it('prevents default on cancel event and calls hide()', async () => {
 		el = await fixture('<nldd-modal-dialog></nldd-modal-dialog>');
 		await waitForUpdate(el);

--- a/src/components/status-and-feedback/modal-dialog/modal-dialog.ts
+++ b/src/components/status-and-feedback/modal-dialog/modal-dialog.ts
@@ -98,7 +98,14 @@ export class NLDDModalDialog extends LitElement {
 	}
 
 	_handleBackdropClick(e: MouseEvent): void {
-		if (e.target === this._dialog) this.hide();
+		if (e.target !== this._dialog) return;
+		// e.target is the dialog for both backdrop clicks and clicks on the dialog's
+		// own padding — distinguish by checking the pointer position against the rect.
+		const rect = this._dialog!.getBoundingClientRect();
+		const insideDialog =
+			e.clientX >= rect.left && e.clientX <= rect.right &&
+			e.clientY >= rect.top && e.clientY <= rect.bottom;
+		if (!insideDialog) this.hide();
 	}
 
 	_handleCancel(e: Event): void {


### PR DESCRIPTION
## Summary
- fix(modal-dialog): padding-klikken sluiten de dialog niet meer
- feat(multi-line-text-field): nieuwe component op basis van <textarea>
  met rows/resize, floating validation icon
- chore(skill): canonieke control-volgorde in component skill
- feat(inputs): alle value-bearing inputs zijn nu form-associated —
  Enter-submit, submit-button, FormData, form.reset() werken native

## Test plan
- [ ] Modal: klik op padding sluit niet, klik op backdrop wel
- [ ] Multi-line: resize=vertical/auto/none werken; validation-icon
      in top-right blokkeert resize-handle niet
- [ ] Form submission: Enter + submit-button werken in interactive
      stories; FormData bevat alle named inputs; reset() werkt
- [ ] npm test (405+ tests slagen)
- [ ] npm run validate:styles + npm run build schoon