### PR TITLE
feat: code components, cell layout, hover gating, accent variants

### DIFF
--- a/.claude/skills/component/SKILL.md
+++ b/.claude/skills/component/SKILL.md
@@ -266,7 +266,7 @@ Per component: pak alleen de keys die je gebruikt en zet ze in deze volgorde. De
 
 ```
 [1. Visueel dominant]
-size, compact, variant, color, background, layout, panes,
+variant, size, compact, color, background, layout, panes,
 iconOnly, responsive, showItemLabels, inspectorAsSheet, sidebarAsSheet, noLogo
 
 [2. Sizing]

--- a/.claude/skills/component/SKILL.md
+++ b/.claude/skills/component/SKILL.md
@@ -457,7 +457,7 @@ Er is geen automatische formatter. Volg deze regels handmatig.
 - Property waarden altijd op **één regel**, ook als ze lang zijn
 - Sorteer rules per element; houd alle gedrag voor een element bij elkaar
 - Gebruik **CSS nesting** voor `@container` en `@media` — nest in de element rule block
-- Declareer **alle** lokale CSS variabelen (`--_*`) in `:host`, inclusief responsive overrides via `@container` nesting. Elementen gebruiken alleen `var(--_foo)`, nooit fallbacks: niet `var(--_foo, 100)`
+- Declareer **alle** lokale CSS variabelen (`--_*`) **bovenin `:host`**, gevolgd door een lege regel die ze scheidt van de overige properties. Inclusief responsive overrides via `@container` nesting. Elementen gebruiken alleen `var(--_foo)`, nooit fallbacks: niet `var(--_foo, 100)`
 - Gebruik **nooit** flex shorthand (`flex: 1`), schrijf de losse properties
 - Level 1 headings (`/* # Section */`): 2 lege regels ervoor, 1 erna
 - Level 2 headings (`/* ## Subsection */`): 1 lege regel ervoor en erna
@@ -481,7 +481,7 @@ Er is geen automatische formatter. Volg deze regels handmatig.
 ```
 
 ```css
-/* GOED — alle lokale vars in :host, inclusief responsive overrides */
+/* GOED — vars bovenin :host, lege regel, dan de rest */
 :host {
 	--_min-height: var(--semantics-controls-md-min-size);
 	--_logo-width: var(--primitives-space-40);
@@ -489,13 +489,20 @@ Er is geen automatische formatter. Volg deze regels handmatig.
 	@container layout-area (min-width: 641px) {
 		--_logo-width: var(--primitives-space-44);
 	}
-}
-.button {
+
+	display: inline-flex;
 	min-height: var(--_min-height);
 }
 .logo {
 	width: var(--_logo-width);
 	height: calc(var(--_logo-width) * 2);
+}
+
+/* FOUT — vars vermengd met properties zonder scheidingsregel */
+:host {
+	display: inline-flex;
+	--_min-height: var(--semantics-controls-md-min-size);
+	min-height: var(--_min-height);
 }
 
 /* FOUT — lokale var op element ipv :host */

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,18 @@
 {
   "name": "@nldd/design-system",
-  "version": "0.8.36",
+  "version": "0.8.40",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nldd/design-system",
-      "version": "0.8.36",
+      "version": "0.8.40",
       "license": "EUPL-1.2",
       "dependencies": {
         "@floating-ui/dom": "^1.7.6",
         "@rijkshuisstijl-community/font": "^1.1.2",
-        "lit": "^3.3.1"
+        "lit": "^3.3.1",
+        "prismjs": "^1.30.0"
       },
       "devDependencies": {
         "@commitlint/cli": "^19.6.1",
@@ -23,6 +24,7 @@
         "@storybook/addon-themes": "^10.3.4",
         "@storybook/addon-vitest": "^10.3.4",
         "@storybook/web-components-vite": "^10.3.4",
+        "@types/prismjs": "^1.26.6",
         "@vitest/browser-playwright": "^4.0.16",
         "@vitest/coverage-v8": "^4.0.16",
         "eslint": "^9.17.0",
@@ -3187,6 +3189,13 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/prismjs": {
+      "version": "1.26.6",
+      "resolved": "https://registry.npmjs.org/@types/prismjs/-/prismjs-1.26.6.tgz",
+      "integrity": "sha512-vqlvI7qlMvcCBbVe0AKAb4f97//Hy0EBTaiW8AalRnG/xAN5zOiWWyrNqNXeq8+KAuvRewjCVY1+IPxk4RdNYw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "19.2.14",
@@ -9489,6 +9498,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/prismjs": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz",
+      "integrity": "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/process-nextick-args": {

--- a/package.json
+++ b/package.json
@@ -63,6 +63,10 @@
       "types": "./dist/components/content/keyboard-shortcut/keyboard-shortcut.d.ts",
       "default": "./dist/components/content/keyboard-shortcut/keyboard-shortcut.js"
     },
+    "./code": {
+      "types": "./dist/components/content/code/code.d.ts",
+      "default": "./dist/components/content/code/code.js"
+    },
     "./form": {
       "types": "./dist/components/forms/form/form.d.ts",
       "default": "./dist/components/forms/form/form.js"
@@ -86,6 +90,10 @@
     "./multi-line-text-field": {
       "types": "./dist/components/inputs/multi-line-text-field/multi-line-text-field.d.ts",
       "default": "./dist/components/inputs/multi-line-text-field/multi-line-text-field.js"
+    },
+    "./code-editor": {
+      "types": "./dist/components/inputs/code-editor/code-editor.d.ts",
+      "default": "./dist/components/inputs/code-editor/code-editor.js"
     },
     "./password-field": {
       "types": "./dist/components/inputs/password-field/password-field.d.ts",
@@ -381,6 +389,7 @@
     "@storybook/addon-themes": "^10.3.4",
     "@storybook/addon-vitest": "^10.3.4",
     "@storybook/web-components-vite": "^10.3.4",
+    "@types/prismjs": "^1.26.6",
     "@vitest/browser-playwright": "^4.0.16",
     "@vitest/coverage-v8": "^4.0.16",
     "eslint": "^9.17.0",
@@ -408,6 +417,7 @@
   "dependencies": {
     "@floating-ui/dom": "^1.7.6",
     "@rijkshuisstijl-community/font": "^1.1.2",
-    "lit": "^3.3.1"
+    "lit": "^3.3.1",
+    "prismjs": "^1.30.0"
   }
 }

--- a/src/assets/styles/settings.css
+++ b/src/assets/styles/settings.css
@@ -572,6 +572,41 @@
 		var(--primitives-font-family-body)
 	;
 
+	/* Monospace tokens use one font-size step smaller than the matching body
+	   size. Constant character widths in monospace render denser than
+	   proportional fonts, so monospace-md sits visually next to body-md
+	   while using font-size-90 (16px) instead of -100 (18px). */
+	--primitives-font-monospace-md-regular-snug:
+		var(--primitives-font-weight-body-regular)
+		var(--primitives-font-size-90) / var(--primitives-line-height-snug)
+		var(--primitives-font-family-monospace)
+	;
+	--primitives-font-monospace-md-regular-flat:
+		var(--primitives-font-weight-body-regular)
+		var(--primitives-font-size-90) / var(--primitives-line-height-flat)
+		var(--primitives-font-family-monospace)
+	;
+	--primitives-font-monospace-sm-regular-snug:
+		var(--primitives-font-weight-body-regular)
+		var(--primitives-font-size-80) / var(--primitives-line-height-snug)
+		var(--primitives-font-family-monospace)
+	;
+	--primitives-font-monospace-sm-regular-flat:
+		var(--primitives-font-weight-body-regular)
+		var(--primitives-font-size-80) / var(--primitives-line-height-flat)
+		var(--primitives-font-family-monospace)
+	;
+	--primitives-font-monospace-xs-regular-snug:
+		var(--primitives-font-weight-body-regular)
+		var(--primitives-font-size-70) / var(--primitives-line-height-snug)
+		var(--primitives-font-family-monospace)
+	;
+	--primitives-font-monospace-xs-regular-flat:
+		var(--primitives-font-weight-body-regular)
+		var(--primitives-font-size-70) / var(--primitives-line-height-flat)
+		var(--primitives-font-family-monospace)
+	;
+
 	--primitives-font-display-1-sm:
 		var(--primitives-font-weight-display-bold)
 		var(--primitives-font-size-700) / var(--primitives-line-height-flat)
@@ -839,7 +874,7 @@
 	--semantics-buttons-neutral-tinted-background-color: light-dark(var(--primitives-color-neutral-75), var(--primitives-color-neutral-200));
 	--semantics-buttons-neutral-tinted-content-color: light-dark(var(--primitives-color-neutral-900), var(--primitives-color-neutral-900));
 	--semantics-buttons-neutral-tinted-secondary-content-color: light-dark(var(--primitives-color-neutral-750), var(--primitives-color-neutral-750));
-	--semantics-buttons-neutral-tinted-divider-color: light-dark(var(--primitives-color-neutral-250), var(--primitives-color-neutral-350));
+	--semantics-buttons-neutral-tinted-divider-color: light-dark(var(--primitives-color-neutral-250), var(--primitives-color-neutral-450));
 	--semantics-buttons-neutral-tinted-is-hovered-background-color: light-dark(var(--primitives-color-neutral-100), var(--primitives-color-neutral-250));
 	--semantics-buttons-neutral-tinted-is-hovered-content-color: light-dark(var(--primitives-color-neutral-1000), var(--primitives-color-neutral-1000));
 	--semantics-buttons-neutral-tinted-is-hovered-secondary-content-color: light-dark(var(--primitives-color-neutral-650), var(--primitives-color-neutral-800));
@@ -866,6 +901,7 @@
 	--semantics-buttons-accent-filled-is-hovered-content-color: light-dark(var(--primitives-color-accent-0), var(--primitives-color-accent-0));
 	--semantics-buttons-accent-filled-is-active-background-color: light-dark(var(--primitives-color-accent-850), var(--primitives-color-accent-750));
 	--semantics-buttons-accent-filled-is-active-content-color: light-dark(var(--primitives-color-accent-0), var(--primitives-color-accent-0));
+	--semantics-buttons-accent-filled-divider-color: light-dark(var(--primitives-color-accent-500), var(--primitives-color-accent-450));
 
 	--semantics-buttons-accent-outlined-border-thickness: var(--primitives-border-width-regular);
 	--semantics-buttons-accent-outlined-border-color: light-dark(var(--primitives-color-accent-750), var(--primitives-color-accent-650));

--- a/src/assets/styles/settings.css
+++ b/src/assets/styles/settings.css
@@ -1095,6 +1095,39 @@
 	--components-keyboard-shortcut-corner-radius: var(--primitives-corner-radius-xs);
 	--components-keyboard-shortcut-separator-color: var(--semantics-content-secondary-color);
 
+	/* ## Code
+
+	   Token colors used by nldd-code's Prism syntax highlighting.
+	   Solarized-inspired, mapped to descriptive DS palettes. Consumers
+	   can override per-instance on `nldd-code` to swap the theme. */
+
+	--components-code-token-comment-color: var(--semantics-content-secondary-color);
+	--components-code-token-punctuation-color: var(--semantics-content-color);
+	--components-code-token-keyword-color: var(--primitives-color-donkergeel-650);
+	--components-code-token-string-color: var(--primitives-color-groen-650);
+	--components-code-token-number-color: var(--primitives-color-oranje-650);
+	--components-code-token-boolean-color: var(--primitives-color-oranje-650);
+	--components-code-token-null-color: var(--primitives-color-oranje-650);
+	--components-code-token-function-color: var(--primitives-color-lintblauw-650);
+	--components-code-token-class-color: var(--primitives-color-donkergeel-650);
+	--components-code-token-builtin-color: var(--primitives-color-donkergeel-650);
+	--components-code-token-tag-color: var(--primitives-color-groen-650);
+	--components-code-token-attr-name-color: var(--primitives-color-lintblauw-650);
+	--components-code-token-attr-value-color: var(--primitives-color-mintgroen-650);
+	--components-code-token-property-color: var(--primitives-color-lintblauw-650);
+	--components-code-token-selector-color: var(--primitives-color-donkergeel-650);
+	--components-code-token-atrule-color: var(--primitives-color-groen-650);
+	--components-code-token-regex-color: var(--primitives-color-rood-650);
+	--components-code-token-url-color: var(--primitives-color-mintgroen-650);
+	--components-code-token-operator-color: var(--primitives-color-groen-650);
+	--components-code-token-constant-color: var(--primitives-color-oranje-650);
+	--components-code-token-deleted-color: var(--primitives-color-rood-650);
+	--components-code-token-inserted-color: var(--primitives-color-groen-650);
+	--components-code-token-important-color: var(--primitives-color-rood-650);
+	--components-code-token-symbol-color: var(--primitives-color-violet-650);
+	--components-code-token-entity-color: var(--primitives-color-paars-650);
+	--components-code-token-variable-color: var(--primitives-color-lintblauw-650);
+
 	/* ## List */
 
 	--components-list-corner-radius: var(--semantics-controls-md-corner-radius);

--- a/src/components/actions/button-bar/button-bar.stories.ts
+++ b/src/components/actions/button-bar/button-bar.stories.ts
@@ -9,6 +9,12 @@ export default {
 	tags: ['autodocs'],
 
 	argTypes: {
+		variant: {
+			control: 'select',
+			options: ['neutral-tinted', 'secondary', 'accent-filled', 'primary'],
+			description: 'Button bar variant',
+			table: { defaultValue: { summary: 'neutral-tinted' } },
+		},
 		size: {
 			control: 'select',
 			options: ['xs', 'sm', 'md'],
@@ -24,13 +30,30 @@ export default {
 };
 
 export const Default = {
-	args: { size: 'md', disabled: false },
+	args: { variant: 'neutral-tinted', size: 'md', disabled: false },
 	render: (args: Record<string, any>) => html`
-		<nldd-button-bar size=${args.size} ?disabled=${args.disabled}>
+		<nldd-button-bar size=${args.size} variant=${args.variant} ?disabled=${args.disabled}>
 			<nldd-icon-button icon="chevron-left" text="Vorige"></nldd-icon-button>
 			<nldd-button-bar-divider></nldd-button-bar-divider>
 			<nldd-icon-button icon="chevron-right" text="Volgende"></nldd-icon-button>
 		</nldd-button-bar>
+	`,
+};
+
+export const Variants = {
+	render: () => html`
+		<div style="display: flex; flex-wrap: wrap; gap: 16px; align-items: center;">
+			<nldd-button-bar variant="neutral-tinted">
+				<nldd-button text="Bewerk"></nldd-button>
+				<nldd-button-bar-divider></nldd-button-bar-divider>
+				<nldd-icon-button icon="trash" text="Verwijder"></nldd-icon-button>
+			</nldd-button-bar>
+			<nldd-button-bar variant="accent-filled">
+				<nldd-button text="Bewerk"></nldd-button>
+				<nldd-button-bar-divider></nldd-button-bar-divider>
+				<nldd-icon-button icon="trash" text="Verwijder"></nldd-icon-button>
+			</nldd-button-bar>
+		</div>
 	`,
 };
 
@@ -63,9 +86,9 @@ export const Sizes = {
 };
 
 export const WithoutDivider = {
-	args: { size: 'md', disabled: false },
+	args: { variant: 'neutral-tinted', size: 'md', disabled: false },
 	render: (args: Record<string, any>) => html`
-		<nldd-button-bar size=${args.size} ?disabled=${args.disabled}>
+		<nldd-button-bar size=${args.size} variant=${args.variant} ?disabled=${args.disabled}>
 			<nldd-button text="Cut"></nldd-button>
 			<nldd-button text="Copy"></nldd-button>
 			<nldd-button text="Paste"></nldd-button>

--- a/src/components/actions/button-bar/button-bar.styles.ts
+++ b/src/components/actions/button-bar/button-bar.styles.ts
@@ -32,7 +32,24 @@ export const buttonBarStyles = css`
 		flex-direction: row;
 		justify-content: center;
 		align-items: center;
+	}
+
+
+	/* # Variants */
+
+	/* ## Variant: Neutral Tinted (Default) / Secondary */
+
+	:host([variant="neutral-tinted"]) .button-bar,
+	:host([variant="secondary"]) .button-bar,
+	:host(:not([variant])) .button-bar {
 		background-color: var(--semantics-buttons-neutral-tinted-background-color);
+	}
+
+	/* ## Variant: Accent Filled / Primary */
+
+	:host([variant="accent-filled"]) .button-bar,
+	:host([variant="primary"]) .button-bar {
+		background-color: var(--semantics-buttons-accent-filled-background-color);
 	}
 
 
@@ -86,6 +103,11 @@ export const buttonBarStyles = css`
 	.button-bar__divider-line {
 		width: var(--semantics-dividers-thickness);
 		background-color: var(--semantics-buttons-neutral-tinted-divider-color);
+	}
+
+	:host([variant="accent-filled"]) .button-bar__divider-line,
+	:host([variant="primary"]) .button-bar__divider-line {
+		background-color: var(--semantics-buttons-accent-filled-divider-color);
 	}
 
 	:host([size="xs"]) .button-bar__divider-line {

--- a/src/components/actions/button-bar/button-bar.test.ts
+++ b/src/components/actions/button-bar/button-bar.test.ts
@@ -115,6 +115,35 @@ describe('nldd-button-bar – child building & attribute propagation', () => {
 		expect(el.querySelector('nldd-icon-button')!.getAttribute('size')).toBe('sm');
 	});
 
+	it('propagates initial variant to button children', async () => {
+		el = await fixture<NLDDButtonBar>(`
+			<nldd-button-bar variant="accent-filled">
+				<nldd-button text="A"></nldd-button>
+				<nldd-icon-button icon="x" text="Close"></nldd-icon-button>
+			</nldd-button-bar>
+		`);
+		await waitForUpdate(el);
+
+		expect(el.querySelector('nldd-button')!.getAttribute('variant')).toBe('accent-filled');
+		expect(el.querySelector('nldd-icon-button')!.getAttribute('variant')).toBe('accent-filled');
+	});
+
+	it('propagates variant change to children', async () => {
+		el = await fixture<NLDDButtonBar>(`
+			<nldd-button-bar variant="neutral-tinted">
+				<nldd-button text="A"></nldd-button>
+			</nldd-button-bar>
+		`);
+		await waitForUpdate(el);
+
+		expect(el.querySelector('nldd-button')!.getAttribute('variant')).toBe('neutral-tinted');
+
+		el.variant = 'accent-filled';
+		await waitForUpdate(el);
+
+		expect(el.querySelector('nldd-button')!.getAttribute('variant')).toBe('accent-filled');
+	});
+
 	it('propagates size change to children', async () => {
 		el = await fixture<NLDDButtonBar>(`
 			<nldd-button-bar size="md">

--- a/src/components/actions/button-group/button-group.styles.ts
+++ b/src/components/actions/button-group/button-group.styles.ts
@@ -22,7 +22,6 @@ export const buttonGroupStyles = css`
 
 	.button-group {
 		display: flex;
-		justify-content: center;
 	}
 
 

--- a/src/components/actions/button/button.styles.ts
+++ b/src/components/actions/button/button.styles.ts
@@ -120,11 +120,13 @@ export const buttonStyles = css`
 		color: var(--semantics-buttons-neutral-tinted-content-color);
 	}
 
-	:host([variant="neutral-tinted"]) .button:hover,
-	:host([variant="secondary"]) .button:hover,
-	:host(:not([variant])) .button:hover {
-		background-color: var(--semantics-buttons-neutral-tinted-is-hovered-background-color);
-		color: var(--semantics-buttons-neutral-tinted-is-hovered-content-color);
+	@media (hover: hover) {
+		:host([variant="neutral-tinted"]) .button:hover,
+		:host([variant="secondary"]) .button:hover,
+		:host(:not([variant])) .button:hover {
+			background-color: var(--semantics-buttons-neutral-tinted-is-hovered-background-color);
+			color: var(--semantics-buttons-neutral-tinted-is-hovered-content-color);
+		}
 	}
 
 	:host([variant="neutral-tinted"]) .button:active,
@@ -141,8 +143,10 @@ export const buttonStyles = css`
 		color: var(--semantics-buttons-neutral-transparent-content-color);
 	}
 
-	:host([variant="neutral-transparent"]) .button:hover {
-		color: var(--semantics-buttons-neutral-transparent-is-hovered-content-color);
+	@media (hover: hover) {
+		:host([variant="neutral-transparent"]) .button:hover {
+			color: var(--semantics-buttons-neutral-transparent-is-hovered-content-color);
+		}
 	}
 
 	:host([variant="neutral-transparent"]) .button:active {
@@ -157,10 +161,12 @@ export const buttonStyles = css`
 		color: var(--semantics-buttons-accent-filled-content-color);
 	}
 
-	:host([variant="accent-filled"]) .button:hover,
-	:host([variant="primary"]) .button:hover {
-		background-color: var(--semantics-buttons-accent-filled-is-hovered-background-color);
-		color: var(--semantics-buttons-accent-filled-is-hovered-content-color);
+	@media (hover: hover) {
+		:host([variant="accent-filled"]) .button:hover,
+		:host([variant="primary"]) .button:hover {
+			background-color: var(--semantics-buttons-accent-filled-is-hovered-background-color);
+			color: var(--semantics-buttons-accent-filled-is-hovered-content-color);
+		}
 	}
 
 	:host([variant="accent-filled"]) .button:active,
@@ -198,9 +204,11 @@ export const buttonStyles = css`
 		;
 	}
 
-	:host([variant="accent-outlined"]) .button:hover {
-		color: var(--semantics-buttons-accent-outlined-is-hovered-content-color);
-		border-color: var(--semantics-buttons-accent-outlined-is-hovered-border-color);
+	@media (hover: hover) {
+		:host([variant="accent-outlined"]) .button:hover {
+			color: var(--semantics-buttons-accent-outlined-is-hovered-content-color);
+			border-color: var(--semantics-buttons-accent-outlined-is-hovered-border-color);
+		}
 	}
 
 	:host([variant="accent-outlined"]) .button:active {
@@ -215,8 +223,10 @@ export const buttonStyles = css`
 		color: var(--semantics-buttons-accent-transparent-content-color);
 	}
 
-	:host([variant="accent-transparent"]) .button:hover {
-		color: var(--semantics-buttons-accent-transparent-is-hovered-content-color);
+	@media (hover: hover) {
+		:host([variant="accent-transparent"]) .button:hover {
+			color: var(--semantics-buttons-accent-transparent-is-hovered-content-color);
+		}
 	}
 
 	:host([variant="accent-transparent"]) .button:active {
@@ -231,10 +241,12 @@ export const buttonStyles = css`
 		color: var(--semantics-buttons-critical-tinted-content-color);
 	}
 
-	:host([variant="critical-tinted"]) .button:hover,
-	:host([variant="destructive"]) .button:hover {
-		background-color: var(--semantics-buttons-critical-tinted-is-hovered-background-color);
-		color: var(--semantics-buttons-critical-tinted-is-hovered-content-color);
+	@media (hover: hover) {
+		:host([variant="critical-tinted"]) .button:hover,
+		:host([variant="destructive"]) .button:hover {
+			background-color: var(--semantics-buttons-critical-tinted-is-hovered-background-color);
+			color: var(--semantics-buttons-critical-tinted-is-hovered-content-color);
+		}
 	}
 
 	:host([variant="critical-tinted"]) .button:active,

--- a/src/components/actions/icon-button/icon-button.stories.ts
+++ b/src/components/actions/icon-button/icon-button.stories.ts
@@ -100,6 +100,14 @@ export default {
 			control: 'text',
 			description: 'Overschrijft de tekst als aria-label en title tooltip voor schermlezer-context. Gebruik als de zichtbare tekst onvoldoende context biedt (bijv. tekst "Toon", accessible-label "Toon wachtwoord"). De tekst blijft zichtbaar in lg formaat.',
 		},
+		hideTooltip: {
+			name: 'hide-tooltip',
+			control: 'boolean',
+			description: 'Onderdrukt de visuele tooltip (aria-label blijft intact). Gebruik wanneer de context al duidelijk is (bv. spin-knoppen in nldd-number-field, chevron in nldd-split-button).',
+			table: {
+				defaultValue: { summary: false },
+			},
+		},
 		disabled: {
 			control: 'boolean',
 			description: 'Uitgeschakelde toestand',
@@ -119,11 +127,12 @@ export default {
 		href: '',
 		target: '',
 		accessibleLabel: '',
+		hideTooltip: false,
 		disabled: false,
 	},
 };
 
-const Template = ({ variant, size, fullWidth, expandable, text, icon, type, href, target, accessibleLabel, disabled }: Record<string, any>) => html`
+const Template = ({ variant, size, fullWidth, expandable, text, icon, type, href, target, accessibleLabel, hideTooltip, disabled }: Record<string, any>) => html`
 	<nldd-icon-button
 		variant=${variant}
 		size=${size}
@@ -136,6 +145,7 @@ const Template = ({ variant, size, fullWidth, expandable, text, icon, type, href
 		target=${target || nothing}
 		?disabled=${disabled}
 		accessible-label=${accessibleLabel || nothing}
+		?hide-tooltip=${hideTooltip}
 	></nldd-icon-button>
 `;
 

--- a/src/components/actions/icon-button/icon-button.styles.ts
+++ b/src/components/actions/icon-button/icon-button.styles.ts
@@ -177,11 +177,13 @@ export const iconButtonStyles = css`
 		color: var(--semantics-buttons-neutral-tinted-content-color);
 	}
 
-	:host([variant='neutral-tinted']) .icon-button:hover,
-	:host([variant='secondary']) .icon-button:hover,
-	:host(:not([variant])) .icon-button:hover {
-		background-color: var(--semantics-buttons-neutral-tinted-is-hovered-background-color);
-		color: var(--semantics-buttons-neutral-tinted-is-hovered-content-color);
+	@media (hover: hover) {
+		:host([variant='neutral-tinted']) .icon-button:hover,
+		:host([variant='secondary']) .icon-button:hover,
+		:host(:not([variant])) .icon-button:hover {
+			background-color: var(--semantics-buttons-neutral-tinted-is-hovered-background-color);
+			color: var(--semantics-buttons-neutral-tinted-is-hovered-content-color);
+		}
 	}
 
 	:host([variant='neutral-tinted']) .icon-button:active,
@@ -198,9 +200,11 @@ export const iconButtonStyles = css`
 		color: var(--semantics-buttons-neutral-transparent-content-color);
 	}
 
-	:host([variant='neutral-transparent']) .icon-button:hover {
-		background-color: transparent;
-		color: var(--semantics-buttons-neutral-transparent-is-hovered-content-color);
+	@media (hover: hover) {
+		:host([variant='neutral-transparent']) .icon-button:hover {
+			background-color: transparent;
+			color: var(--semantics-buttons-neutral-transparent-is-hovered-content-color);
+		}
 	}
 
 	:host([variant='neutral-transparent']) .icon-button:active {
@@ -215,10 +219,12 @@ export const iconButtonStyles = css`
 		color: var(--semantics-buttons-accent-filled-content-color);
 	}
 
-	:host([variant='accent-filled']) .icon-button:hover,
-	:host([variant='primary']) .icon-button:hover {
-		background-color: var(--semantics-buttons-accent-filled-is-hovered-background-color);
-		color: var(--semantics-buttons-accent-filled-is-hovered-content-color);
+	@media (hover: hover) {
+		:host([variant='accent-filled']) .icon-button:hover,
+		:host([variant='primary']) .icon-button:hover {
+			background-color: var(--semantics-buttons-accent-filled-is-hovered-background-color);
+			color: var(--semantics-buttons-accent-filled-is-hovered-content-color);
+		}
 	}
 
 	:host([variant='accent-filled']) .icon-button:active,
@@ -253,9 +259,11 @@ export const iconButtonStyles = css`
 		padding: calc(var(--primitives-space-4) - var(--semantics-buttons-accent-outlined-border-thickness));
 	}
 
-	:host([variant='accent-outlined']) .icon-button:hover {
-		border-color: var(--semantics-buttons-accent-outlined-is-hovered-border-color);
-		color: var(--semantics-buttons-accent-outlined-is-hovered-content-color);
+	@media (hover: hover) {
+		:host([variant='accent-outlined']) .icon-button:hover {
+			border-color: var(--semantics-buttons-accent-outlined-is-hovered-border-color);
+			color: var(--semantics-buttons-accent-outlined-is-hovered-content-color);
+		}
 	}
 
 	:host([variant='accent-outlined']) .icon-button:active {
@@ -270,8 +278,10 @@ export const iconButtonStyles = css`
 		color: var(--semantics-buttons-accent-transparent-content-color);
 	}
 
-	:host([variant='accent-transparent']) .icon-button:hover {
-		color: var(--semantics-buttons-accent-transparent-is-hovered-content-color);
+	@media (hover: hover) {
+		:host([variant='accent-transparent']) .icon-button:hover {
+			color: var(--semantics-buttons-accent-transparent-is-hovered-content-color);
+		}
 	}
 
 	:host([variant='accent-transparent']) .icon-button:active {
@@ -286,10 +296,12 @@ export const iconButtonStyles = css`
 		color: var(--semantics-buttons-critical-tinted-content-color);
 	}
 
-	:host([variant='critical-tinted']) .icon-button:hover,
-	:host([variant='destructive']) .icon-button:hover {
-		background-color: var(--semantics-buttons-critical-tinted-is-hovered-background-color);
-		color: var(--semantics-buttons-critical-tinted-is-hovered-content-color);
+	@media (hover: hover) {
+		:host([variant='critical-tinted']) .icon-button:hover,
+		:host([variant='destructive']) .icon-button:hover {
+			background-color: var(--semantics-buttons-critical-tinted-is-hovered-background-color);
+			color: var(--semantics-buttons-critical-tinted-is-hovered-content-color);
+		}
 	}
 
 	:host([variant='critical-tinted']) .icon-button:active,

--- a/src/components/actions/icon-button/icon-button.template.ts
+++ b/src/components/actions/icon-button/icon-button.template.ts
@@ -61,7 +61,7 @@ export function template(this: NLDDIconButton) {
 		`;
 	};
 
-	if (tooltipText) {
+	if (tooltipText && !this.hideTooltip) {
 		return html`
 			<nldd-tooltip text=${tooltipText}>
 				${renderButton()}

--- a/src/components/actions/icon-button/icon-button.ts
+++ b/src/components/actions/icon-button/icon-button.ts
@@ -14,6 +14,10 @@
  *                                     and title tooltip. Use when the visible text alone lacks context for screen
  *                                     readers (e.g. text "Toon", accessible-label "Toon wachtwoord").
  *                                     The text is still shown visually in lg size regardless.
+ * @attr {boolean} hide-tooltip      - Suppress the visual tooltip while keeping aria-label intact.
+ *                                     Use when the surrounding context already explains the button
+ *                                     (e.g. spin buttons in nldd-number-field, the chevron in
+ *                                     nldd-split-button) — screen readers still get the label.
  * @attr {string}  href              - When set, renders an <a> element instead of <button>
  * @attr {string}  target            - Link target (e.g. '_blank'); only used when href is set
  * @attr {string}  rel               - Link rel attribute; defaults to 'noopener noreferrer' when target is '_blank'
@@ -84,6 +88,10 @@ export class NLDDIconButton extends LitElement {
 	 *  The text is still shown visually in lg size regardless. */
 	@property({ type: String, attribute: 'accessible-label' })
 	accessibleLabel = '';
+
+	/** Suppress the visual tooltip while keeping aria-label intact. */
+	@property({ type: Boolean, reflect: true, attribute: 'hide-tooltip' })
+	hideTooltip = false;
 
 	/** When set, renders an <a> element instead of <button>. */
 	@property({ type: String, reflect: true })

--- a/src/components/actions/link/link.styles.ts
+++ b/src/components/actions/link/link.styles.ts
@@ -54,8 +54,10 @@ export const linkStyles = css`
 		font: var(--primitives-font-body-lg-regular-flat);
 	}
 
-	.link:hover {
-		color: var(--semantics-links-is-hovered-color);
+	@media (hover: hover) {
+		.link:hover {
+			color: var(--semantics-links-is-hovered-color);
+		}
 	}
 
 	.link:active {

--- a/src/components/actions/split-button/split-button.stories.ts
+++ b/src/components/actions/split-button/split-button.stories.ts
@@ -25,6 +25,14 @@ export default {
 		},
 	},
 	argTypes: {
+		variant: {
+			control: 'select',
+			options: ['neutral-tinted', 'secondary', 'accent-filled', 'primary'],
+			description: 'Button variant',
+			table: {
+				defaultValue: { summary: 'neutral-tinted' },
+			},
+		},
 		size: {
 			control: 'select',
 			options: ['xs', 'sm', 'md'],
@@ -46,6 +54,7 @@ export default {
 		},
 	},
 	args: {
+		variant: 'neutral-tinted',
 		size: 'md',
 		text: 'Opslaan',
 		disabled: false,
@@ -59,10 +68,11 @@ const menuItems = html`
 	<nldd-menu-item text="Verwijderen" @select=${action('select: delete')}></nldd-menu-item>
 `;
 
-const Template = ({ size, text, disabled }: Record<string, any>) => html`
+const Template = ({ size, variant, text, disabled }: Record<string, any>) => html`
 	<nldd-split-button
 		text=${text}
 		size=${size}
+		variant=${variant}
 		?disabled=${disabled}
 		@action-click=${action('action-click')}
 		@menu-click=${action('menu-click')}
@@ -72,6 +82,19 @@ const Template = ({ size, text, disabled }: Record<string, any>) => html`
 export const Default = {
 	render: Template,
 	args: {},
+};
+
+// All variants overview
+export const Variants = {
+	render: () => html`
+	<div style="display: flex; flex-wrap: wrap; gap: 16px; align-items: center;">
+		<nldd-split-button text="Opslaan" variant="neutral-tinted">${menuItems}</nldd-split-button>
+		<nldd-split-button text="Opslaan" variant="accent-filled">${menuItems}</nldd-split-button>
+	</div>
+`,
+	parameters: {
+		controls: { disable: true },
+	},
 };
 
 // All sizes overview

--- a/src/components/actions/split-button/split-button.styles.ts
+++ b/src/components/actions/split-button/split-button.styles.ts
@@ -81,11 +81,19 @@ export const splitButtonStyles = css`
 
 	/* # Variants */
 
-	/* ## Variant: Neutral Tintend (Default) */
+	/* ## Variant: Neutral Tintend (Default) / Secondary */
 
 	:host([variant="neutral-tinted"]) .split-button,
+	:host([variant="secondary"]) .split-button,
 	:host(:not([variant])) .split-button {
 		background-color: var(--semantics-buttons-neutral-tinted-background-color);
+	}
+
+	/* ## Variant: Accent Filled / Primary */
+
+	:host([variant="accent-filled"]) .split-button,
+	:host([variant="primary"]) .split-button {
+		background-color: var(--semantics-buttons-accent-filled-background-color);
 	}
 
 
@@ -95,5 +103,10 @@ export const splitButtonStyles = css`
 		width: 1px;
 		flex-shrink: 0;
 		background-color: var(--semantics-buttons-neutral-tinted-divider-color);
+	}
+
+	:host([variant="accent-filled"]) .split-button__divider,
+	:host([variant="primary"]) .split-button__divider {
+		background-color: var(--semantics-buttons-accent-filled-divider-color);
 	}
 `;

--- a/src/components/actions/split-button/split-button.template.ts
+++ b/src/components/actions/split-button/split-button.template.ts
@@ -18,6 +18,7 @@ export function template(this: NLDDSplitButton) {
 				size=${this.size}
 				icon="chevron-down-small"
 				text=${this._t('components.split-button.menu-action')}
+				hide-tooltip
 				?disabled=${this.disabled}
 				aria-haspopup="menu"
 				aria-expanded=${this._hasMenuItems ? String(this._menuIsOpen) : nothing}

--- a/src/components/actions/toolbar/toolbar.styles.ts
+++ b/src/components/actions/toolbar/toolbar.styles.ts
@@ -6,8 +6,6 @@ export const toolbarStyles = css`
 	/* # Host */
 
 	:host {
-		display: block;
-		box-sizing: border-box;
 		--_item-width: auto;
 		--_item-min-width: 0px;
 		--_title-group-min-width: 200px;
@@ -18,6 +16,9 @@ export const toolbarStyles = css`
 		--_center-width: 0px;
 		--_end-width: 0px;
 		--_overflow-button-width: 0px;
+
+		display: block;
+		box-sizing: border-box;
 	}
 
 	:host([hidden]) {

--- a/src/components/content/blockquote/blockquote.styles.ts
+++ b/src/components/content/blockquote/blockquote.styles.ts
@@ -12,6 +12,7 @@ export const blockquoteStyles = css`
 		--_spacing: var(--semantics-blockquotes-md-spacing);
 		--_quote-font: var(--semantics-blockquotes-md-quote-font);
 		--_attribution-font: var(--semantics-blockquotes-md-attribution-font);
+
 		display: block;
 		max-width: var(--semantics-blockquotes-max-width);
 	}

--- a/src/components/content/code/code.stories.ts
+++ b/src/components/content/code/code.stories.ts
@@ -1,0 +1,69 @@
+import { html } from 'lit';
+import './code.ts';
+
+export default {
+	title: 'Components/Content/Code',
+	component: 'nldd-code',
+	tags: ['autodocs'],
+	parameters: {
+		componentSource: {
+			file: 'src/components/content/code/code.ts',
+			repository: 'https://github.com/MinBZK/storybook',
+		},
+		status: { type: 'stable' },
+	},
+};
+
+export const Default = () => html`
+	<nldd-code>const greet = (name) =&gt; \`Hallo, \${name}!\`;
+console.log(greet('wereld'));</nldd-code>
+`;
+
+export const Trace = () => html`
+	<nldd-code>[engine] resolved input: bsn=999993653
+[engine] action 'heeft_recht_op_zorgtoeslag' = true
+[engine] action 'hoogte_zorgtoeslag' = 12345 (cents)
+[engine] elapsed 4ms</nldd-code>
+`;
+
+export const LongLines = () => html`
+	<nldd-code>function deeplyNestedFunctionWithAVeryLongNameThatExceedsTheTypicalContainerWidth(parameterOne, parameterTwo, parameterThree) {
+  return parameterOne + parameterTwo + parameterThree;
+}</nldd-code>
+`;
+
+export const Wrap = () => html`
+	<nldd-code wrap>function deeplyNestedFunctionWithAVeryLongNameThatExceedsTheTypicalContainerWidth(parameterOne, parameterTwo, parameterThree) {
+  return parameterOne + parameterTwo + parameterThree;
+}</nldd-code>
+`;
+
+export const HighlightYaml = () => html`
+	<nldd-code language="yaml"># wet_op_de_zorgtoeslag — artikel 2
+$id: zorgtoeslagwet
+articles:
+  - number: '2'
+    title: 'Recht op zorgtoeslag'
+    is_active: true
+    threshold: 32502
+    actions:
+      - output: heeft_recht_op_zorgtoeslag
+        operation: AND</nldd-code>
+`;
+
+export const HighlightJson = () => html`
+	<nldd-code language="json">{
+  "lawId": "zorgtoeslagwet",
+  "article": 2,
+  "active": true,
+  "outputs": ["heeft_recht_op_zorgtoeslag", "hoogte_zorgtoeslag"]
+}</nldd-code>
+`;
+
+export const HighlightJavaScript = () => html`
+	<nldd-code language="javascript">// Compute eligibility
+function isEligible(person, threshold = 32502) {
+  if (person.income > threshold) return false;
+  return person.age >= 18 && person.insured;
+}</nldd-code>
+`;

--- a/src/components/content/code/code.stories.ts
+++ b/src/components/content/code/code.stories.ts
@@ -10,7 +10,7 @@ export default {
 			file: 'src/components/content/code/code.ts',
 			repository: 'https://github.com/MinBZK/storybook',
 		},
-		status: { type: 'stable' },
+		status: { type: 'beta' },
 	},
 };
 

--- a/src/components/content/code/code.styles.ts
+++ b/src/components/content/code/code.styles.ts
@@ -13,35 +13,6 @@ export const codeStyles = css`
 		--_corner-radius: var(--primitives-corner-radius-lg);
 		--_font: var(--primitives-font-monospace-sm-regular-snug);
 
-		/* Token theme — Solarized-inspired, mapped to descriptive DS palettes.
-		   Override per-instance to swap colors. */
-		--_token-comment-color: var(--semantics-content-secondary-color);
-		--_token-punctuation-color: var(--_content-color);
-		--_token-keyword-color: var(--primitives-color-donkergeel-650);
-		--_token-string-color: var(--primitives-color-groen-650);
-		--_token-number-color: var(--primitives-color-oranje-650);
-		--_token-boolean-color: var(--primitives-color-oranje-650);
-		--_token-null-color: var(--primitives-color-oranje-650);
-		--_token-function-color: var(--primitives-color-lintblauw-650);
-		--_token-class-color: var(--primitives-color-donkergeel-650);
-		--_token-builtin-color: var(--primitives-color-donkergeel-650);
-		--_token-tag-color: var(--primitives-color-groen-650);
-		--_token-attr-name-color: var(--primitives-color-lintblauw-650);
-		--_token-attr-value-color: var(--primitives-color-mintgroen-650);
-		--_token-property-color: var(--primitives-color-lintblauw-650);
-		--_token-selector-color: var(--primitives-color-donkergeel-650);
-		--_token-atrule-color: var(--primitives-color-groen-650);
-		--_token-regex-color: var(--primitives-color-rood-650);
-		--_token-url-color: var(--primitives-color-mintgroen-650);
-		--_token-operator-color: var(--primitives-color-groen-650);
-		--_token-constant-color: var(--primitives-color-oranje-650);
-		--_token-deleted-color: var(--primitives-color-rood-650);
-		--_token-inserted-color: var(--primitives-color-groen-650);
-		--_token-important-color: var(--primitives-color-rood-650);
-		--_token-symbol-color: var(--primitives-color-violet-650);
-		--_token-entity-color: var(--primitives-color-paars-650);
-		--_token-variable-color: var(--primitives-color-lintblauw-650);
-
 		display: block;
 	}
 
@@ -84,45 +55,79 @@ export const codeStyles = css`
 	}
 
 
-	/* # Tokens (Prism) */
+	/* # Tokens (Prism)
+	 *
+	 * Component-level token theme — Solarized-inspired, mapped to
+	 * descriptive DS palettes. These are part of the public API: consumers
+	 * can override per-instance to swap colors. Documented in the JSDoc
+	 * of nldd-code (see code.ts). */
+
+	:host {
+		--components-code-token-comment-color: var(--semantics-content-secondary-color);
+		--components-code-token-punctuation-color: var(--_content-color);
+		--components-code-token-keyword-color: var(--primitives-color-donkergeel-650);
+		--components-code-token-string-color: var(--primitives-color-groen-650);
+		--components-code-token-number-color: var(--primitives-color-oranje-650);
+		--components-code-token-boolean-color: var(--primitives-color-oranje-650);
+		--components-code-token-null-color: var(--primitives-color-oranje-650);
+		--components-code-token-function-color: var(--primitives-color-lintblauw-650);
+		--components-code-token-class-color: var(--primitives-color-donkergeel-650);
+		--components-code-token-builtin-color: var(--primitives-color-donkergeel-650);
+		--components-code-token-tag-color: var(--primitives-color-groen-650);
+		--components-code-token-attr-name-color: var(--primitives-color-lintblauw-650);
+		--components-code-token-attr-value-color: var(--primitives-color-mintgroen-650);
+		--components-code-token-property-color: var(--primitives-color-lintblauw-650);
+		--components-code-token-selector-color: var(--primitives-color-donkergeel-650);
+		--components-code-token-atrule-color: var(--primitives-color-groen-650);
+		--components-code-token-regex-color: var(--primitives-color-rood-650);
+		--components-code-token-url-color: var(--primitives-color-mintgroen-650);
+		--components-code-token-operator-color: var(--primitives-color-groen-650);
+		--components-code-token-constant-color: var(--primitives-color-oranje-650);
+		--components-code-token-deleted-color: var(--primitives-color-rood-650);
+		--components-code-token-inserted-color: var(--primitives-color-groen-650);
+		--components-code-token-important-color: var(--primitives-color-rood-650);
+		--components-code-token-symbol-color: var(--primitives-color-violet-650);
+		--components-code-token-entity-color: var(--primitives-color-paars-650);
+		--components-code-token-variable-color: var(--primitives-color-lintblauw-650);
+	}
 
 	.token.comment,
 	.token.prolog,
 	.token.doctype,
-	.token.cdata { color: var(--_token-comment-color); font-style: italic; }
+	.token.cdata { color: var(--components-code-token-comment-color); font-style: italic; }
 
-	.token.punctuation { color: var(--_token-punctuation-color); }
+	.token.punctuation { color: var(--components-code-token-punctuation-color); }
 
 	.token.namespace { opacity: 0.7; }
 
-	.token.keyword { color: var(--_token-keyword-color); }
+	.token.keyword { color: var(--components-code-token-keyword-color); }
 	.token.string,
-	.token.char { color: var(--_token-string-color); }
-	.token.number { color: var(--_token-number-color); }
-	.token.boolean { color: var(--_token-boolean-color); }
-	.token.null { color: var(--_token-null-color); }
-	.token.function { color: var(--_token-function-color); }
-	.token.class-name { color: var(--_token-class-color); }
-	.token.builtin { color: var(--_token-builtin-color); }
-	.token.tag { color: var(--_token-tag-color); }
-	.token.attr-name { color: var(--_token-attr-name-color); }
-	.token.attr-value { color: var(--_token-attr-value-color); }
-	.token.property { color: var(--_token-property-color); }
-	.token.selector { color: var(--_token-selector-color); }
-	.token.atrule { color: var(--_token-atrule-color); }
-	.token.regex { color: var(--_token-regex-color); }
-	.token.url { color: var(--_token-url-color); }
-	.token.operator { color: var(--_token-operator-color); }
-	.token.constant { color: var(--_token-constant-color); }
-	.token.deleted { color: var(--_token-deleted-color); }
-	.token.inserted { color: var(--_token-inserted-color); }
-	.token.important { color: var(--_token-important-color); font-weight: bold; }
-	.token.symbol { color: var(--_token-symbol-color); }
-	.token.entity { color: var(--_token-entity-color); }
-	.token.variable { color: var(--_token-variable-color); }
+	.token.char { color: var(--components-code-token-string-color); }
+	.token.number { color: var(--components-code-token-number-color); }
+	.token.boolean { color: var(--components-code-token-boolean-color); }
+	.token.null { color: var(--components-code-token-null-color); }
+	.token.function { color: var(--components-code-token-function-color); }
+	.token.class-name { color: var(--components-code-token-class-color); }
+	.token.builtin { color: var(--components-code-token-builtin-color); }
+	.token.tag { color: var(--components-code-token-tag-color); }
+	.token.attr-name { color: var(--components-code-token-attr-name-color); }
+	.token.attr-value { color: var(--components-code-token-attr-value-color); }
+	.token.property { color: var(--components-code-token-property-color); }
+	.token.selector { color: var(--components-code-token-selector-color); }
+	.token.atrule { color: var(--components-code-token-atrule-color); }
+	.token.regex { color: var(--components-code-token-regex-color); }
+	.token.url { color: var(--components-code-token-url-color); }
+	.token.operator { color: var(--components-code-token-operator-color); }
+	.token.constant { color: var(--components-code-token-constant-color); }
+	.token.deleted { color: var(--components-code-token-deleted-color); }
+	.token.inserted { color: var(--components-code-token-inserted-color); }
+	.token.important { color: var(--components-code-token-important-color); font-weight: bold; }
+	.token.symbol { color: var(--components-code-token-symbol-color); }
+	.token.entity { color: var(--components-code-token-entity-color); }
+	.token.variable { color: var(--components-code-token-variable-color); }
 
 	/* YAML key uses the property/keyword slot so YAML reads naturally */
-	.token.key { color: var(--_token-property-color); }
+	.token.key { color: var(--components-code-token-property-color); }
 
 	.token.bold { font-weight: bold; }
 	.token.italic { font-style: italic; }

--- a/src/components/content/code/code.styles.ts
+++ b/src/components/content/code/code.styles.ts
@@ -57,39 +57,10 @@ export const codeStyles = css`
 
 	/* # Tokens (Prism)
 	 *
-	 * Component-level token theme — Solarized-inspired, mapped to
-	 * descriptive DS palettes. These are part of the public API: consumers
-	 * can override per-instance to swap colors. Documented in the JSDoc
-	 * of nldd-code (see code.ts). */
-
-	:host {
-		--components-code-token-comment-color: var(--semantics-content-secondary-color);
-		--components-code-token-punctuation-color: var(--_content-color);
-		--components-code-token-keyword-color: var(--primitives-color-donkergeel-650);
-		--components-code-token-string-color: var(--primitives-color-groen-650);
-		--components-code-token-number-color: var(--primitives-color-oranje-650);
-		--components-code-token-boolean-color: var(--primitives-color-oranje-650);
-		--components-code-token-null-color: var(--primitives-color-oranje-650);
-		--components-code-token-function-color: var(--primitives-color-lintblauw-650);
-		--components-code-token-class-color: var(--primitives-color-donkergeel-650);
-		--components-code-token-builtin-color: var(--primitives-color-donkergeel-650);
-		--components-code-token-tag-color: var(--primitives-color-groen-650);
-		--components-code-token-attr-name-color: var(--primitives-color-lintblauw-650);
-		--components-code-token-attr-value-color: var(--primitives-color-mintgroen-650);
-		--components-code-token-property-color: var(--primitives-color-lintblauw-650);
-		--components-code-token-selector-color: var(--primitives-color-donkergeel-650);
-		--components-code-token-atrule-color: var(--primitives-color-groen-650);
-		--components-code-token-regex-color: var(--primitives-color-rood-650);
-		--components-code-token-url-color: var(--primitives-color-mintgroen-650);
-		--components-code-token-operator-color: var(--primitives-color-groen-650);
-		--components-code-token-constant-color: var(--primitives-color-oranje-650);
-		--components-code-token-deleted-color: var(--primitives-color-rood-650);
-		--components-code-token-inserted-color: var(--primitives-color-groen-650);
-		--components-code-token-important-color: var(--primitives-color-rood-650);
-		--components-code-token-symbol-color: var(--primitives-color-violet-650);
-		--components-code-token-entity-color: var(--primitives-color-paars-650);
-		--components-code-token-variable-color: var(--primitives-color-lintblauw-650);
-	}
+	 * Token theme — Solarized-inspired, mapped to descriptive DS palettes.
+	 * Defaults defined in settings.css under --components-code-token-*;
+	 * consumers can override per-instance to swap colors. Documented in
+	 * the JSDoc of nldd-code (see code.ts). */
 
 	.token.comment,
 	.token.prolog,

--- a/src/components/content/code/code.styles.ts
+++ b/src/components/content/code/code.styles.ts
@@ -1,0 +1,129 @@
+import { css } from 'lit';
+
+export const codeStyles = css`
+
+
+	/* # Host */
+
+	:host {
+		--_background-color: var(--semantics-surfaces-tinted-background-color);
+		--_content-color: var(--semantics-content-color);
+		--_inline-padding: var(--primitives-space-16);
+		--_block-padding: var(--primitives-space-16);
+		--_corner-radius: var(--primitives-corner-radius-lg);
+		--_font: var(--primitives-font-monospace-sm-regular-snug);
+
+		/* Token theme — Solarized-inspired, mapped to descriptive DS palettes.
+		   Override per-instance to swap colors. */
+		--_token-comment-color: var(--semantics-content-secondary-color);
+		--_token-punctuation-color: var(--_content-color);
+		--_token-keyword-color: var(--primitives-color-donkergeel-650);
+		--_token-string-color: var(--primitives-color-groen-650);
+		--_token-number-color: var(--primitives-color-oranje-650);
+		--_token-boolean-color: var(--primitives-color-oranje-650);
+		--_token-null-color: var(--primitives-color-oranje-650);
+		--_token-function-color: var(--primitives-color-lintblauw-650);
+		--_token-class-color: var(--primitives-color-donkergeel-650);
+		--_token-builtin-color: var(--primitives-color-donkergeel-650);
+		--_token-tag-color: var(--primitives-color-groen-650);
+		--_token-attr-name-color: var(--primitives-color-lintblauw-650);
+		--_token-attr-value-color: var(--primitives-color-mintgroen-650);
+		--_token-property-color: var(--primitives-color-lintblauw-650);
+		--_token-selector-color: var(--primitives-color-donkergeel-650);
+		--_token-atrule-color: var(--primitives-color-groen-650);
+		--_token-regex-color: var(--primitives-color-rood-650);
+		--_token-url-color: var(--primitives-color-mintgroen-650);
+		--_token-operator-color: var(--primitives-color-groen-650);
+		--_token-constant-color: var(--primitives-color-oranje-650);
+		--_token-deleted-color: var(--primitives-color-rood-650);
+		--_token-inserted-color: var(--primitives-color-groen-650);
+		--_token-important-color: var(--primitives-color-rood-650);
+		--_token-symbol-color: var(--primitives-color-violet-650);
+		--_token-entity-color: var(--primitives-color-paars-650);
+		--_token-variable-color: var(--primitives-color-lintblauw-650);
+
+		display: block;
+	}
+
+	:host([hidden]) {
+		display: none;
+	}
+
+
+	/* # Block */
+
+	.code {
+		margin: 0;
+		padding: var(--_block-padding) var(--_inline-padding);
+		background-color: var(--_background-color);
+		color: var(--_content-color);
+		border-radius: var(--_corner-radius);
+		font: var(--_font);
+		overflow-x: auto;
+		white-space: pre;
+	}
+
+	:host([wrap]) .code {
+		overflow-x: visible;
+		white-space: pre-wrap;
+		word-break: break-word;
+	}
+
+	/* When highlighting is active, hide the raw slot output and show the
+	   tokenised <code> instead. The slot stays in the tree as the source
+	   of truth — slotchange listens there and feeds the highlighter.
+	   Lit reflects empty-string properties as language="" attributes,
+	   so we explicitly exclude that case. */
+	:host([language]:not([language=""])) slot {
+		display: none;
+	}
+
+	.code__highlighted {
+		font: inherit;
+		color: inherit;
+	}
+
+
+	/* # Tokens (Prism) */
+
+	.token.comment,
+	.token.prolog,
+	.token.doctype,
+	.token.cdata { color: var(--_token-comment-color); font-style: italic; }
+
+	.token.punctuation { color: var(--_token-punctuation-color); }
+
+	.token.namespace { opacity: 0.7; }
+
+	.token.keyword { color: var(--_token-keyword-color); }
+	.token.string,
+	.token.char { color: var(--_token-string-color); }
+	.token.number { color: var(--_token-number-color); }
+	.token.boolean { color: var(--_token-boolean-color); }
+	.token.null { color: var(--_token-null-color); }
+	.token.function { color: var(--_token-function-color); }
+	.token.class-name { color: var(--_token-class-color); }
+	.token.builtin { color: var(--_token-builtin-color); }
+	.token.tag { color: var(--_token-tag-color); }
+	.token.attr-name { color: var(--_token-attr-name-color); }
+	.token.attr-value { color: var(--_token-attr-value-color); }
+	.token.property { color: var(--_token-property-color); }
+	.token.selector { color: var(--_token-selector-color); }
+	.token.atrule { color: var(--_token-atrule-color); }
+	.token.regex { color: var(--_token-regex-color); }
+	.token.url { color: var(--_token-url-color); }
+	.token.operator { color: var(--_token-operator-color); }
+	.token.constant { color: var(--_token-constant-color); }
+	.token.deleted { color: var(--_token-deleted-color); }
+	.token.inserted { color: var(--_token-inserted-color); }
+	.token.important { color: var(--_token-important-color); font-weight: bold; }
+	.token.symbol { color: var(--_token-symbol-color); }
+	.token.entity { color: var(--_token-entity-color); }
+	.token.variable { color: var(--_token-variable-color); }
+
+	/* YAML key uses the property/keyword slot so YAML reads naturally */
+	.token.key { color: var(--_token-property-color); }
+
+	.token.bold { font-weight: bold; }
+	.token.italic { font-style: italic; }
+`;

--- a/src/components/content/code/code.template.ts
+++ b/src/components/content/code/code.template.ts
@@ -3,6 +3,16 @@ import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 import type { NLDDCode } from './code.js';
 
 export function codeTemplate(component: NLDDCode): TemplateResult {
+	// `language` is interpolated into a class name. Lit's tagged template
+	// literal escapes attribute values, so a malicious string can't break
+	// out of the attribute — but it can still produce a wonky class name.
+	// We accept that since `language` is a developer-set identifier, not
+	// user-supplied content.
+	//
+	// `unsafeHTML(_highlightedHtml)` injects the Prism output verbatim.
+	// Prism escapes HTML entities in its input (`<` → `&lt;`) before
+	// wrapping tokens in spans, so the only HTML in the output is the
+	// span scaffolding Prism itself emits. Safe by construction.
 	return html`<pre class="code"><slot @slotchange=${component._onSlotChange}></slot>${
 		component.language && component._highlightedHtml
 			? html`<code class="code__highlighted language-${component.language}">${unsafeHTML(component._highlightedHtml)}</code>`

--- a/src/components/content/code/code.template.ts
+++ b/src/components/content/code/code.template.ts
@@ -1,0 +1,11 @@
+import { html, TemplateResult } from 'lit';
+import { unsafeHTML } from 'lit/directives/unsafe-html.js';
+import type { NLDDCode } from './code.js';
+
+export function codeTemplate(component: NLDDCode): TemplateResult {
+	return html`<pre class="code"><slot @slotchange=${component._onSlotChange}></slot>${
+		component.language && component._highlightedHtml
+			? html`<code class="code__highlighted language-${component.language}">${unsafeHTML(component._highlightedHtml)}</code>`
+			: ''
+	}</pre>`;
+}

--- a/src/components/content/code/code.test.ts
+++ b/src/components/content/code/code.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { fixture, cleanup, waitForUpdate } from '../../../test-utils.ts';
+import './code.ts';
+
+describe('nldd-code', () => {
+	let el: HTMLElement;
+
+	afterEach(() => {
+		if (el) cleanup(el);
+	});
+
+	it('rendert zonder fouten', async () => {
+		el = await fixture('<nldd-code>hello</nldd-code>');
+		await waitForUpdate(el);
+		expect(el.shadowRoot).not.toBeNull();
+	});
+
+	it('rendert een pre element met de code class', async () => {
+		el = await fixture('<nldd-code>hello</nldd-code>');
+		await waitForUpdate(el);
+		const pre = el.shadowRoot!.querySelector('pre.code');
+		expect(pre).not.toBeNull();
+	});
+
+	it('toont slot content', async () => {
+		el = await fixture('<nldd-code>example content</nldd-code>');
+		await waitForUpdate(el);
+		const slot = el.shadowRoot!.querySelector('slot');
+		const assigned = slot!.assignedNodes({ flatten: true });
+		expect(assigned[0].textContent).toContain('example content');
+	});
+
+	it('reflects the wrap attribute', async () => {
+		el = await fixture('<nldd-code wrap>x</nldd-code>');
+		await waitForUpdate(el);
+		expect(el.hasAttribute('wrap')).toBe(true);
+	});
+});

--- a/src/components/content/code/code.test.ts
+++ b/src/components/content/code/code.test.ts
@@ -35,4 +35,34 @@ describe('nldd-code', () => {
 		await waitForUpdate(el);
 		expect(el.hasAttribute('wrap')).toBe(true);
 	});
+
+	it('renders the highlighted <code> wrapper only when language is set', async () => {
+		el = await fixture('<nldd-code>const x = 1;</nldd-code>');
+		await waitForUpdate(el);
+		expect(el.shadowRoot!.querySelector('code.code__highlighted')).toBeNull();
+	});
+
+	it('produces highlighted html with token spans for a known language', async () => {
+		el = await fixture('<nldd-code language="json">{"foo": 1, "bar": true}</nldd-code>');
+		await waitForUpdate(el);
+		const highlighted = el.shadowRoot!.querySelector('code.code__highlighted');
+		expect(highlighted).not.toBeNull();
+		// Prism wraps tokens in <span class="token …"> nodes.
+		expect(highlighted!.querySelectorAll('.token').length).toBeGreaterThan(0);
+	});
+
+	it('falls back to raw slot when language is unknown', async () => {
+		el = await fixture('<nldd-code language="not-a-real-language">plain text</nldd-code>');
+		await waitForUpdate(el);
+		expect(el.shadowRoot!.querySelector('code.code__highlighted')).toBeNull();
+	});
+
+	it('clears the highlighted html when language is removed', async () => {
+		el = await fixture<HTMLElement>('<nldd-code language="json">{"a":1}</nldd-code>');
+		await waitForUpdate(el);
+		expect(el.shadowRoot!.querySelector('code.code__highlighted')).not.toBeNull();
+		el.removeAttribute('language');
+		await waitForUpdate(el);
+		expect(el.shadowRoot!.querySelector('code.code__highlighted')).toBeNull();
+	});
 });

--- a/src/components/content/code/code.ts
+++ b/src/components/content/code/code.ts
@@ -64,7 +64,12 @@ function loadGrammar(language: string): Promise<unknown> | undefined {
 	if (!loader) return undefined;
 	let pending = grammarLoads.get(language);
 	if (!pending) {
-		pending = loader();
+		// Drop the cache entry on failure so a subsequent attempt can retry
+		// the import (e.g. transient chunk-load failure on a flaky network).
+		pending = loader().catch((err) => {
+			grammarLoads.delete(language);
+			throw err;
+		});
 		grammarLoads.set(language, pending);
 	}
 	return pending;

--- a/src/components/content/code/code.ts
+++ b/src/components/content/code/code.ts
@@ -12,10 +12,11 @@
  * than wrapping.
  *
  * ## Syntax highlighting
- * Set `language` to one of the bundled grammars (yaml, json, javascript,
+ * Set `language` to one of the supported grammars (yaml, json, javascript,
  * typescript, css, html, bash, markdown) to highlight the slot content
  * with Prism. Without `language` the slot content is rendered raw, no
- * highlighting applied.
+ * highlighting applied. Grammars are loaded lazily on first use, so a
+ * page that never sets `language` ships zero grammar code.
  *
  * ### Theming
  * Token colors are exposed as `--components-code-token-*` custom
@@ -38,16 +39,36 @@
 import { LitElement } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import Prism from 'prismjs';
-import 'prismjs/components/prism-yaml.js';
-import 'prismjs/components/prism-json.js';
-import 'prismjs/components/prism-javascript.js';
-import 'prismjs/components/prism-typescript.js';
-import 'prismjs/components/prism-css.js';
-import 'prismjs/components/prism-markup.js'; // covers html/xml/svg
-import 'prismjs/components/prism-bash.js';
-import 'prismjs/components/prism-markdown.js';
 import { codeStyles } from './code.styles.js';
 import { codeTemplate } from './code.template.js';
+
+/* Map our public language names to Prism grammar loaders. `html` shares
+ * the markup grammar (covers html/xml/svg). Static `import()` calls let
+ * the bundler emit one chunk per file, so consumers only download
+ * grammars they actually render. */
+const GRAMMAR_LOADERS: Record<string, () => Promise<unknown>> = {
+	yaml: () => import('prismjs/components/prism-yaml.js'),
+	json: () => import('prismjs/components/prism-json.js'),
+	javascript: () => import('prismjs/components/prism-javascript.js'),
+	typescript: () => import('prismjs/components/prism-typescript.js'),
+	css: () => import('prismjs/components/prism-css.js'),
+	html: () => import('prismjs/components/prism-markup.js'),
+	bash: () => import('prismjs/components/prism-bash.js'),
+	markdown: () => import('prismjs/components/prism-markdown.js'),
+};
+
+const grammarLoads = new Map<string, Promise<unknown>>();
+
+function loadGrammar(language: string): Promise<unknown> | undefined {
+	const loader = GRAMMAR_LOADERS[language];
+	if (!loader) return undefined;
+	let pending = grammarLoads.get(language);
+	if (!pending) {
+		pending = loader();
+		grammarLoads.set(language, pending);
+	}
+	return pending;
+}
 
 @customElement('nldd-code')
 export class NLDDCode extends LitElement {
@@ -62,6 +83,8 @@ export class NLDDCode extends LitElement {
 	@state()
 	_highlightedHtml = '';
 
+	private _highlightPending: Promise<void> = Promise.resolve();
+
 	override render() {
 		return codeTemplate(this);
 	}
@@ -74,12 +97,35 @@ export class NLDDCode extends LitElement {
 		if (changed.has('language')) this._refreshHighlight();
 	}
 
+	/* Lazy grammar loading is async; surface the in-flight highlight
+	 * through updateComplete so consumers (and tests) can `await
+	 * el.updateComplete` and see the final highlighted output. */
+	override async getUpdateComplete(): Promise<boolean> {
+		const result = await super.getUpdateComplete();
+		await this._highlightPending;
+		return result;
+	}
+
 	private _refreshHighlight(slot?: HTMLSlotElement) {
+		this._highlightPending = this._runHighlight(slot);
+	}
+
+	private async _runHighlight(slot?: HTMLSlotElement) {
 		if (!this.language) {
 			this._highlightedHtml = '';
 			return;
 		}
-		const grammar = Prism.languages[this.language];
+		const language = this.language;
+		if (!Prism.languages[language]) {
+			const pending = loadGrammar(language);
+			if (!pending) {
+				this._highlightedHtml = '';
+				return;
+			}
+			await pending;
+			if (this.language !== language) return;
+		}
+		const grammar = Prism.languages[language];
 		if (!grammar) {
 			this._highlightedHtml = '';
 			return;
@@ -90,7 +136,7 @@ export class NLDDCode extends LitElement {
 			.assignedNodes({ flatten: true })
 			.map((n) => n.textContent ?? '')
 			.join('');
-		this._highlightedHtml = Prism.highlight(text, grammar, this.language);
+		this._highlightedHtml = Prism.highlight(text, grammar, language);
 	}
 }
 

--- a/src/components/content/code/code.ts
+++ b/src/components/content/code/code.ts
@@ -18,13 +18,13 @@
  * highlighting applied.
  *
  * ### Theming
- * Token colors are exposed as `--_token-*` custom properties on the
- * host. Override them per-instance to swap the theme:
+ * Token colors are exposed as `--components-code-token-*` custom
+ * properties on the host. Override them per-instance to swap the theme:
  *
  * ```css
  * nldd-code {
- *   --_token-keyword-color: var(--my-purple);
- *   --_token-string-color: var(--my-green);
+ *   --components-code-token-keyword-color: var(--my-purple);
+ *   --components-code-token-string-color: var(--my-green);
  * }
  * ```
  *

--- a/src/components/content/code/code.ts
+++ b/src/components/content/code/code.ts
@@ -1,0 +1,101 @@
+/**
+ * Nederlandse Digitale Dienst Code Component (Lit + TypeScript)
+ *
+ * A block of monospaced text for code, traces, output dumps, etc.
+ * Renders a styled `<pre>` with the design-system's monospace family,
+ * tinted background and standard content color.
+ *
+ * Whitespace is preserved (`white-space: pre`); long lines scroll
+ * horizontally by default. Set `wrap` to break long lines onto the
+ * next visual line — useful for prose-like content (YAML strings,
+ * formatted output) where horizontal scrolling is more disruptive
+ * than wrapping.
+ *
+ * ## Syntax highlighting
+ * Set `language` to one of the bundled grammars (yaml, json, javascript,
+ * typescript, css, html, bash, markdown) to highlight the slot content
+ * with Prism. Without `language` the slot content is rendered raw, no
+ * highlighting applied.
+ *
+ * ### Theming
+ * Token colors are exposed as `--_token-*` custom properties on the
+ * host. Override them per-instance to swap the theme:
+ *
+ * ```css
+ * nldd-code {
+ *   --_token-keyword-color: var(--my-purple);
+ *   --_token-string-color: var(--my-green);
+ * }
+ * ```
+ *
+ * @element nldd-code
+ *
+ * @attr {string} language - Grammar to highlight with (yaml, json, javascript, typescript, css, html, bash, markdown). Empty disables highlighting.
+ * @attr {boolean} wrap - Wrap long lines instead of horizontal scroll
+ *
+ * @slot - Default slot for the code/text content
+ */
+import { LitElement } from 'lit';
+import { customElement, property, state } from 'lit/decorators.js';
+import Prism from 'prismjs';
+import 'prismjs/components/prism-yaml.js';
+import 'prismjs/components/prism-json.js';
+import 'prismjs/components/prism-javascript.js';
+import 'prismjs/components/prism-typescript.js';
+import 'prismjs/components/prism-css.js';
+import 'prismjs/components/prism-markup.js'; // covers html/xml/svg
+import 'prismjs/components/prism-bash.js';
+import 'prismjs/components/prism-markdown.js';
+import { codeStyles } from './code.styles.js';
+import { codeTemplate } from './code.template.js';
+
+@customElement('nldd-code')
+export class NLDDCode extends LitElement {
+	static override styles = codeStyles;
+
+	@property({ type: String, reflect: true })
+	language = '';
+
+	@property({ type: Boolean, reflect: true })
+	wrap = false;
+
+	@state()
+	_highlightedHtml = '';
+
+	override render() {
+		return codeTemplate(this);
+	}
+
+	_onSlotChange(e: Event) {
+		this._refreshHighlight(e.target as HTMLSlotElement);
+	}
+
+	override updated(changed: Map<string, unknown>) {
+		if (changed.has('language')) this._refreshHighlight();
+	}
+
+	private _refreshHighlight(slot?: HTMLSlotElement) {
+		if (!this.language) {
+			this._highlightedHtml = '';
+			return;
+		}
+		const grammar = Prism.languages[this.language];
+		if (!grammar) {
+			this._highlightedHtml = '';
+			return;
+		}
+		const target = slot ?? this.shadowRoot?.querySelector('slot');
+		if (!target) return;
+		const text = target
+			.assignedNodes({ flatten: true })
+			.map((n) => n.textContent ?? '')
+			.join('');
+		this._highlightedHtml = Prism.highlight(text, grammar, this.language);
+	}
+}
+
+declare global {
+	interface HTMLElementTagNameMap {
+		'nldd-code': NLDDCode;
+	}
+}

--- a/src/components/content/keyboard-shortcut/keyboard-shortcut.styles.ts
+++ b/src/components/content/keyboard-shortcut/keyboard-shortcut.styles.ts
@@ -9,6 +9,7 @@ export const keyboardShortcutStyles = css`
 		--_size: var(--components-keyboard-shortcut-md-size);
 		--_inline-padding: var(--primitives-space-6);
 		--_font: var(--primitives-font-body-xs-regular-flat);
+
 		display: inline-flex;
 		vertical-align: middle;
 	}

--- a/src/components/content/tag/tag.styles.ts
+++ b/src/components/content/tag/tag.styles.ts
@@ -15,6 +15,7 @@ export const tagStyles = css`
 		--_icon-size: var(--primitives-space-16);
 		--_icon-offset-correction: var(--primitives-space-1);
 		--_corner-radius: var(--components-tag-md-corner-radius);
+
 		display: inline-flex;
 		vertical-align: middle;
 	}

--- a/src/components/content/tooltip/tooltip.styles.ts
+++ b/src/components/content/tooltip/tooltip.styles.ts
@@ -6,7 +6,6 @@ export const tooltipStyles = css`
 	/* # Host */
 
 	:host {
-		display: contents;
 		--_z-index: 10000;
 		--_show-delay: 700ms;
 		--_show-duration: var(--primitives-transition-duration-fast);
@@ -15,6 +14,8 @@ export const tooltipStyles = css`
 		--_offset: 4; /* px, unitless — read by JS */
 		--_shift-padding: 8; /* px, unitless — read by JS */
 		--_max-width: var(--primitives-area-280);
+
+		display: contents;
 	}
 
 	:host([hidden]) {

--- a/src/components/forms/form-field/form-field.styles.ts
+++ b/src/components/forms/form-field/form-field.styles.ts
@@ -202,8 +202,10 @@ export const formFieldHelpTextStyles = css`
 		border-radius: var(--primitives-corner-radius-xxs);
 	}
 
-	::slotted(a:hover) {
-		color: var(--semantics-links-is-hovered-color);
+	@media (hover: hover) {
+		::slotted(a:hover) {
+			color: var(--semantics-links-is-hovered-color);
+		}
 	}
 
 	::slotted(a:active) {
@@ -257,8 +259,10 @@ export const formFieldErrorTextStyles = css`
 		border-radius: var(--primitives-corner-radius-xxs);
 	}
 
-	::slotted(a:hover) {
-		color: var(--semantics-links-is-hovered-color);
+	@media (hover: hover) {
+		::slotted(a:hover) {
+			color: var(--semantics-links-is-hovered-color);
+		}
 	}
 
 	::slotted(a:active) {

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -29,6 +29,7 @@ export { NLDDTooltip } from './content/tooltip/tooltip.js';
 export { NLDDBlockquote } from './content/blockquote/blockquote.js';
 export { NLDDTag } from './content/tag/tag.js';
 export { NLDDKeyboardShortcut } from './content/keyboard-shortcut/keyboard-shortcut.js';
+export { NLDDCode } from './content/code/code.js';
 
 
 // # Forms components
@@ -43,6 +44,7 @@ export { NLDDFormSection } from './forms/form-section/form-section.js';
 
 export { NLDDTextField } from './inputs/text-field/text-field.js';
 export { NLDDMultiLineTextField } from './inputs/multi-line-text-field/multi-line-text-field.js';
+export { NLDDCodeEditor } from './inputs/code-editor/code-editor.js';
 export { NLDDPasswordField } from './inputs/password-field/password-field.js';
 export { NLDDSearchField } from './inputs/search-field/search-field.js';
 export { NLDDNumberField } from './inputs/number-field/number-field.js';

--- a/src/components/inputs/checkbox/checkbox.styles.ts
+++ b/src/components/inputs/checkbox/checkbox.styles.ts
@@ -59,15 +59,17 @@ export const checkboxStyles = css`
 
 	/* # Hover */
 
-	.checkbox__input:hover:not(:disabled) ~ .checkbox__box {
-		border-color: var(--components-checkbox-is-hovered-border-color);
-	}
+	@media (hover: hover) {
+		.checkbox__input:hover:not(:disabled) ~ .checkbox__box {
+			border-color: var(--components-checkbox-is-hovered-border-color);
+		}
 
-	.checkbox__input:checked:hover:not(:disabled) ~ .checkbox__box,
-	.checkbox__input:indeterminate:hover:not(:disabled) ~ .checkbox__box {
-		border-color: var(--components-checkbox-is-selected-is-hovered-border-color);
-		background-color: var(--components-checkbox-is-selected-is-hovered-background-color);
-		color: var(--components-checkbox-is-selected-is-hovered-icon-color);
+		.checkbox__input:checked:hover:not(:disabled) ~ .checkbox__box,
+		.checkbox__input:indeterminate:hover:not(:disabled) ~ .checkbox__box {
+			border-color: var(--components-checkbox-is-selected-is-hovered-border-color);
+			background-color: var(--components-checkbox-is-selected-is-hovered-background-color);
+			color: var(--components-checkbox-is-selected-is-hovered-icon-color);
+		}
 	}
 
 

--- a/src/components/inputs/code-editor/code-editor.stories.ts
+++ b/src/components/inputs/code-editor/code-editor.stories.ts
@@ -1,0 +1,123 @@
+import { html, nothing } from 'lit';
+import './code-editor.ts';
+
+export default {
+	title: 'Components/Inputs/Code Editor',
+	component: 'nldd-code-editor',
+	tags: ['autodocs'],
+	parameters: {
+		componentSource: {
+			file: 'src/components/inputs/code-editor/code-editor.ts',
+			repository: 'https://github.com/MinBZK/storybook',
+		},
+		status: { type: 'stable' },
+	},
+	args: {
+		value: '',
+		placeholder: '',
+		rows: 6,
+		resize: 'vertical',
+		wrap: false,
+		disabled: false,
+		readonly: false,
+		accessibleLabel: 'Code',
+	},
+	argTypes: {
+		value: {
+			control: 'text',
+			description: 'De inhoud van het veld',
+			table: { defaultValue: { summary: '' } },
+		},
+		placeholder: {
+			control: 'text',
+			description: 'Placeholder tekst',
+			table: { defaultValue: { summary: '' } },
+		},
+		rows: {
+			control: 'number',
+			description: 'Initiële zichtbare regels',
+			table: { defaultValue: { summary: 6 } },
+		},
+		resize: {
+			control: 'select',
+			options: ['none', 'vertical', 'auto'],
+			description: 'Resize-gedrag van de textarea',
+			table: { defaultValue: { summary: 'vertical' } },
+		},
+		wrap: {
+			control: 'boolean',
+			description: 'Wrap lange regels in plaats van horizontaal scrollen',
+			table: { defaultValue: { summary: false } },
+		},
+		disabled: {
+			control: 'boolean',
+			description: 'Uitgeschakelde staat',
+			table: { defaultValue: { summary: false } },
+		},
+		readonly: {
+			control: 'boolean',
+			description: 'Alleen-lezen staat',
+			table: { defaultValue: { summary: false } },
+		},
+		accessibleLabel: {
+			name: 'accessible-label',
+			control: 'text',
+			description: 'Toegankelijk label',
+			table: { defaultValue: { summary: 'Code' } },
+		},
+	},
+};
+
+const Template = ({
+	value,
+	placeholder,
+	rows,
+	resize,
+	wrap,
+	disabled,
+	readonly,
+	accessibleLabel,
+}: Record<string, unknown>) => html`
+	<nldd-code-editor
+		.value=${value || ''}
+		placeholder=${placeholder || nothing}
+		rows=${rows as number}
+		resize=${resize as string}
+		?wrap=${wrap}
+		?disabled=${disabled}
+		?readonly=${readonly}
+		accessible-label=${accessibleLabel || nothing}
+	></nldd-code-editor>
+`;
+
+export const Default = Template.bind({});
+
+export const WithYaml = Template.bind({});
+WithYaml.args = {
+	value: `# wet_op_de_zorgtoeslag — artikel 2
+$id: zorgtoeslagwet
+articles:
+  - number: '2'
+    title: 'Recht op zorgtoeslag'
+    is_active: true
+    threshold: 32502`,
+	rows: 8,
+};
+
+export const Wrap = Template.bind({});
+Wrap.args = {
+	value: 'function deeplyNestedFunctionWithAVeryLongNameThatExceedsTheTypicalContainerWidth(parameterOne, parameterTwo, parameterThree) { return parameterOne + parameterTwo + parameterThree; }',
+	wrap: true,
+};
+
+export const ReadOnly = Template.bind({});
+ReadOnly.args = {
+	value: '{ "lawId": "zorgtoeslagwet", "active": true }',
+	readonly: true,
+};
+
+export const Disabled = Template.bind({});
+Disabled.args = {
+	value: '# disabled\nfoo: bar',
+	disabled: true,
+};

--- a/src/components/inputs/code-editor/code-editor.stories.ts
+++ b/src/components/inputs/code-editor/code-editor.stories.ts
@@ -10,7 +10,7 @@ export default {
 			file: 'src/components/inputs/code-editor/code-editor.ts',
 			repository: 'https://github.com/MinBZK/storybook',
 		},
-		status: { type: 'stable' },
+		status: { type: 'beta' },
 	},
 	args: {
 		value: '',

--- a/src/components/inputs/code-editor/code-editor.styles.ts
+++ b/src/components/inputs/code-editor/code-editor.styles.ts
@@ -20,7 +20,9 @@ export const codeEditorStyles = css`
 		   consumers in flex parents don't have to set them on every use. */
 		display: flex;
 		flex-direction: column;
-		flex: 1;
+		flex-grow: 1;
+		flex-shrink: 1;
+		flex-basis: auto;
 		min-height: 0;
 		-webkit-tap-highlight-color: transparent;
 	}
@@ -36,7 +38,9 @@ export const codeEditorStyles = css`
 		position: relative;
 		display: flex;
 		flex-direction: column;
-		flex: 1;
+		flex-grow: 1;
+		flex-shrink: 1;
+		flex-basis: auto;
 		min-height: 0;
 		box-sizing: border-box;
 		background-color: var(--_background-color);
@@ -60,7 +64,9 @@ export const codeEditorStyles = css`
 	.code-editor__input {
 		display: block;
 		box-sizing: border-box;
-		flex: 1;
+		flex-grow: 1;
+		flex-shrink: 1;
+		flex-basis: auto;
 		min-height: 0;
 		width: 100%;
 		margin: 0;

--- a/src/components/inputs/code-editor/code-editor.styles.ts
+++ b/src/components/inputs/code-editor/code-editor.styles.ts
@@ -1,0 +1,104 @@
+import { css } from 'lit';
+
+export const codeEditorStyles = css`
+
+
+	/* # Host */
+
+	:host {
+		--_background-color: var(--semantics-surfaces-tinted-background-color);
+		--_content-color: var(--semantics-content-color);
+		--_inline-padding: var(--primitives-space-16);
+		--_block-padding: var(--primitives-space-16);
+		--_corner-radius: var(--primitives-corner-radius-lg);
+		--_font: var(--primitives-font-monospace-sm-regular-snug);
+
+		/* flex column lets the textarea grow when the host has a fixed
+		   height (e.g. as a flex item in a tall pane). With no set height,
+		   the textarea falls back to its rows attribute.
+		   flex: 1 + min-height: 0 make the host a good flex citizen so
+		   consumers in flex parents don't have to set them on every use. */
+		display: flex;
+		flex-direction: column;
+		flex: 1;
+		min-height: 0;
+		-webkit-tap-highlight-color: transparent;
+	}
+
+	:host([hidden]) {
+		display: none;
+	}
+
+
+	/* # Block */
+
+	.code-editor {
+		position: relative;
+		display: flex;
+		flex-direction: column;
+		flex: 1;
+		min-height: 0;
+		box-sizing: border-box;
+		background-color: var(--_background-color);
+		border-radius: var(--_corner-radius);
+		overflow: hidden;
+	}
+
+	:host([disabled]) .code-editor {
+		opacity: var(--primitives-opacity-disabled);
+	}
+
+	.code-editor:focus-within {
+		outline: var(--semantics-focus-ring-outline);
+		outline-offset: var(--semantics-focus-ring-outline-offset);
+		box-shadow: var(--semantics-focus-ring-box-shadow);
+	}
+
+
+	/* # Input */
+
+	.code-editor__input {
+		display: block;
+		box-sizing: border-box;
+		flex: 1;
+		min-height: 0;
+		width: 100%;
+		margin: 0;
+		padding: var(--_block-padding) var(--_inline-padding);
+		color: var(--_content-color);
+		background: transparent;
+		border: none;
+		outline: none;
+		appearance: none;
+		font: var(--_font);
+		tab-size: 2;
+		white-space: pre;
+		overflow-wrap: normal;
+	}
+
+	:host([wrap]) .code-editor__input {
+		white-space: pre-wrap;
+		overflow-wrap: break-word;
+	}
+
+	:host([resize='vertical']) .code-editor__input {
+		resize: vertical;
+	}
+
+	:host([resize='none']) .code-editor__input {
+		resize: none;
+	}
+
+	:host([resize='auto']) .code-editor__input {
+		resize: none;
+		field-sizing: content;
+	}
+
+	:host([disabled]) .code-editor__input {
+		pointer-events: none;
+	}
+
+	.code-editor__input::placeholder {
+		color: var(--semantics-input-fields-placeholder-color);
+	}
+`;

--- a/src/components/inputs/code-editor/code-editor.template.ts
+++ b/src/components/inputs/code-editor/code-editor.template.ts
@@ -1,0 +1,25 @@
+import { html, nothing, TemplateResult } from 'lit';
+import type { NLDDCodeEditor } from './code-editor.js';
+
+export function codeEditorTemplate(component: NLDDCodeEditor): TemplateResult {
+	return html`
+		<div class="code-editor">
+			<textarea class="code-editor__input"
+				id=${component.inputId || nothing}
+				rows=${component.rows}
+				.value=${component.value}
+				placeholder=${component.placeholder || nothing}
+				?disabled=${component.disabled}
+				?readonly=${component.readonly}
+				?required=${component.required}
+				spellcheck="false"
+				autocomplete="off"
+				autocorrect="off"
+				autocapitalize="off"
+				aria-label=${component.accessibleLabel || nothing}
+				@input=${component._handleInput}
+				@change=${component._handleChange}
+			></textarea>
+		</div>
+	`;
+}

--- a/src/components/inputs/code-editor/code-editor.test.ts
+++ b/src/components/inputs/code-editor/code-editor.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { fixture, cleanup, waitForUpdate } from '../../../test-utils.ts';
+import './code-editor.ts';
+
+describe('nldd-code-editor', () => {
+	let el: HTMLElement;
+
+	afterEach(() => {
+		if (el) cleanup(el);
+	});
+
+	it('rendert zonder fouten', async () => {
+		el = await fixture('<nldd-code-editor accessible-label="Code"></nldd-code-editor>');
+		await waitForUpdate(el);
+		expect(el.shadowRoot).not.toBeNull();
+	});
+
+	it('rendert een textarea', async () => {
+		el = await fixture('<nldd-code-editor accessible-label="Code"></nldd-code-editor>');
+		await waitForUpdate(el);
+		const textarea = el.shadowRoot!.querySelector('textarea.code-editor__input');
+		expect(textarea).not.toBeNull();
+	});
+
+	it('zet spellcheck en autocomplete uit by default', async () => {
+		el = await fixture('<nldd-code-editor accessible-label="Code"></nldd-code-editor>');
+		await waitForUpdate(el);
+		const textarea = el.shadowRoot!.querySelector('textarea')!;
+		expect(textarea.spellcheck).toBe(false);
+		expect(textarea.autocomplete).toBe('off');
+	});
+
+	it('reflects the wrap attribute', async () => {
+		el = await fixture('<nldd-code-editor wrap accessible-label="Code"></nldd-code-editor>');
+		await waitForUpdate(el);
+		expect(el.hasAttribute('wrap')).toBe(true);
+	});
+
+	it('emits input event with value', async () => {
+		el = await fixture('<nldd-code-editor accessible-label="Code"></nldd-code-editor>');
+		await waitForUpdate(el);
+		const textarea = el.shadowRoot!.querySelector('textarea')!;
+		let received: string | undefined;
+		el.addEventListener('input', ((e: CustomEvent) => { received = e.detail.value; }) as EventListener);
+		textarea.value = 'foo: bar';
+		textarea.dispatchEvent(new Event('input'));
+		expect(received).toBe('foo: bar');
+	});
+});

--- a/src/components/inputs/code-editor/code-editor.test.ts
+++ b/src/components/inputs/code-editor/code-editor.test.ts
@@ -46,4 +46,37 @@ describe('nldd-code-editor', () => {
 		textarea.dispatchEvent(new Event('input'));
 		expect(received).toBe('foo: bar');
 	});
+
+	it('formResetCallback restores the initial value', async () => {
+		const el2 = await fixture<HTMLElement & { formResetCallback: () => void; value: string }>(
+			'<nldd-code-editor accessible-label="Code" value="initial"></nldd-code-editor>',
+		);
+		await waitForUpdate(el2);
+		el2.value = 'edited';
+		await waitForUpdate(el2);
+		expect(el2.value).toBe('edited');
+		el2.formResetCallback();
+		expect(el2.value).toBe('initial');
+		cleanup(el2);
+	});
+
+	it('formStateRestoreCallback applies a string state', async () => {
+		const el2 = await fixture<HTMLElement & { formStateRestoreCallback: (state: unknown) => void; value: string }>(
+			'<nldd-code-editor accessible-label="Code"></nldd-code-editor>',
+		);
+		await waitForUpdate(el2);
+		el2.formStateRestoreCallback('restored');
+		expect(el2.value).toBe('restored');
+		cleanup(el2);
+	});
+
+	it('formStateRestoreCallback ignores non-string state', async () => {
+		const el2 = await fixture<HTMLElement & { formStateRestoreCallback: (state: unknown) => void; value: string }>(
+			'<nldd-code-editor accessible-label="Code" value="kept"></nldd-code-editor>',
+		);
+		await waitForUpdate(el2);
+		el2.formStateRestoreCallback(new FormData());
+		expect(el2.value).toBe('kept');
+		cleanup(el2);
+	});
 });

--- a/src/components/inputs/code-editor/code-editor.ts
+++ b/src/components/inputs/code-editor/code-editor.ts
@@ -1,0 +1,152 @@
+/**
+ * Nederlandse Digitale Dienst Code Editor Component (Lit + TypeScript)
+ *
+ * A monospace text editor for code, YAML, JSON, and other technical
+ * content. Visually pairs with `nldd-code` (same tinted background,
+ * same monospace font, same rounded corners) so a read-only view and
+ * the editable counterpart look like the same surface.
+ *
+ * Built on a native `<textarea>` — no syntax highlighting, no line
+ * numbers. Reach for a real editor library (CodeMirror, Monaco) when
+ * those features are required.
+ *
+ * Spellcheck and autocorrect are disabled by default since they don't
+ * help on code; long lines scroll horizontally unless `wrap` is set.
+ *
+ * @element nldd-code-editor
+ *
+ * @attr {string} value           - The textarea value
+ * @attr {string} placeholder     - Placeholder text
+ * @attr {string} input-id        - Sets the id on the native textarea. Set automatically by nldd-form-field.
+ * @attr {boolean} disabled       - Disabled state
+ * @attr {string} name            - Textarea name for form submission
+ * @attr {boolean} readonly       - Readonly state
+ * @attr {boolean} required       - Required state
+ * @attr {boolean} wrap           - Wrap long lines instead of horizontal scroll
+ * @attr {number} rows            - Initial visible rows (minimum height). Default: 6.
+ * @attr {string} resize          - 'none' | 'vertical' (default) | 'auto'.
+ *                                  'auto' grows with content (native field-sizing).
+ * @attr {string} accessible-label - Accessible label forwarded to the inner textarea. Set automatically by nldd-form-field.
+ *
+ * @fires input  - When value changes
+ * @fires change - When value is committed (blur)
+ */
+import { LitElement, type PropertyValues } from 'lit';
+import { customElement, property, query } from 'lit/decorators.js';
+import { codeEditorStyles } from './code-editor.styles.js';
+import { codeEditorTemplate } from './code-editor.template.js';
+
+export type ResizeMode = 'none' | 'vertical' | 'auto';
+
+@customElement('nldd-code-editor')
+export class NLDDCodeEditor extends LitElement {
+	static formAssociated = true;
+
+	static override shadowRootOptions = {
+		...LitElement.shadowRootOptions,
+		delegatesFocus: true,
+	};
+
+	static override styles = codeEditorStyles;
+
+	private _internals = this.attachInternals();
+
+	private _initialValue = '';
+
+	@property({ type: String })
+	value = '';
+
+	@property({ type: String, attribute: 'input-id' })
+	inputId = '';
+
+	@property({ type: String })
+	placeholder = '';
+
+	@property({ type: Boolean, reflect: true })
+	disabled = false;
+
+	@property({ type: String, reflect: true })
+	name = '';
+
+	@property({ type: Boolean, reflect: true })
+	readonly = false;
+
+	@property({ type: Boolean, reflect: true })
+	required = false;
+
+	@property({ type: Boolean, reflect: true })
+	wrap = false;
+
+	@property({ type: Number })
+	rows = 6;
+
+	@property({ type: String, reflect: true })
+	resize: ResizeMode = 'vertical';
+
+	@property({ type: String, attribute: 'accessible-label' })
+	accessibleLabel = '';
+
+	@query('.code-editor__input')
+	private _textarea!: HTMLTextAreaElement;
+
+	override firstUpdated(): void {
+		this._initialValue = this.value;
+		if (import.meta.env?.DEV && !this.accessibleLabel && !this.inputId) {
+			console.warn('<nldd-code-editor>: No accessible-label or input-id provided. Use nldd-form-field for labeled usage, or set accessible-label for screen reader accessibility.');
+		}
+	}
+
+	override updated(changed: PropertyValues): void {
+		if (changed.has('resize') && this.resize === 'auto' && this._textarea) {
+			this._textarea.style.width = '';
+			this._textarea.style.height = '';
+		}
+		if (changed.has('value')) {
+			this._internals.setFormValue(this.value);
+		}
+	}
+
+	formResetCallback(): void {
+		this.value = this._initialValue;
+	}
+
+	formDisabledCallback(disabled: boolean): void {
+		this.disabled = disabled;
+	}
+
+	formStateRestoreCallback(state: File | string | FormData | null): void {
+		if (typeof state === 'string') this.value = state;
+	}
+
+	public _handleInput(e: Event): void {
+		e.stopPropagation();
+		const textarea = e.target as HTMLTextAreaElement;
+		this.value = textarea.value;
+		this.dispatchEvent(new CustomEvent('input', {
+			detail: { value: this.value },
+			bubbles: true,
+			composed: true,
+		}));
+	}
+
+	public _handleChange(e: Event): void {
+		e.stopPropagation();
+		const textarea = e.target as HTMLTextAreaElement;
+		this.value = textarea.value;
+		this.dispatchEvent(new CustomEvent('change', {
+			detail: { value: this.value },
+			bubbles: true,
+			composed: true,
+		}));
+	}
+
+	override render() {
+		return codeEditorTemplate(this);
+	}
+}
+
+declare global {
+	interface HTMLElementTagNameMap {
+		'nldd-code-editor': NLDDCodeEditor;
+	}
+}

--- a/src/components/inputs/code-editor/code-editor.ts
+++ b/src/components/inputs/code-editor/code-editor.ts
@@ -91,8 +91,12 @@ export class NLDDCodeEditor extends LitElement {
 
 	override firstUpdated(): void {
 		this._initialValue = this.value;
-		if (import.meta.env?.DEV && !this.accessibleLabel && !this.inputId) {
-			console.warn('<nldd-code-editor>: No accessible-label or input-id provided. Use nldd-form-field for labeled usage, or set accessible-label for screen reader accessibility.');
+		// Always warn — production sites without an accessible label fail
+		// WCAG SC 4.1.2 silently otherwise. Cheaper than a runtime throw,
+		// which would risk breaking pages that rely on a parent
+		// nldd-form-field setting input-id slightly later in the lifecycle.
+		if (!this.accessibleLabel && !this.inputId) {
+			console.warn('<nldd-code-editor>: No accessible-label or input-id provided. Use nldd-form-field for labeled usage, or set accessible-label for screen reader accessibility (WCAG SC 4.1.2).');
 		}
 	}
 

--- a/src/components/inputs/code-editor/code-editor.ts
+++ b/src/components/inputs/code-editor/code-editor.ts
@@ -89,25 +89,28 @@ export class NLDDCodeEditor extends LitElement {
 	@query('.code-editor__input')
 	private _textarea!: HTMLTextAreaElement;
 
+	private _accessibleLabelWarned = false;
+
 	override firstUpdated(): void {
 		this._initialValue = this.value;
-		// Always warn — production sites without an accessible label fail
-		// WCAG SC 4.1.2 silently otherwise. Cheaper than a runtime throw,
-		// which would risk breaking pages that rely on a parent
-		// nldd-form-field setting input-id slightly later in the lifecycle.
-		if (!this.accessibleLabel && !this.inputId) {
-			console.warn('<nldd-code-editor>: No accessible-label or input-id provided. Use nldd-form-field for labeled usage, or set accessible-label for screen reader accessibility (WCAG SC 4.1.2).');
-		}
 	}
 
 	override updated(changed: PropertyValues): void {
-		if (changed.has('resize') && this.resize === 'auto' && this._textarea) {
-			this._textarea.style.width = '';
-			this._textarea.style.height = '';
-		}
 		if (changed.has('value')) {
 			this._internals.setFormValue(this.value);
 		}
+		this._checkAccessibleLabel();
+	}
+
+	/* Ran from updated(), not firstUpdated(): a parent nldd-form-field sets
+	 * input-id slightly after our first render, so checking earlier triggers
+	 * a spurious warning for the standard form-field usage. We re-check on
+	 * every update and warn once if the missing label is still missing. */
+	private _checkAccessibleLabel(): void {
+		if (this._accessibleLabelWarned) return;
+		if (this.accessibleLabel || this.inputId) return;
+		this._accessibleLabelWarned = true;
+		console.warn('<nldd-code-editor>: No accessible-label or input-id provided. Use nldd-form-field for labeled usage, or set accessible-label for screen reader accessibility (WCAG SC 4.1.2).');
 	}
 
 	formResetCallback(): void {

--- a/src/components/inputs/combo-box/combo-box.styles.ts
+++ b/src/components/inputs/combo-box/combo-box.styles.ts
@@ -6,9 +6,10 @@ export const comboBoxStyles = css`
 	/* # Host */
 
 	:host {
-		display: block;
 		--_background-color: var(--semantics-input-fields-background-color);
 		--_z-index-button-focus: 1;
+
+		display: block;
 		-webkit-tap-highlight-color: transparent;
 	}
 

--- a/src/components/inputs/combo-box/combo-box.template.ts
+++ b/src/components/inputs/combo-box/combo-box.template.ts
@@ -60,6 +60,7 @@ export function comboBoxTemplate(component: NLDDComboBox): TemplateResult {
 							size=${iconButtonSize}
 							icon="dismiss"
 							text=${component._t('components.combo-box.clear-action')}
+							hide-tooltip
 							?disabled=${component.disabled}
 							@click=${component._handleClear}
 						></nldd-icon-button>
@@ -72,6 +73,7 @@ export function comboBoxTemplate(component: NLDDComboBox): TemplateResult {
 						size=${iconButtonSize}
 						icon="chevron-down"
 						text=${component._t('components.combo-box.open-menu-action')}
+						hide-tooltip
 						?disabled=${component.disabled}
 						@pointerdown=${component._handlePickerPointerdown}
 						@click=${component._toggleMenu}

--- a/src/components/inputs/dropdown/dropdown.styles.ts
+++ b/src/components/inputs/dropdown/dropdown.styles.ts
@@ -6,10 +6,11 @@ export const dropdownStyles = css`
 	/* # Host */
 
 	:host {
-		display: block;
 		--_xs-picker-icon-size: var(--primitives-space-16);
 		--_sm-picker-icon-size: var(--primitives-space-20);
 		--_md-picker-icon-size: var(--primitives-space-24);
+
+		display: block;
 		-webkit-tap-highlight-color: transparent;
 	}
 

--- a/src/components/inputs/multi-line-text-field/multi-line-text-field.styles.ts
+++ b/src/components/inputs/multi-line-text-field/multi-line-text-field.styles.ts
@@ -6,8 +6,9 @@ export const multiLineTextFieldStyles = css`
 	/* # Host */
 
 	:host {
-		display: block;
 		--_background-color: var(--semantics-input-fields-background-color);
+
+		display: block;
 		-webkit-tap-highlight-color: transparent;
 	}
 

--- a/src/components/inputs/number-field/number-field.styles.ts
+++ b/src/components/inputs/number-field/number-field.styles.ts
@@ -6,8 +6,9 @@ export const numberFieldStyles = css`
 	/* # Host */
 
 	:host {
-		display: inline-block;
 		--_width: auto;
+
+		display: inline-block;
 		-webkit-tap-highlight-color: transparent;
 	}
 

--- a/src/components/inputs/number-field/number-field.template.ts
+++ b/src/components/inputs/number-field/number-field.template.ts
@@ -19,6 +19,7 @@ export function numberFieldTemplate(component: NLDDNumberField): TemplateResult 
 						size=${iconButtonSize}
 						icon="minus"
 						text=${component._t('components.number-field.decrement-action')}
+						hide-tooltip
 						?disabled=${component.disabled || !canDecrease}
 						@click=${component._handleDecrease}
 					></nldd-icon-button>
@@ -44,6 +45,7 @@ export function numberFieldTemplate(component: NLDDNumberField): TemplateResult 
 						size=${iconButtonSize}
 						icon="plus"
 						text=${component._t('components.number-field.increment-action')}
+						hide-tooltip
 						?disabled=${component.disabled || !canIncrease}
 						@click=${component._handleIncrease}
 					></nldd-icon-button>

--- a/src/components/inputs/password-field/password-field.styles.ts
+++ b/src/components/inputs/password-field/password-field.styles.ts
@@ -6,9 +6,10 @@ export const passwordFieldStyles = css`
 	/* # Host */
 
 	:host {
-		display: block;
 		--_background-color: var(--semantics-input-fields-background-color);
 		--_z-index-button-focus: 1;
+
+		display: block;
 		-webkit-tap-highlight-color: transparent;
 	}
 

--- a/src/components/inputs/radio-button/radio-button.styles.ts
+++ b/src/components/inputs/radio-button/radio-button.styles.ts
@@ -75,17 +75,19 @@ export const radioButtonStyles = css`
 
 	/* # Hover */
 
-	.radio-button__input:hover:not(:disabled) ~ .radio-button__outer-shape {
-		border-color: var(--components-radio-button-is-hovered-border-color);
-	}
+	@media (hover: hover) {
+		.radio-button__input:hover:not(:disabled) ~ .radio-button__outer-shape {
+			border-color: var(--components-radio-button-is-hovered-border-color);
+		}
 
-	.radio-button__input:checked:hover:not(:disabled) ~ .radio-button__outer-shape {
-		border-color: var(--components-radio-button-is-selected-is-hovered-border-color);
-		background-color: var(--components-radio-button-is-selected-is-hovered-background-color);
-	}
+		.radio-button__input:checked:hover:not(:disabled) ~ .radio-button__outer-shape {
+			border-color: var(--components-radio-button-is-selected-is-hovered-border-color);
+			background-color: var(--components-radio-button-is-selected-is-hovered-background-color);
+		}
 
-	.radio-button__input:checked:hover:not(:disabled) ~ .radio-button__outer-shape .radio-button__inner-shape {
-		border-color: var(--components-radio-button-is-selected-is-hovered-inner-shape-border-color);
+		.radio-button__input:checked:hover:not(:disabled) ~ .radio-button__outer-shape .radio-button__inner-shape {
+			border-color: var(--components-radio-button-is-selected-is-hovered-inner-shape-border-color);
+		}
 	}
 
 

--- a/src/components/inputs/segmented-control/segmented-control.styles.ts
+++ b/src/components/inputs/segmented-control/segmented-control.styles.ts
@@ -54,15 +54,16 @@ export const segmentedControlItemStyles = css`
 	/* # Host */
 
 	:host {
-		display: flex;
-		min-width: 0;
-		position: relative;
 		--_segmented-control-md-inset-size: var(--primitives-space-4);
 		--_segmented-control-md-gap-size: var(--primitives-space-4);
 		--_segmented-control-md-item-icon-size: var(--primitives-space-24);
 		--_segmented-control-sm-inset-size: var(--primitives-space-3);
 		--_segmented-control-sm-gap-size: var(--primitives-space-2);
 		--_segmented-control-sm-item-icon-size: var(--primitives-space-20);
+
+		display: flex;
+		min-width: 0;
+		position: relative;
 		-webkit-tap-highlight-color: transparent;
 	}
 

--- a/src/components/inputs/segmented-control/segmented-control.styles.ts
+++ b/src/components/inputs/segmented-control/segmented-control.styles.ts
@@ -207,8 +207,10 @@ export const segmentedControlItemStyles = css`
 		background-color: var(--semantics-buttons-neutral-tinted-is-selected-background-color);
 	}
 
-	:host(:not([selected])) .segmented-control__item-label:hover::before {
-		background-color: var(--semantics-buttons-neutral-tinted-is-hovered-background-color);
+	@media (hover: hover) {
+		:host(:not([selected])) .segmented-control__item-label:hover::before {
+			background-color: var(--semantics-buttons-neutral-tinted-is-hovered-background-color);
+		}
 	}
 
 

--- a/src/components/inputs/stepper/stepper.template.ts
+++ b/src/components/inputs/stepper/stepper.template.ts
@@ -22,6 +22,7 @@ export function stepperTemplate(component: NLDDStepper): TemplateResult {
 				size=${component.size}
 				icon="minus"
 				text=${component._t('components.stepper.decrement-action')}
+				hide-tooltip
 				?disabled=${component.disabled || atMin}
 				aria-hidden="true"
 				tabindex="-1"
@@ -35,6 +36,7 @@ export function stepperTemplate(component: NLDDStepper): TemplateResult {
 				size=${component.size}
 				icon="plus"
 				text=${component._t('components.stepper.increment-action')}
+				hide-tooltip
 				?disabled=${component.disabled || atMax}
 				aria-hidden="true"
 				tabindex="-1"

--- a/src/components/inputs/switch/switch.styles.ts
+++ b/src/components/inputs/switch/switch.styles.ts
@@ -6,9 +6,6 @@ export const switchStyles = css`
 	/* # Host */
 
 	:host {
-		display: inline-block;
-		position: relative;
-		flex-shrink: 0;
 		--_switch-xs-width: var(--semantics-controls-md-min-size);
 		--_switch-xs-height: var(--semantics-controls-xs-min-size);
 		--_switch-sm-width: var(--semantics-controls-lg-min-size);
@@ -17,6 +14,10 @@ export const switchStyles = css`
 		--_switch-xs-thumb-size: calc(var(--_switch-xs-height) - var(--_switch-padding) * 2 - var(--components-switch-thumb-border-thickness) * 2);
 		--_switch-sm-thumb-size: calc(var(--_switch-sm-height) - var(--_switch-padding) * 2 - var(--components-switch-thumb-border-thickness) * 2);
 		--_transition-duration: var(--primitives-transition-duration-fast);
+
+		display: inline-block;
+		position: relative;
+		flex-shrink: 0;
 		-webkit-tap-highlight-color: transparent;
 	}
 

--- a/src/components/inputs/text-field/text-field.styles.ts
+++ b/src/components/inputs/text-field/text-field.styles.ts
@@ -6,8 +6,9 @@ export const textFieldStyles = css`
 	/* # Host */
 
 	:host {
-		display: block;
 		--_background-color: var(--semantics-input-fields-background-color);
+
+		display: block;
 		-webkit-tap-highlight-color: transparent;
 	}
 

--- a/src/components/inputs/toggle-button/toggle-button.styles.ts
+++ b/src/components/inputs/toggle-button/toggle-button.styles.ts
@@ -92,10 +92,12 @@ export const toggleButtonStyles = css`
 
 	/* ## Hover */
 
-	.toggle-button:hover,
-	.toggle-button:has(.toggle-button__input:hover) {
-		background-color: var(--semantics-buttons-neutral-tinted-is-hovered-background-color);
-		color: var(--semantics-buttons-neutral-tinted-is-hovered-content-color);
+	@media (hover: hover) {
+		.toggle-button:hover,
+		.toggle-button:has(.toggle-button__input:hover) {
+			background-color: var(--semantics-buttons-neutral-tinted-is-hovered-background-color);
+			color: var(--semantics-buttons-neutral-tinted-is-hovered-content-color);
+		}
 	}
 
 	/* ## Selected */
@@ -105,10 +107,12 @@ export const toggleButtonStyles = css`
 		color: var(--semantics-buttons-neutral-tinted-is-selected-content-color);
 	}
 
-	:host([selected]) .toggle-button:hover,
-	:host([selected]) .toggle-button:has(.toggle-button__input:hover) {
-		background-color: var(--semantics-buttons-neutral-tinted-is-selected-is-hovered-background-color);
-		color: var(--semantics-buttons-neutral-tinted-is-selected-is-hovered-content-color);
+	@media (hover: hover) {
+		:host([selected]) .toggle-button:hover,
+		:host([selected]) .toggle-button:has(.toggle-button__input:hover) {
+			background-color: var(--semantics-buttons-neutral-tinted-is-selected-is-hovered-background-color);
+			color: var(--semantics-buttons-neutral-tinted-is-selected-is-hovered-content-color);
+		}
 	}
 
 	/* ## Focus */

--- a/src/components/inputs/token/token.styles.ts
+++ b/src/components/inputs/token/token.styles.ts
@@ -77,9 +77,11 @@ export const tokenStyles = css`
 
 	/* ## Hover — menu */
 
-	:host([control="menu"]) .token:hover:not(:disabled) {
-		background-color: var(--semantics-buttons-neutral-tinted-is-hovered-background-color);
-		color: var(--semantics-buttons-neutral-tinted-is-hovered-content-color);
+	@media (hover: hover) {
+		:host([control="menu"]) .token:hover:not(:disabled) {
+			background-color: var(--semantics-buttons-neutral-tinted-is-hovered-background-color);
+			color: var(--semantics-buttons-neutral-tinted-is-hovered-content-color);
+		}
 	}
 
 	/* ## Open — menu */
@@ -89,9 +91,11 @@ export const tokenStyles = css`
 		color: var(--semantics-buttons-neutral-tinted-is-active-content-color);
 	}
 
-	:host([open]) .token:hover:not(:disabled) {
-		background-color: var(--semantics-buttons-neutral-tinted-is-active-background-color);
-		color: var(--semantics-buttons-neutral-tinted-is-active-content-color);
+	@media (hover: hover) {
+		:host([open]) .token:hover:not(:disabled) {
+			background-color: var(--semantics-buttons-neutral-tinted-is-active-background-color);
+			color: var(--semantics-buttons-neutral-tinted-is-active-content-color);
+		}
 	}
 
 	/* ## Focus — menu */

--- a/src/components/inputs/token/token.template.ts
+++ b/src/components/inputs/token/token.template.ts
@@ -29,6 +29,7 @@ export function tokenTemplate(component: NLDDToken): TemplateResult {
 						icon="dismiss-small"
 						text=${component.dismissText}
 						accessible-label=${component.dismissText}
+						hide-tooltip
 						?disabled=${component.disabled}
 						@click=${component._handleDismiss}
 					></nldd-icon-button>

--- a/src/components/layout/app-view/app-view.test.ts
+++ b/src/components/layout/app-view/app-view.test.ts
@@ -100,4 +100,47 @@ describe('nldd-app-view', () => {
 			expect(document.body.style.backgroundColor).toBe('');
 		});
 	});
+
+	describe('overscroll-behavior on documentElement and body', () => {
+		const instances: NLDDAppView[] = [];
+		async function track(html: string): Promise<NLDDAppView> {
+			const el = await fixture<NLDDAppView>(html);
+			instances.push(el);
+			return el;
+		}
+
+		afterEach(() => {
+			while (instances.length > 0) {
+				const inst = instances.pop()!;
+				if (inst.isConnected) cleanup(inst);
+			}
+			document.documentElement.style.removeProperty('overscroll-behavior');
+			document.body.style.removeProperty('overscroll-behavior');
+		});
+
+		it('locks overscroll on connect and clears on last disconnect', async () => {
+			el = await track('<nldd-app-view></nldd-app-view>');
+			await waitForUpdate(el);
+			expect(document.documentElement.style.overscrollBehavior).toBe('none');
+			expect(document.body.style.overscrollBehavior).toBe('none');
+
+			cleanup(el);
+			el = undefined as unknown as NLDDAppView;
+			expect(document.documentElement.style.overscrollBehavior).toBe('');
+			expect(document.body.style.overscrollBehavior).toBe('');
+		});
+
+		it('keeps the lock while another instance is still connected', async () => {
+			const first = await track('<nldd-app-view></nldd-app-view>');
+			await waitForUpdate(first);
+			const second = await track('<nldd-app-view></nldd-app-view>');
+			await waitForUpdate(second);
+
+			cleanup(first);
+			expect(document.body.style.overscrollBehavior).toBe('none');
+
+			cleanup(second);
+			expect(document.body.style.overscrollBehavior).toBe('');
+		});
+	});
 });

--- a/src/components/layout/app-view/app-view.ts
+++ b/src/components/layout/app-view/app-view.ts
@@ -14,6 +14,13 @@
  * blend with the app instead of revealing the user-agent's default white.
  * Cleared when the app-view disconnects.
  *
+ * ## Overscroll
+ * `overscroll-behavior: none` is set on `document.documentElement` and
+ * `document.body` while the app-view is connected. Combined with the
+ * `overscroll-behavior: contain` on `nldd-page`'s scroll target, this
+ * prevents iOS rubber-band on the viewport when scroll gestures land
+ * outside an `nldd-page` (e.g. on a top-bar). Cleared on last disconnect.
+ *
  * @element nldd-app-view
  *
  * @attr {'default'|'tinted'} background - Background color (cascades to descendants)
@@ -52,6 +59,8 @@ export class NLDDAppView extends LitElement {
 		super.connectedCallback();
 		_connectedStack.push(this);
 		this._writeBodyBackground();
+		document.documentElement.style.overscrollBehavior = 'none';
+		document.body.style.overscrollBehavior = 'none';
 	}
 
 	override disconnectedCallback(): void {
@@ -62,10 +71,13 @@ export class NLDDAppView extends LitElement {
 		if (owner) {
 			// Re-apply whichever instance is now on top — fixes the case where
 			// a younger instance disconnects first and an older one is still
-			// in the DOM but had its background overwritten.
+			// in the DOM but had its background overwritten. Overscroll value
+			// is the same across instances, no re-apply needed.
 			owner._writeBodyBackground();
 		} else {
 			document.body.style.removeProperty('background-color');
+			document.documentElement.style.removeProperty('overscroll-behavior');
+			document.body.style.removeProperty('overscroll-behavior');
 		}
 	}
 

--- a/src/components/layout/page/page.styles.ts
+++ b/src/components/layout/page/page.styles.ts
@@ -14,6 +14,7 @@ export const pageStyles = css`
 		height: 100%;
 		overflow-y: auto;
 		overflow-x: hidden;
+		overscroll-behavior: contain;
 		background-color: var(--_background-color);
 	}
 
@@ -96,6 +97,7 @@ export const pageStyles = css`
 	:host([sticky-header]) .page__scroll {
 		overflow-y: auto;
 		overflow-x: hidden;
+		overscroll-behavior: contain;
 	}
 
 

--- a/src/components/layout/sheet/sheet.styles.ts
+++ b/src/components/layout/sheet/sheet.styles.ts
@@ -168,6 +168,20 @@ export const sheetStyles = css`
 	}
 
 
+	/* # Full-height
+	   Force a bottom sheet to take its full max-height (= viewport minus
+	   the top-inset), so visualisation-heavy content (graph view, full
+	   editors) doesn't shrink to its intrinsic size. The top-inset stays
+	   intact: it gives users a tap target to dismiss the sheet and a
+	   visual cue that this is an overlay, not a full page. The sm
+	   responsive block below covers the case where any placement
+	   collapses to a bottom sheet on small viewports. */
+
+	:host([placement='bottom'][full-height]) .sheet {
+		height: calc(100dvh - var(--semantics-sheets-bottom-top-inset));
+	}
+
+
 	/* # Responsive: sm viewport — all placements become bottom sheet */
 
 	@media (max-width: ${smMax}) {
@@ -188,6 +202,10 @@ export const sheetStyles = css`
 			&.is-closing {
 				animation: sheet-slide-out-bottom var(--semantics-sheets-bottom-animation-duration) var(--primitives-transition-easing-default) both;
 			}
+		}
+
+		:host([full-height]) .sheet {
+			height: calc(100dvh - var(--semantics-sheets-bottom-top-inset));
 		}
 	}
 

--- a/src/components/layout/sheet/sheet.styles.ts
+++ b/src/components/layout/sheet/sheet.styles.ts
@@ -11,8 +11,9 @@ export const sheetStyles = css`
 	/* # Host */
 
 	:host {
-		display: block;
 		--_custom-width: initial;
+
+		display: block;
 	}
 
 

--- a/src/components/layout/sheet/sheet.test.ts
+++ b/src/components/layout/sheet/sheet.test.ts
@@ -233,6 +233,53 @@ describe('nldd-sheet – placement', () => {
 
 
 /* ============================================================
+   Full-height
+   ============================================================ */
+
+describe('nldd-sheet – full-height', () => {
+	let el: NLDDSheet;
+
+	afterEach(() => {
+		if (el) cleanup(el);
+	});
+
+	it('defaults full-height to false', async () => {
+		el = await fixture<NLDDSheet>('<nldd-sheet></nldd-sheet>');
+		await waitForUpdate(el);
+		expect(el.fullHeight).toBe(false);
+		expect(el.hasAttribute('full-height')).toBe(false);
+	});
+
+	it('reflects full-height attribute when set in markup', async () => {
+		el = await fixture<NLDDSheet>('<nldd-sheet placement="bottom" full-height></nldd-sheet>');
+		await waitForUpdate(el);
+		expect(el.fullHeight).toBe(true);
+		expect(el.hasAttribute('full-height')).toBe(true);
+	});
+
+	it('reflects full-height when set via property', async () => {
+		el = await fixture<NLDDSheet>('<nldd-sheet placement="bottom"></nldd-sheet>');
+		await waitForUpdate(el);
+		expect(el.hasAttribute('full-height')).toBe(false);
+
+		el.fullHeight = true;
+		await waitForUpdate(el);
+		expect(el.hasAttribute('full-height')).toBe(true);
+	});
+
+	it('removes full-height attribute when property cleared', async () => {
+		el = await fixture<NLDDSheet>('<nldd-sheet placement="bottom" full-height></nldd-sheet>');
+		await waitForUpdate(el);
+		expect(el.hasAttribute('full-height')).toBe(true);
+
+		el.fullHeight = false;
+		await waitForUpdate(el);
+		expect(el.hasAttribute('full-height')).toBe(false);
+	});
+});
+
+
+/* ============================================================
    Slot
    ============================================================ */
 

--- a/src/components/layout/sheet/sheet.ts
+++ b/src/components/layout/sheet/sheet.ts
@@ -11,6 +11,9 @@
  * @element nldd-sheet
  *
  * @attr {string}  placement        - Sheet position: 'left' | 'right' | 'bottom' (default: 'right')
+ * @attr {boolean} full-height      - Force the sheet to fill the viewport top to bottom. Applies to
+ *                                    bottom sheets and to any sheet on sm viewports (where all
+ *                                    placements collapse to bottom). No effect on side sheets at md+.
  * @attr {boolean} modeless         - Non-modal (no backdrop or focus lock); the sheet is modal by default
  * @attr {string}  accessible-label - Accessible name for the dialog, forwarded as aria-label (default: 'Dialoogvenster')
  * @attr {string}  width            - Custom width for side sheets (left/right) as a CSS length
@@ -41,6 +44,9 @@ export class NLDDSheet extends LitElement {
 
 	@property({ type: String, reflect: true })
 	placement: Placement = 'right';
+
+	@property({ type: Boolean, reflect: true, attribute: 'full-height' })
+	fullHeight = false;
 
 	@property({ type: Boolean, reflect: true })
 	modeless = false;

--- a/src/components/lists-and-menus/cells/cell/cell.styles.ts
+++ b/src/components/lists-and-menus/cells/cell/cell.styles.ts
@@ -6,15 +6,16 @@ export const cellStyles = css`
 	/* # Host */
 
 	:host {
+		--_width: auto;
+		--_min-width: 0;
+		--_max-width: none;
+		--_min-height: 0;
+
 		display: flex;
 		flex-direction: column;
 		align-items: stretch;
 		flex-shrink: 0;
 		justify-content: center;
-		--_width: auto;
-		--_min-width: 0;
-		--_max-width: none;
-		--_min-height: 0;
 		width: var(--_width);
 		min-width: var(--_min-width);
 		max-width: var(--_max-width);
@@ -31,17 +32,21 @@ export const cellStyles = css`
 	:host([width='stretch']) {
 		flex-grow: 1;
 		flex-shrink: 1;
-		min-width: 0;
 	}
 
 	:host([width='fit-content']),
 	:host(:not([width])) {
 		flex-grow: 0;
+		flex-basis: auto;
 		width: fit-content;
 	}
 
 	:host([width]:not([width='stretch']):not([width='fit-content'])) {
 		flex-shrink: 0;
+	}
+
+	:host([max-width]) {
+		flex-basis: var(--_max-width);
 	}
 
 

--- a/src/components/lists-and-menus/cells/description-cell/description-cell.styles.ts
+++ b/src/components/lists-and-menus/cells/description-cell/description-cell.styles.ts
@@ -6,13 +6,14 @@ export const descriptionCellStyles = css`
 	/* # Host */
 
 	:host {
-		display: flex;
-		flex-direction: column;
-		justify-content: center;
 		--_width: auto;
 		--_min-width: 0;
 		--_max-width: none;
 		--_min-height: 0;
+
+		display: flex;
+		flex-direction: column;
+		justify-content: center;
 		width: var(--_width);
 		min-width: var(--_min-width);
 		max-width: var(--_max-width);
@@ -29,7 +30,7 @@ export const descriptionCellStyles = css`
 	:host([width='stretch']),
 	:host(:not([width])) {
 		flex-grow: 1;
-		min-width: 0;
+		flex-shrink: 1;
 	}
 
 	:host([width='fit-content']) {
@@ -41,6 +42,10 @@ export const descriptionCellStyles = css`
 
 	:host([width]:not([width='stretch']):not([width='fit-content'])) {
 		flex-shrink: 0;
+	}
+
+	:host([max-width]) {
+		flex-basis: var(--_max-width);
 	}
 
 

--- a/src/components/lists-and-menus/cells/text-cell/text-cell.styles.ts
+++ b/src/components/lists-and-menus/cells/text-cell/text-cell.styles.ts
@@ -6,13 +6,14 @@ export const textCellStyles = css`
 	/* # Host */
 
 	:host {
-		display: flex;
-		flex-direction: column;
-		justify-content: center;
 		--_width: auto;
 		--_min-width: 0;
 		--_max-width: none;
 		--_min-height: 0;
+
+		display: flex;
+		flex-direction: column;
+		justify-content: center;
 		width: var(--_width);
 		min-width: var(--_min-width);
 		max-width: var(--_max-width);
@@ -29,7 +30,7 @@ export const textCellStyles = css`
 	:host([width='stretch']),
 	:host(:not([width])) {
 		flex-grow: 1;
-		min-width: 0;
+		flex-shrink: 1;
 	}
 
 	:host([width='fit-content']) {
@@ -41,6 +42,10 @@ export const textCellStyles = css`
 
 	:host([width]:not([width='stretch']):not([width='fit-content'])) {
 		flex-shrink: 0;
+	}
+
+	:host([max-width]) {
+		flex-basis: var(--_max-width);
 	}
 
 

--- a/src/components/lists-and-menus/cells/title-cell/title-cell.styles.ts
+++ b/src/components/lists-and-menus/cells/title-cell/title-cell.styles.ts
@@ -6,13 +6,14 @@ export const titleCellStyles = css`
 	/* # Host */
 
 	:host {
-		display: flex;
-		flex-direction: column;
-		justify-content: center;
 		--_width: auto;
 		--_min-width: 0;
 		--_max-width: none;
 		--_min-height: 0;
+
+		display: flex;
+		flex-direction: column;
+		justify-content: center;
 		width: var(--_width);
 		min-width: var(--_min-width);
 		max-width: var(--_max-width);
@@ -29,7 +30,7 @@ export const titleCellStyles = css`
 	:host([width='stretch']),
 	:host(:not([width])) {
 		flex-grow: 1;
-		min-width: 0;
+		flex-shrink: 1;
 	}
 
 	:host([width='fit-content']) {
@@ -41,6 +42,10 @@ export const titleCellStyles = css`
 
 	:host([width]:not([width='stretch']):not([width='fit-content'])) {
 		flex-shrink: 0;
+	}
+
+	:host([max-width]) {
+		flex-basis: var(--_max-width);
 	}
 
 

--- a/src/components/lists-and-menus/list-item/list-item.styles.ts
+++ b/src/components/lists-and-menus/list-item/list-item.styles.ts
@@ -131,9 +131,23 @@ export const listItemStyles = css`
 		pointer-events: none;
 	}
 
-	.list-item__action:hover {
-		--_background-color: var(--components-list-item-is-hovered-background-color);
-		--context-cell-content-color: var(--components-list-item-is-hovered-content-color);
+	/* Hover rules only on hover-capable devices: prevents touch-scrolling
+	 * from briefly flashing the hover state on the row under the finger. */
+	@media (hover: hover) {
+		.list-item__action:hover {
+			--_background-color: var(--components-list-item-is-hovered-background-color);
+			--context-cell-content-color: var(--components-list-item-is-hovered-content-color);
+		}
+
+		:host([selected]) .list-item__action:hover {
+			--_background-color: var(--components-list-item-is-selected-background-color);
+			--context-cell-content-color: var(--components-list-item-is-selected-content-color);
+		}
+
+		:host([selected]) .list-item__action:focus:hover {
+			--_background-color: var(--components-list-item-is-highlighted-background-color);
+			--context-cell-content-color: var(--components-list-item-is-highlighted-content-color);
+		}
 	}
 
 	:host([selected]) .list-item__action {
@@ -141,17 +155,7 @@ export const listItemStyles = css`
 		--context-cell-content-color: var(--components-list-item-is-selected-content-color);
 	}
 
-	:host([selected]) .list-item__action:hover {
-		--_background-color: var(--components-list-item-is-selected-background-color);
-		--context-cell-content-color: var(--components-list-item-is-selected-content-color);
-	}
-
 	:host([selected]) .list-item__action:focus {
-		--_background-color: var(--components-list-item-is-highlighted-background-color);
-		--context-cell-content-color: var(--components-list-item-is-highlighted-content-color);
-	}
-
-	:host([selected]) .list-item__action:focus:hover {
 		--_background-color: var(--components-list-item-is-highlighted-background-color);
 		--context-cell-content-color: var(--components-list-item-is-highlighted-content-color);
 	}

--- a/src/components/lists-and-menus/list-item/list-item.styles.ts
+++ b/src/components/lists-and-menus/list-item/list-item.styles.ts
@@ -6,16 +6,17 @@ export const listItemStyles = css`
 	/* # Host */
 
 	:host {
-		display: block;
-		width: 100%;
-		-webkit-tap-highlight-color: transparent;
-		container-type: inline-size;
-		container-name: list-item;
 		--_background-color: transparent;
 		--_z-index-content: 0;
 		--_z-index-focus: 1;
 		--_z-index-indicator: calc(var(--_z-index-content) - 1);
 		--_focus-outline-offset: 6px;
+
+		display: block;
+		width: 100%;
+		-webkit-tap-highlight-color: transparent;
+		container-type: inline-size;
+		container-name: list-item;
 	}
 
 	:host([hidden]) {

--- a/src/components/lists-and-menus/list/list.styles.ts
+++ b/src/components/lists-and-menus/list/list.styles.ts
@@ -6,15 +6,16 @@ export const listStyles = css`
 	/* # Host */
 
 	:host {
-		display: block;
-		position: relative;
-		isolation: isolate;
 		--_drag-clone-top: 0px;
 		--_drag-clone-left: 0px;
 		--_drag-clone-width: 0px;
 		--_drag-clone-height: 0px;
 		--_drag-clone-opacity: 0.95;
 		--_drag-clone-z-index: 100;
+
+		display: block;
+		position: relative;
+		isolation: isolate;
 	}
 
 

--- a/src/components/lists-and-menus/menu/menu.styles.ts
+++ b/src/components/lists-and-menus/menu/menu.styles.ts
@@ -6,6 +6,18 @@ export const menuStyles = css`
 	/* # Host */
 
 	:host {
+		--_viewport-margin: 16px;
+		--_menu-width: var(--primitives-area-280);
+		--_menu-max-height: calc(infinity * 1px);
+		--_menu-max-items: 9999;
+		--_menu-item-size: var(--semantics-controls-md-min-size);
+		--_menu-padding: var(--primitives-space-8);
+
+		@media (pointer: fine) {
+			--_menu-item-size: var(--semantics-controls-sm-min-size);
+			--_menu-padding: var(--primitives-space-6);
+		}
+
 		display: block;
 		padding: 0;
 		border: none;
@@ -13,16 +25,6 @@ export const menuStyles = css`
 		margin: 0;
 		position: absolute;
 		overflow: visible;
-		--_viewport-margin: 16px;
-		--_menu-width: var(--primitives-area-280);
-		--_menu-max-height: calc(infinity * 1px);
-		--_menu-max-items: 9999;
-		--_menu-item-size: var(--semantics-controls-md-min-size);
-		--_menu-padding: var(--primitives-space-8);
-		@media (pointer: fine) {
-			--_menu-item-size: var(--semantics-controls-sm-min-size);
-			--_menu-padding: var(--primitives-space-6);
-		}
 		-webkit-tap-highlight-color: transparent;
 	}
 

--- a/src/components/navigation/document-tab-bar/document-tab-bar.styles.ts
+++ b/src/components/navigation/document-tab-bar/document-tab-bar.styles.ts
@@ -253,8 +253,10 @@ export const documentTabBarItemStyles = css`
 		text-decoration: none;
 	}
 
-	.document-tab-bar__item-tab:hover {
-		background-color: var(--semantics-buttons-neutral-tinted-is-hovered-background-color);
+	@media (hover: hover) {
+		.document-tab-bar__item-tab:hover {
+			background-color: var(--semantics-buttons-neutral-tinted-is-hovered-background-color);
+		}
 	}
 
 	.document-tab-bar__item-tab:active {
@@ -265,8 +267,10 @@ export const documentTabBarItemStyles = css`
 		background-color: var(--semantics-buttons-neutral-tinted-is-selected-background-color);
 	}
 
-	:host([selected]) .document-tab-bar__item-tab:hover {
-		background-color: var(--semantics-buttons-neutral-tinted-is-selected-background-color);
+	@media (hover: hover) {
+		:host([selected]) .document-tab-bar__item-tab:hover {
+			background-color: var(--semantics-buttons-neutral-tinted-is-selected-background-color);
+		}
 	}
 
 	/* ## Focus */
@@ -376,8 +380,10 @@ export const documentTabBarItemStyles = css`
 		color: var(--semantics-buttons-neutral-tinted-content-color);
 	}
 
-	.document-tab-bar__item-dismiss-button:hover {
-		background-color: var(--primitives-color-neutral-150);
+	@media (hover: hover) {
+		.document-tab-bar__item-dismiss-button:hover {
+			background-color: var(--primitives-color-neutral-150);
+		}
 	}
 
 	.document-tab-bar__item-dismiss-button:active {
@@ -388,8 +394,10 @@ export const documentTabBarItemStyles = css`
 		color: var(--semantics-buttons-neutral-tinted-is-selected-content-color);
 	}
 
-	:host([selected]) .document-tab-bar__item-dismiss-button:hover {
-		background-color: var(--primitives-color-accent-650);
+	@media (hover: hover) {
+		:host([selected]) .document-tab-bar__item-dismiss-button:hover {
+			background-color: var(--primitives-color-accent-650);
+		}
 	}
 
 	:host([selected]) .document-tab-bar__item-dismiss-button:active {

--- a/src/components/navigation/document-tab-bar/document-tab-bar.styles.ts
+++ b/src/components/navigation/document-tab-bar/document-tab-bar.styles.ts
@@ -6,9 +6,6 @@ export const documentTabBarStyles = css`
 	/* # Host */
 
 	:host {
-		display: block;
-		position: relative;
-		isolation: isolate;
 		--_drag-clone-top: 0px;
 		--_drag-clone-left: 0px;
 		--_drag-clone-width: 0px;
@@ -18,6 +15,10 @@ export const documentTabBarStyles = css`
 		--_short-text-threshold: 200px;
 		--_item-min-width: 100px;
 		--_overflow-button-reserve: 52px; /* Used for overflowButtonReserve. Overflow button width + spacing */
+
+		display: block;
+		position: relative;
+		isolation: isolate;
 		-webkit-tap-highlight-color: transparent;
 	}
 

--- a/src/components/navigation/menu-bar-item/menu-bar-item.styles.ts
+++ b/src/components/navigation/menu-bar-item/menu-bar-item.styles.ts
@@ -9,6 +9,7 @@ export const menuBarItemStyles = css`
 		--_indicator-z-index: 0;
 		--_content-z-index: 1;
 		--_focus-z-index: 1;
+
 		display: inline-block;
 		position: relative;
 		isolation: isolate;

--- a/src/components/navigation/menu-bar-item/menu-bar-item.styles.ts
+++ b/src/components/navigation/menu-bar-item/menu-bar-item.styles.ts
@@ -61,16 +61,20 @@ export const menuBarItemStyles = css`
 		z-index: var(--_indicator-z-index);
 	}
 
-	.menu-bar-item:hover::before {
-		background-color: var(--components-menu-bar-item-is-hovered-indicator-background-color);
+	@media (hover: hover) {
+		.menu-bar-item:hover::before {
+			background-color: var(--components-menu-bar-item-is-hovered-indicator-background-color);
+		}
 	}
 
 	:host([open]) .menu-bar-item::before {
 		background-color: var(--components-menu-bar-item-is-open-indicator-background-color);
 	}
 
-	:host([open]) .menu-bar-item:hover::before {
-		background-color: var(--components-menu-bar-item-is-hovered-indicator-background-color);
+	@media (hover: hover) {
+		:host([open]) .menu-bar-item:hover::before {
+			background-color: var(--components-menu-bar-item-is-hovered-indicator-background-color);
+		}
 	}
 
 	/* ## Current indicator (::after) */

--- a/src/components/navigation/pagination/pagination.styles.ts
+++ b/src/components/navigation/pagination/pagination.styles.ts
@@ -61,9 +61,14 @@ export const paginationStyles = css`
 		text-decoration: none;
 	}
 
-	.pagination__page-button:hover,
 	.pagination__page-button:focus-visible {
 		z-index: 1;
+	}
+
+	@media (hover: hover) {
+		.pagination__page-button:hover {
+			z-index: 1;
+		}
 	}
 
 	.pagination__page-button:focus-visible {
@@ -86,8 +91,10 @@ export const paginationStyles = css`
 		pointer-events: none;
 	}
 
-	.pagination__page-button:hover:not(.is-current)::before {
-		background-color: var(--semantics-buttons-neutral-tinted-is-hovered-background-color);
+	@media (hover: hover) {
+		.pagination__page-button:hover:not(.is-current)::before {
+			background-color: var(--semantics-buttons-neutral-tinted-is-hovered-background-color);
+		}
 	}
 
 	.pagination__page-button.is-current::before {

--- a/src/components/navigation/skip-link/skip-link.styles.ts
+++ b/src/components/navigation/skip-link/skip-link.styles.ts
@@ -11,6 +11,7 @@ export const skipLinkStyles = css`
 		--_box-shadow: var(--primitives-box-shadows-level-3);
 		--_focus-box-shadow: inset var(--semantics-focus-ring-box-shadow);
 		--_focus-outline-offset: -6px;
+
 		display: block;
 		position: relative;
 	}

--- a/src/components/navigation/tab-bar/tab-bar.styles.ts
+++ b/src/components/navigation/tab-bar/tab-bar.styles.ts
@@ -30,8 +30,12 @@ export const tabBarStyles = css`
 	.tab-bar {
 		display: flex;
 		flex-direction: row;
-		justify-content: center;
+		justify-content: flex-start;
 		align-items: center;
+	}
+
+	:host([full-width]) .tab-bar {
+		justify-content: center;
 	}
 
 	.tab-bar__items {

--- a/src/components/navigation/tab-bar/tab-bar.styles.ts
+++ b/src/components/navigation/tab-bar/tab-bar.styles.ts
@@ -154,8 +154,10 @@ export const tabBarItemStyles = css`
 		pointer-events: none;
 	}
 
-	.tab-bar__item:hover::before {
-		background-color: var(--semantics-buttons-neutral-tinted-is-hovered-background-color);
+	@media (hover: hover) {
+		.tab-bar__item:hover::before {
+			background-color: var(--semantics-buttons-neutral-tinted-is-hovered-background-color);
+		}
 	}
 
 	:host([selected]) .tab-bar__item::before {

--- a/src/components/navigation/top-title-bar/top-title-bar.test.ts
+++ b/src/components/navigation/top-title-bar/top-title-bar.test.ts
@@ -193,6 +193,26 @@ describe('nldd-top-title-bar – is-compact', () => {
 		expect(el.classList.contains('is-compact')).toBe(true);
 	});
 
+	it('does not auto-compact when neither collapse-anchor nor text is set', async () => {
+		el = await fixture<NLDDTopTitleBar>('<nldd-top-title-bar back-text="Terug"></nldd-top-title-bar>');
+		await waitForUpdate(el);
+		expect(el.classList.contains('is-compact')).toBe(false);
+	});
+
+	it('toggles is-compact when text changes while no collapse-anchor is set', async () => {
+		el = await fixture<NLDDTopTitleBar>('<nldd-top-title-bar back-text="Terug"></nldd-top-title-bar>');
+		await waitForUpdate(el);
+		expect(el.classList.contains('is-compact')).toBe(false);
+
+		el.text = 'Titel';
+		await waitForUpdate(el);
+		expect(el.classList.contains('is-compact')).toBe(true);
+
+		el.text = '';
+		await waitForUpdate(el);
+		expect(el.classList.contains('is-compact')).toBe(false);
+	});
+
 	it('stores the anchor element when collapse-anchor id matches', async () => {
 		const container = await fixture<HTMLElement>(`
 			<div>

--- a/src/components/navigation/top-title-bar/top-title-bar.ts
+++ b/src/components/navigation/top-title-bar/top-title-bar.ts
@@ -11,6 +11,10 @@
  * When `collapse-anchor` is set, the `is-compact` class is automatically applied
  * as soon as the top of the anchor element reaches the top of the scroll container.
  *
+ * Without `collapse-anchor` the bar takes a static state: compact when `text`
+ * is set (so the title shows in the title-group), non-compact otherwise (so
+ * the `back-text` button stays visible).
+ *
  * @slot toolbar - Optional buttons to the left of the dismiss button
  *
  * @fires back    - Fired when the back button is clicked (not fired when back-href is set)
@@ -58,10 +62,7 @@ export class NLDDTopTitleBar extends LitElement {
 		super.connectedCallback();
 		this._connectPage();
 		this._connectAnchor();
-		// Without a collapse-anchor there is no scroll trigger — always compact
-		if (!this.collapseAnchor) {
-			this.classList.add('is-compact');
-		}
+		this._updateAutoCompact();
 	}
 
 	override disconnectedCallback(): void {
@@ -74,10 +75,21 @@ export class NLDDTopTitleBar extends LitElement {
 			this._teardownAnchor();
 			if (this.collapseAnchor) {
 				this._connectAnchor();
-			} else {
-				this.classList.add('is-compact');
 			}
+			this._updateAutoCompact();
+		} else if (changed.has('text')) {
+			this._updateAutoCompact();
 		}
+	}
+
+	// Without a scroll anchor the bar can't toggle compact state on scroll,
+	// so we settle on a static state. With a `text` value we auto-compact
+	// (so the title shows in the title-group); without `text` we stay
+	// non-compact so the `back-text` button is visible. With an anchor the
+	// scroll listener owns the class — this method is a no-op.
+	private _updateAutoCompact(): void {
+		if (this.collapseAnchor) return;
+		this.classList.toggle('is-compact', Boolean(this.text));
 	}
 
 	private _connectPage(): void {

--- a/src/components/status-and-feedback/badge/badge.styles.ts
+++ b/src/components/status-and-feedback/badge/badge.styles.ts
@@ -15,6 +15,7 @@ export const badgeStyles = css`
 		--_icon-size: var(--primitives-space-14);
 		--_icon-offset-correction: var(--primitives-space-1);
 		--_dot-size: var(--primitives-space-10);
+
 		display: inline-flex;
 		vertical-align: middle;
 	}

--- a/src/components/status-and-feedback/inline-dialog/inline-dialog.styles.ts
+++ b/src/components/status-and-feedback/inline-dialog/inline-dialog.styles.ts
@@ -6,12 +6,12 @@ export const inlineDialogStyles = css`
 	/* # Host */
 
 	:host {
+		--_icon-color: var(--semantics-content-color);
+
 		display: flex;
 		justify-content: center;
 		align-items: center;
 		flex-grow: 1;
-
-		--_icon-color: var(--semantics-content-color);
 	}
 
 	:host([hidden]) {
@@ -19,7 +19,7 @@ export const inlineDialogStyles = css`
 	}
 
 	:host([variant='alert']) {
-		--_icon-color: var(--primitives-color-warning-350);
+		--_icon-color: light-dark(var(--primitives-color-warning-350), var(--primitives-color-warning-650));
 	}
 
 

--- a/src/components/status-and-feedback/inline-dialog/inline-dialog.styles.ts
+++ b/src/components/status-and-feedback/inline-dialog/inline-dialog.styles.ts
@@ -6,6 +6,7 @@ export const inlineDialogStyles = css`
 	/* # Host */
 
 	:host {
+		--_icon-size: var(--primitives-space-48);
 		--_icon-color: var(--semantics-content-color);
 
 		display: flex;
@@ -41,8 +42,8 @@ export const inlineDialogStyles = css`
 		display: flex;
 		align-items: center;
 		justify-content: center;
-		width: var(--primitives-space-48);
-		height: var(--primitives-space-48);
+		width: var(--_icon-size);
+		height: var(--_icon-size);
 		color: var(--_icon-color);
 		flex-shrink: 0;
 	}

--- a/src/components/status-and-feedback/modal-dialog/modal-dialog.styles.ts
+++ b/src/components/status-and-feedback/modal-dialog/modal-dialog.styles.ts
@@ -9,10 +9,11 @@ export const modalDialogStyles = css`
 	/* # Host */
 
 	:host {
-		display: contents;
 		--_max-height: 90vh;
 		--_animation-duration: 150ms;
 		--_animation-easing: ease;
+
+		display: contents;
 	}
 
 	:host([hidden]) {

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,9 @@
 /// <reference types="vite/client" />
+
+/* @types/prismjs ships no declarations for the per-grammar submodules.
+ * They register themselves with Prism.languages on load — the import
+ * itself is a side effect, the default export is unused. */
+declare module 'prismjs/components/*' {
+	const _: unknown;
+	export default _;
+}


### PR DESCRIPTION
## Summary

Six commits worth of design-system improvements gathered in one branch. Each commit is self-contained — review per commit if helpful.

### New components
- **`nldd-code`** — read-only block of monospace text. Optional `language` attribute uses Prism to highlight slot content (yaml, json, javascript, typescript, css, html, bash, markdown). Theme tokens (`--_token-*-color`) expose every Prism class for per-instance overrides. Without `language` the slot is rendered raw.
- **`nldd-code-editor`** — editable counterpart with the same chrome (tinted background, monospace, rounded corners). Form-associated. Spellcheck/autocorrect off by default.

### Component fixes
- **Cells** (`cell`, `text-cell`, `title-cell`, `description-cell`): `max-width` now also acts as `flex-basis` so a cell with `max-width=120px` next to a stretching sibling claims that width as a column. `flex-shrink: 1` made explicit on the stretch rule. `min-width: 0` removed from the stretch rule.
- **`nldd-top-title-bar`**: defaults to non-compact when neither `collapse-anchor` nor `text` is set.
- **`nldd-tab-bar`**: default `justify-content: flex-start`; only `[full-width]` centers.
- **Hover gating**: wrapped `:hover` rules in `@media (hover: hover)` across 14 components — fixes the touch-scroll hover-flash.
- **`nldd-app-view` + `nldd-page`**: prevent iOS rubber-band and scroll chaining.
- **`nldd-inline-dialog`**: alert icon color uses `light-dark()` for dark mode.
- **`nldd-icon-button`**: new `hide-tooltip` attribute applied to low-context cases (split-button chevron, spin buttons, dismiss, etc.).

### Variants
- **`nldd-split-button`** + **`nldd-button-bar`** support `accent-filled` / `primary`. New `--semantics-buttons-accent-filled-divider-color` token. Bumped `neutral-tinted` divider in dark mode for more contrast.

### Tokens
- Six new monospace primitives (md/sm/xs × snug/flat).

### Conventions
- SKILL canonical control order: variant moved before size in "visueel dominant".
- Local CSS vars at top of `:host`, blank line before properties — codified in SKILL, all components migrated.

## Test plan
- [ ] Storybook stories render for new components (light + dark)
- [ ] Touch hover-flash: gone on lists/tabs/buttons
- [ ] iOS rubber-band: gone
- [ ] Cells: max-width column behavior in editor panes
- [ ] vitest passes