### PR TITLE
feat(actions): form-associated buttons, text slot, and consistent active states

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,27 @@ the type of conventional-commit determines the release. Conventional types
 `chore`, `docs`, `ci`, `style`, `test`, `build` are intentionally omitted
 here; consult the commit history if you need that level of detail.
 
+## Unreleased
+
+### Highlights
+
+- Buttons doen nu echt mee in formulieren: `nldd-button` en `nldd-icon-button`
+  zijn form-associated, dus `type="submit"` en `type="reset"` werken nu ook
+  binnen een `<form>` (voorheen deed een klik niets over de shadow-grens).
+- Consistente "pressed" (active) feedback op alle neutral-tinted controls.
+
+### Added
+
+- **button**: een `text`-slot voor rijke labelinhoud (inline markup) ([c3fb360](https://github.com/MinBZK/storybook/commit/c3fb360))
+- **button / icon-button**: form-associatie via `ElementInternals`, zodat `type="submit"`/`"reset"` het formulier aandrijven ([fc56980](https://github.com/MinBZK/storybook/commit/fc56980), [0867ae6](https://github.com/MinBZK/storybook/commit/0867ae6))
+- **inputs**: `:active` (pressed) state op pagination-paginaknoppen, de pagination-select, segmented-control items, toggle-button en de menu-token; de pagination-select krijgt daarnaast hover/active/expanded surfaces zoals de dropdown, en de token-expanded volgt nu de volledige `is-expanded`-tokenfamilie ([216efdd](https://github.com/MinBZK/storybook/commit/216efdd))
+
+### Fixed
+
+- **form-field**: ruimere afstand tussen label en control zodat de focus-ring het label niet meer overlapt ([032528a](https://github.com/MinBZK/storybook/commit/032528a))
+- **forms**: ruimere "tight" gap tussen gestapelde formulierelementen ([98a9f82](https://github.com/MinBZK/storybook/commit/98a9f82))
+- **layout**: container gebruikt `height: auto` in plaats van `100%` ([017a38d](https://github.com/MinBZK/storybook/commit/017a38d))
+
 ## <small>0.8.45 (2026-05-21)</small>
 
 * feat!: bugs and housekeeping — menu, container, variant API, icon API, CSS refactor pass ([d53da4d](https://github.com/MinBZK/storybook/commit/d53da4d))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,25 +11,18 @@ here; consult the commit history if you need that level of detail.
 
 ## Unreleased
 
+<!--
+  Alleen Highlights worden hier handmatig bijgehouden — de Added/Changed/Fixed
+  entries genereert semantic-release bij de merge automatisch uit de commits.
+  Verplaats deze Highlights na de release onder de nieuwe versie-sectie.
+-->
+
 ### Highlights
 
 - Buttons doen nu echt mee in formulieren: `nldd-button` en `nldd-icon-button`
   zijn form-associated, dus `type="submit"` en `type="reset"` werken nu ook
   binnen een `<form>` (voorheen deed een klik niets over de shadow-grens).
 - Consistente "pressed" (active) feedback op alle neutral-tinted controls.
-
-### Added
-
-* **actions:** add a text slot to button for rich label content ([c3fb360](https://github.com/MinBZK/storybook/commit/c3fb360))
-* **actions:** make button form-associated so type=submit/reset works ([fc56980](https://github.com/MinBZK/storybook/commit/fc56980))
-* **actions:** make icon-button form-associated so type=submit/reset works ([0867ae6](https://github.com/MinBZK/storybook/commit/0867ae6))
-* **inputs:** add active states and align expanded states across controls ([216efdd](https://github.com/MinBZK/storybook/commit/216efdd))
-
-### Fixed
-
-* **forms:** widen form-field label-to-control gap so focus ring clears the label ([032528a](https://github.com/MinBZK/storybook/commit/032528a))
-* **forms:** widen the tight gap between stacked form elements ([98a9f82](https://github.com/MinBZK/storybook/commit/98a9f82))
-* **layout:** container height auto instead of 100% ([017a38d](https://github.com/MinBZK/storybook/commit/017a38d))
 
 ## <small>0.8.45 (2026-05-21)</small>
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,15 +20,16 @@ here; consult the commit history if you need that level of detail.
 
 ### Added
 
-- **button**: een `text`-slot voor rijke labelinhoud (inline markup) ([c3fb360](https://github.com/MinBZK/storybook/commit/c3fb360))
-- **button / icon-button**: form-associatie via `ElementInternals`, zodat `type="submit"`/`"reset"` het formulier aandrijven ([fc56980](https://github.com/MinBZK/storybook/commit/fc56980), [0867ae6](https://github.com/MinBZK/storybook/commit/0867ae6))
-- **inputs**: `:active` (pressed) state op pagination-paginaknoppen, de pagination-select, segmented-control items, toggle-button en de menu-token; de pagination-select krijgt daarnaast hover/active/expanded surfaces zoals de dropdown, en de token-expanded volgt nu de volledige `is-expanded`-tokenfamilie ([216efdd](https://github.com/MinBZK/storybook/commit/216efdd))
+* **actions:** add a text slot to button for rich label content ([c3fb360](https://github.com/MinBZK/storybook/commit/c3fb360))
+* **actions:** make button form-associated so type=submit/reset works ([fc56980](https://github.com/MinBZK/storybook/commit/fc56980))
+* **actions:** make icon-button form-associated so type=submit/reset works ([0867ae6](https://github.com/MinBZK/storybook/commit/0867ae6))
+* **inputs:** add active states and align expanded states across controls ([216efdd](https://github.com/MinBZK/storybook/commit/216efdd))
 
 ### Fixed
 
-- **form-field**: ruimere afstand tussen label en control zodat de focus-ring het label niet meer overlapt ([032528a](https://github.com/MinBZK/storybook/commit/032528a))
-- **forms**: ruimere "tight" gap tussen gestapelde formulierelementen ([98a9f82](https://github.com/MinBZK/storybook/commit/98a9f82))
-- **layout**: container gebruikt `height: auto` in plaats van `100%` ([017a38d](https://github.com/MinBZK/storybook/commit/017a38d))
+* **forms:** widen form-field label-to-control gap so focus ring clears the label ([032528a](https://github.com/MinBZK/storybook/commit/032528a))
+* **forms:** widen the tight gap between stacked form elements ([98a9f82](https://github.com/MinBZK/storybook/commit/98a9f82))
+* **layout:** container height auto instead of 100% ([017a38d](https://github.com/MinBZK/storybook/commit/017a38d))
 
 ## <small>0.8.45 (2026-05-21)</small>
 

--- a/src/assets/styles/settings.css
+++ b/src/assets/styles/settings.css
@@ -1070,10 +1070,6 @@
 
 	--components-document-tab-bar-tab-title-font: var(--primitives-font-body-sm-bold-flat);
 
-	/* ## Form field */
-
-	--components-form-field-gap: var(--primitives-space-2);
-
 	/* ## Icon — rijkskleuren
 
 	   Shade per rijkskleur picked to keep ≥400 shade distance from the

--- a/src/assets/styles/settings.css
+++ b/src/assets/styles/settings.css
@@ -955,7 +955,7 @@
 	/* ## Forms */
 
 	--semantics-forms-gap: var(--primitives-space-16);
-	--semantics-forms-gap-tight: var(--primitives-space-8);
+	--semantics-forms-gap-tight: var(--primitives-space-10);
 	--semantics-forms-label-column-width: var(--primitives-area-240);
 	--semantics-forms-columns-gap: var(--primitives-space-8);
 	--semantics-forms-section-title-font: var(--primitives-font-body-lg-bold-tight);

--- a/src/components/actions/button/button.stories.ts
+++ b/src/components/actions/button/button.stories.ts
@@ -203,8 +203,8 @@ export const RoleBased = {
 			description: {
 				story: 'Role based buttons zijn aliases van de appearance based buttons.',
 			},
+		},
 	},
-},
 };
 
 export const AppearanceBased = {
@@ -250,8 +250,8 @@ export const WithStartIcon = {
 			description: {
 				story: 'Button met een icoon aan de linkerkant via het <code>start-icon</code> attribute.',
 			},
+		},
 	},
-},
 };
 
 export const WithEndIcon = {
@@ -268,8 +268,8 @@ export const WithEndIcon = {
 			description: {
 				story: 'Button met een icoon aan de rechterkant via het <code>end-icon</code> attribute.',
 			},
+		},
 	},
-},
 };
 
 export const WithBothIcons = {
@@ -286,8 +286,8 @@ export const WithBothIcons = {
 			description: {
 				story: 'Button met zowel een start als end icoon via de <code>start-icon</code> en <code>end-icon</code> attributes.',
 			},
+		},
 	},
-},
 };
 
 export const WithDisclosureIcon = {
@@ -304,8 +304,8 @@ export const WithDisclosureIcon = {
 			description: {
 				story: 'Button die een menu of popover opent. Gebruik de <code>expandable</code> attribute om aan te geven dat deze button een menu of popover opent.',
 			},
+		},
 	},
-},
 };
 
 export const CustomIconSlot = {
@@ -329,8 +329,8 @@ export const CustomIconSlot = {
 			description: {
 				story: 'Gebruik de <code>start-icon</code> en <code>end-icon</code> slots om custom SVG iconen te plaatsen in plaats van de icon attributes.',
 			},
+		},
 	},
-},
 };
 
 export const TextSlot = {
@@ -350,6 +350,6 @@ export const TextSlot = {
 			description: {
 				story: 'Gebruik de <code>text</code> slot wanneer de knoptekst meer dan platte tekst nodig heeft (inline markup). Het <code>text</code> attribuut heeft voorrang; zet <code>accessible-label</code> wanneer de inhoud geen leesbare platte tekst is.',
 			},
+		},
 	},
-},
 };

--- a/src/components/actions/button/button.stories.ts
+++ b/src/components/actions/button/button.stories.ts
@@ -332,3 +332,24 @@ export const CustomIconSlot = {
 	},
 },
 };
+
+export const TextSlot = {
+	render: () => html`
+	<div style="display: flex; flex-wrap: wrap; gap: 16px; align-items: center;">
+		<nldd-button>
+			<span slot="text">Tekst met <strong>nadruk</strong></span>
+		</nldd-button>
+		<nldd-button variant="secondary" accessible-label="Prijs 15 euro, was 20 euro">
+			<span slot="text">Prijs <span style="text-decoration: line-through;">€20</span> €15</span>
+		</nldd-button>
+	</div>
+`,
+	parameters: {
+		controls: { disable: true },
+		docs: {
+			description: {
+				story: 'Gebruik de <code>text</code> slot wanneer de knoptekst meer dan platte tekst nodig heeft (inline markup). Het <code>text</code> attribuut heeft voorrang; zet <code>accessible-label</code> wanneer de inhoud geen leesbare platte tekst is.',
+			},
+	},
+},
+};

--- a/src/components/actions/button/button.template.ts
+++ b/src/components/actions/button/button.template.ts
@@ -13,7 +13,7 @@ function renderContent(component: NLDDButton) {
 					name=${component.startIcon}
 				></nldd-icon>
 			` : html`<slot name="start-icon"></slot>`}
-			<span class="button__text">${component.text}</span>
+			<span class="button__text">${component.text ? component.text : html`<slot name="text"></slot>`}</span>
 			${component.endIcon ? html`
 				<nldd-icon class="button__end-icon"
 					name=${component.endIcon}

--- a/src/components/actions/button/button.template.ts
+++ b/src/components/actions/button/button.template.ts
@@ -6,6 +6,9 @@ interface TemplateHelpers {
 }
 
 function renderContent(component: NLDDButton) {
+	// `button__text` falls back to the slot on falsy `text`. The property
+	// defaults to '', so `text=""` and an absent attribute are indistinguishable
+	// — both intentionally render the slot rather than an empty label.
 	return html`
 		<span class="button__content">
 			${component.startIcon ? html`

--- a/src/components/actions/button/button.test.ts
+++ b/src/components/actions/button/button.test.ts
@@ -24,6 +24,23 @@ describe('nldd-button', () => {
 		expect(content.textContent).toContain('Click me');
 	});
 
+	it('renders a text slot when the text attribute is not set', async () => {
+		el = await fixture('<nldd-button><strong slot="text">Bold label</strong></nldd-button>');
+		await waitForUpdate(el);
+		const slot = el.shadowRoot!.querySelector('.button__text slot[name="text"]') as HTMLSlotElement;
+		expect(slot).not.toBeNull();
+		const assigned = slot.assignedElements();
+		expect(assigned.length).toBe(1);
+		expect(assigned[0].textContent).toBe('Bold label');
+	});
+
+	it('text attribute takes precedence over the text slot (no slot rendered)', async () => {
+		el = await fixture('<nldd-button text="Attr wins"><span slot="text">Slotted</span></nldd-button>');
+		await waitForUpdate(el);
+		expect(el.shadowRoot!.querySelector('.button__text slot[name="text"]')).toBeNull();
+		expect(el.shadowRoot!.querySelector('.button__text')!.textContent).toContain('Attr wins');
+	});
+
 	it('forwards aria-label to the inner button element', async () => {
 		el = await fixture('<nldd-button accessible-label="Close dialog" text="X"></nldd-button>');
 		await waitForUpdate(el);

--- a/src/components/actions/button/button.test.ts
+++ b/src/components/actions/button/button.test.ts
@@ -405,3 +405,63 @@ describe('nldd-button – popoverTargetElement / popoverTargetAction IDL forward
 		expect(inner.popoverTargetAction).toBe('hide');
 	});
 });
+
+describe('nldd-button – form association', () => {
+	let host: HTMLElement;
+
+	afterEach(() => {
+		if (host) cleanup(host);
+	});
+
+	function clickInner(root: ParentNode) {
+		const btn = root.querySelector('nldd-button')!;
+		(btn.shadowRoot!.querySelector('button') as HTMLElement).click();
+	}
+
+	it('submits the closest form on click when type=submit', async () => {
+		host = await fixture('<form><input name="x" /><nldd-button type="submit" text="Go"></nldd-button></form>');
+		await waitForUpdate(host.querySelector('nldd-button')!);
+		let submitted = false;
+		host.addEventListener('submit', (e) => { e.preventDefault(); submitted = true; });
+		clickInner(host);
+		expect(submitted).toBe(true);
+	});
+
+	it('does not submit when type is the default (button)', async () => {
+		host = await fixture('<form><input name="x" /><nldd-button text="Go"></nldd-button></form>');
+		await waitForUpdate(host.querySelector('nldd-button')!);
+		let submitted = false;
+		host.addEventListener('submit', (e) => { e.preventDefault(); submitted = true; });
+		clickInner(host);
+		expect(submitted).toBe(false);
+	});
+
+	it('does not submit when disabled', async () => {
+		host = await fixture('<form><input name="x" /><nldd-button type="submit" disabled text="Go"></nldd-button></form>');
+		await waitForUpdate(host.querySelector('nldd-button')!);
+		let submitted = false;
+		host.addEventListener('submit', (e) => { e.preventDefault(); submitted = true; });
+		clickInner(host);
+		expect(submitted).toBe(false);
+	});
+
+	it('resets the form on click when type=reset', async () => {
+		host = await fixture('<form><input name="x" /><nldd-button type="reset" text="Reset"></nldd-button></form>');
+		await waitForUpdate(host.querySelector('nldd-button')!);
+		const input = host.querySelector('input') as HTMLInputElement;
+		input.value = 'changed';
+		clickInner(host);
+		expect(input.value).toBe('');
+	});
+
+	it('a link button (href) never triggers form submission', async () => {
+		host = await fixture('<form><input name="x" /><nldd-button type="submit" href="/x" text="Link"></nldd-button></form>');
+		await waitForUpdate(host.querySelector('nldd-button')!);
+		let submitted = false;
+		host.addEventListener('submit', (e) => { e.preventDefault(); submitted = true; });
+		const a = host.querySelector('nldd-button')!.shadowRoot!.querySelector('a') as HTMLElement;
+		a.addEventListener('click', (e) => e.preventDefault());
+		a.click();
+		expect(submitted).toBe(false);
+	});
+});

--- a/src/components/actions/button/button.ts
+++ b/src/components/actions/button/button.ts
@@ -184,6 +184,15 @@ export class NLDDButton extends LitElement {
 		// the light-DOM form across the shadow boundary. requestSubmit() runs
 		// constraint validation and fires a cancelable submit event, matching a
 		// native submit button.
+		//
+		// Limitation: we call requestSubmit() without a submitter, so
+		// SubmitEvent.submitter is null. A form handler that branches on
+		// event.submitter to tell multiple submit buttons apart won't see this
+		// element. There is no fix via requestSubmit(submitter): the inner shadow
+		// <button> is not a form descendant (throws NotFoundError) and this host
+		// is not a "submit button" per spec (throws TypeError) — both verified.
+		// Consumers that need to distinguish submitters should use a hidden field
+		// or separate forms.
 		if (this.href) return;
 		if (this.type === 'submit') this._internals.form?.requestSubmit();
 		else if (this.type === 'reset') this._internals.form?.reset();

--- a/src/components/actions/button/button.ts
+++ b/src/components/actions/button/button.ts
@@ -19,6 +19,7 @@
  * @attr {string} target - Link target (e.g. '_blank'); only used when href is set
  * @attr {string} rel - Link rel attribute; defaults to 'noopener noreferrer' when target is '_blank'
  *
+ * @slot text - Slot for custom button content (e.g. text with inline markup). Only used when the text attribute is not set. Provide accessible-label when the slotted content isn't plain text.
  * @slot start-icon - Slot for a custom start icon (e.g. custom SVG). Only used when start-icon attribute is not set.
  * @slot end-icon - Slot for a custom end icon (e.g. custom SVG). Only used when end-icon attribute is not set.
  *

--- a/src/components/actions/button/button.ts
+++ b/src/components/actions/button/button.ts
@@ -50,6 +50,12 @@ type PopupType = 'menu' | 'listbox' | 'dialog' | 'tree' | 'grid';
 export class NLDDButton extends LitElement {
 	static override styles = buttonStyles;
 
+	// Form-associated so a type="submit"/"reset" button can drive its form.
+	// The inner <button> lives in the shadow root and has no form owner across
+	// the shadow boundary, so the host element must carry the association.
+	static formAssociated = true;
+	private _internals = this.attachInternals();
+
 	@property({ type: String, reflect: true })
 	variant: Variant = 'neutral-tinted';
 
@@ -173,6 +179,14 @@ export class NLDDButton extends LitElement {
 			e.stopPropagation();
 			return;
 		}
+		// A link button has no form behaviour. Otherwise drive the associated
+		// form ourselves: the shadow <button type="submit"|"reset"> can't reach
+		// the light-DOM form across the shadow boundary. requestSubmit() runs
+		// constraint validation and fires a cancelable submit event, matching a
+		// native submit button.
+		if (this.href) return;
+		if (this.type === 'submit') this._internals.form?.requestSubmit();
+		else if (this.type === 'reset') this._internals.form?.reset();
 	}
 
 	/** Resolves the effective rel value for link rendering. */

--- a/src/components/actions/button/button.ts
+++ b/src/components/actions/button/button.ts
@@ -19,7 +19,7 @@
  * @attr {string} target - Link target (e.g. '_blank'); only used when href is set
  * @attr {string} rel - Link rel attribute; defaults to 'noopener noreferrer' when target is '_blank'
  *
- * @slot text - Slot for custom button content (e.g. text with inline markup). Only used when the text attribute is not set. Provide accessible-label when the slotted content isn't plain text.
+ * @slot text - Slot for custom button content (e.g. text with inline markup). Used when the text attribute is empty or not set (an empty string counts as "not set", since the attribute and the unset property are indistinguishable). Provide accessible-label when the slotted content isn't plain text.
  * @slot start-icon - Slot for a custom start icon (e.g. custom SVG). Only used when start-icon attribute is not set.
  * @slot end-icon - Slot for a custom end icon (e.g. custom SVG). Only used when end-icon attribute is not set.
  *

--- a/src/components/actions/icon-button/icon-button.test.ts
+++ b/src/components/actions/icon-button/icon-button.test.ts
@@ -435,3 +435,52 @@ describe('nldd-icon-button – popoverTargetElement / popoverTargetAction IDL fo
 		expect(inner.popoverTargetAction).toBe('hide');
 	});
 });
+
+describe('nldd-icon-button – form association', () => {
+	let host: HTMLElement;
+
+	afterEach(() => {
+		if (host) cleanup(host);
+	});
+
+	function clickInner(root: ParentNode) {
+		const btn = root.querySelector('nldd-icon-button')!;
+		(btn.shadowRoot!.querySelector('button') as HTMLElement).click();
+	}
+
+	it('submits the closest form on click when type=submit', async () => {
+		host = await fixture('<form><input name="x" /><nldd-icon-button type="submit" icon="check-mark" accessible-label="Verstuur"></nldd-icon-button></form>');
+		await waitForUpdate(host.querySelector('nldd-icon-button')!);
+		let submitted = false;
+		host.addEventListener('submit', (e) => { e.preventDefault(); submitted = true; });
+		clickInner(host);
+		expect(submitted).toBe(true);
+	});
+
+	it('does not submit when type is the default (button)', async () => {
+		host = await fixture('<form><input name="x" /><nldd-icon-button icon="check-mark" accessible-label="Actie"></nldd-icon-button></form>');
+		await waitForUpdate(host.querySelector('nldd-icon-button')!);
+		let submitted = false;
+		host.addEventListener('submit', (e) => { e.preventDefault(); submitted = true; });
+		clickInner(host);
+		expect(submitted).toBe(false);
+	});
+
+	it('resets the form on click when type=reset', async () => {
+		host = await fixture('<form><input name="x" /><nldd-icon-button type="reset" icon="arrow-2-counter-clockwise" accessible-label="Reset"></nldd-icon-button></form>');
+		await waitForUpdate(host.querySelector('nldd-icon-button')!);
+		const input = host.querySelector('input') as HTMLInputElement;
+		input.value = 'changed';
+		clickInner(host);
+		expect(input.value).toBe('');
+	});
+
+	it('does not submit when disabled', async () => {
+		host = await fixture('<form><input name="x" /><nldd-icon-button type="submit" disabled icon="check-mark" accessible-label="Verstuur"></nldd-icon-button></form>');
+		await waitForUpdate(host.querySelector('nldd-icon-button')!);
+		let submitted = false;
+		host.addEventListener('submit', (e) => { e.preventDefault(); submitted = true; });
+		clickInner(host);
+		expect(submitted).toBe(false);
+	});
+});

--- a/src/components/actions/icon-button/icon-button.test.ts
+++ b/src/components/actions/icon-button/icon-button.test.ts
@@ -483,4 +483,15 @@ describe('nldd-icon-button – form association', () => {
 		clickInner(host);
 		expect(submitted).toBe(false);
 	});
+
+	it('a link icon-button (href) never triggers form submission', async () => {
+		host = await fixture('<form><input name="x" /><nldd-icon-button type="submit" href="/x" icon="arrow-right" accessible-label="Link"></nldd-icon-button></form>');
+		await waitForUpdate(host.querySelector('nldd-icon-button')!);
+		let submitted = false;
+		host.addEventListener('submit', (e) => { e.preventDefault(); submitted = true; });
+		const a = host.querySelector('nldd-icon-button')!.shadowRoot!.querySelector('a') as HTMLElement;
+		a.addEventListener('click', (e) => e.preventDefault());
+		a.click();
+		expect(submitted).toBe(false);
+	});
 });

--- a/src/components/actions/icon-button/icon-button.ts
+++ b/src/components/actions/icon-button/icon-button.ts
@@ -205,6 +205,15 @@ export class NLDDIconButton extends LitElement {
 		// A link icon-button has no form behaviour. Otherwise drive the
 		// associated form ourselves: the shadow <button type="submit"|"reset">
 		// can't reach the light-DOM form across the shadow boundary.
+		//
+		// Limitation: we call requestSubmit() without a submitter, so
+		// SubmitEvent.submitter is null. A form handler that branches on
+		// event.submitter to tell multiple submit buttons apart won't see this
+		// element. There is no fix via requestSubmit(submitter): the inner shadow
+		// <button> is not a form descendant (throws NotFoundError) and this host
+		// is not a "submit button" per spec (throws TypeError) — both verified.
+		// Consumers that need to distinguish submitters should use a hidden field
+		// or separate forms.
 		if (this.href) return;
 		if (this.type === 'submit') this._internals.form?.requestSubmit();
 		else if (this.type === 'reset') this._internals.form?.reset();

--- a/src/components/actions/icon-button/icon-button.ts
+++ b/src/components/actions/icon-button/icon-button.ts
@@ -60,6 +60,12 @@ export type PopupType = 'menu' | 'listbox' | 'dialog' | 'tree' | 'grid';
 export class NLDDIconButton extends LitElement {
 	static override styles = iconButtonStyles;
 
+	// Form-associated so a type="submit"/"reset" icon-button can drive its
+	// form. The inner <button> lives in the shadow root and has no form owner
+	// across the shadow boundary, so the host element must carry the association.
+	static formAssociated = true;
+	private _internals = this.attachInternals();
+
 	@property({ type: String, reflect: true })
 	variant: Variant = 'neutral-tinted';
 
@@ -196,6 +202,12 @@ export class NLDDIconButton extends LitElement {
 			e.stopPropagation();
 			return;
 		}
+		// A link icon-button has no form behaviour. Otherwise drive the
+		// associated form ourselves: the shadow <button type="submit"|"reset">
+		// can't reach the light-DOM form across the shadow boundary.
+		if (this.href) return;
+		if (this.type === 'submit') this._internals.form?.requestSubmit();
+		else if (this.type === 'reset') this._internals.form?.reset();
 	}
 
 	/**

--- a/src/components/forms/form-field/form-field.styles.ts
+++ b/src/components/forms/form-field/form-field.styles.ts
@@ -9,6 +9,8 @@ export const formFieldStyles = css`
 	/* # Host */
 
 	:host {
+		--_gap: calc(var(--primitives-space-10) / 2);
+
 		display: block;
 		container-type: inline-size;
 	}
@@ -23,7 +25,7 @@ export const formFieldStyles = css`
 	.form-field {
 		display: flex;
 		flex-direction: column;
-		gap: var(--components-form-field-gap);
+		gap: var(--_gap);
 	}
 
 	:host([label-alignment="left"]) .form-field,

--- a/src/components/inputs/segmented-control/segmented-control.styles.ts
+++ b/src/components/inputs/segmented-control/segmented-control.styles.ts
@@ -118,6 +118,16 @@ export const segmentedControlItemStyles = css`
 		}
 	}
 
+	:host(:not([selected])) .segmented-control__item:active {
+		background-color: var(--semantics-buttons-neutral-tinted-is-active-background-color);
+		color: var(--semantics-buttons-neutral-tinted-is-active-content-color);
+	}
+
+	:host([selected]) .segmented-control__item:active {
+		background-color: var(--semantics-buttons-neutral-tinted-is-selected-is-active-background-color);
+		color: var(--semantics-buttons-neutral-tinted-is-selected-is-active-content-color);
+	}
+
 	:host([disabled]) .segmented-control__item {
 		opacity: var(--primitives-opacity-disabled);
 	}

--- a/src/components/inputs/toggle-button/toggle-button.styles.ts
+++ b/src/components/inputs/toggle-button/toggle-button.styles.ts
@@ -84,6 +84,12 @@ export const toggleButtonStyles = css`
 		}
 	}
 
+	.toggle-button:active,
+	.toggle-button:has(.toggle-button__input:active) {
+		background-color: var(--semantics-buttons-neutral-tinted-is-active-background-color);
+		color: var(--semantics-buttons-neutral-tinted-is-active-content-color);
+	}
+
 	:host([selected]) .toggle-button {
 		background-color: var(--semantics-buttons-neutral-tinted-is-selected-background-color);
 		color: var(--semantics-buttons-neutral-tinted-is-selected-content-color);
@@ -95,6 +101,12 @@ export const toggleButtonStyles = css`
 			background-color: var(--semantics-buttons-neutral-tinted-is-selected-is-hovered-background-color);
 			color: var(--semantics-buttons-neutral-tinted-is-selected-is-hovered-content-color);
 		}
+	}
+
+	:host([selected]) .toggle-button:active,
+	:host([selected]) .toggle-button:has(.toggle-button__input:active) {
+		background-color: var(--semantics-buttons-neutral-tinted-is-selected-is-active-background-color);
+		color: var(--semantics-buttons-neutral-tinted-is-selected-is-active-content-color);
 	}
 
 	.toggle-button:focus-visible,

--- a/src/components/inputs/token/token.styles.ts
+++ b/src/components/inputs/token/token.styles.ts
@@ -52,16 +52,26 @@ export const tokenStyles = css`
 		}
 	}
 
-	:host([expanded]) .token {
+	:host([control="menu"]) .token:active:not(:disabled) {
 		background-color: var(--semantics-buttons-neutral-tinted-is-active-background-color);
 		color: var(--semantics-buttons-neutral-tinted-is-active-content-color);
 	}
 
+	:host([expanded]) .token {
+		background-color: var(--semantics-buttons-neutral-tinted-is-expanded-background-color);
+		color: var(--semantics-buttons-neutral-tinted-is-expanded-content-color);
+	}
+
 	@media (hover: hover) {
 		:host([expanded]) .token:hover:not(:disabled) {
-			background-color: var(--semantics-buttons-neutral-tinted-is-active-background-color);
-			color: var(--semantics-buttons-neutral-tinted-is-active-content-color);
+			background-color: var(--semantics-buttons-neutral-tinted-is-expanded-is-hovered-background-color);
+			color: var(--semantics-buttons-neutral-tinted-is-expanded-is-hovered-content-color);
 		}
+	}
+
+	:host([expanded]) .token:active:not(:disabled) {
+		background-color: var(--semantics-buttons-neutral-tinted-is-expanded-is-active-background-color);
+		color: var(--semantics-buttons-neutral-tinted-is-expanded-is-active-content-color);
 	}
 
 	:host([control="menu"]) .token:focus-visible {

--- a/src/components/layout/container/container.styles.ts
+++ b/src/components/layout/container/container.styles.ts
@@ -36,7 +36,7 @@ export const containerStyles = css`
 		--_lg-padding-left: var(--_padding-left);
 
 		display: flex;
-		height: 100%;
+		height: auto;
 		flex-direction: column;
 		flex-wrap: nowrap;
 		justify-content: var(--_justify-content);

--- a/src/components/navigation/pagination/pagination.styles.ts
+++ b/src/components/navigation/pagination/pagination.styles.ts
@@ -80,9 +80,19 @@ export const paginationStyles = css`
 		}
 	}
 
+	.pagination__page-button:active:not(.is-current) {
+		background-color: var(--semantics-buttons-neutral-tinted-is-active-background-color);
+		color: var(--semantics-buttons-neutral-tinted-is-active-content-color);
+	}
+
 	.pagination__page-button.is-current {
 		background-color: var(--semantics-buttons-neutral-tinted-is-selected-background-color);
 		color: var(--semantics-buttons-neutral-tinted-is-selected-content-color);
+	}
+
+	.pagination__page-button.is-current:active {
+		background-color: var(--semantics-buttons-neutral-tinted-is-selected-is-active-background-color);
+		color: var(--semantics-buttons-neutral-tinted-is-selected-is-active-content-color);
 	}
 
 	@media (forced-colors: active) {
@@ -143,9 +153,53 @@ export const paginationStyles = css`
 	/* # Select (compact fallback) */
 
 	.pagination__select-wrapper {
+		/* Mirrors the dropdown's neutral-tinted state tokens. The visible
+		   <select> sits on top with a transparent background, so the wrapper
+		   carries the hover/active/expanded surface behind it. */
+		--_background-color: transparent;
+		--_content-color: inherit;
+		--_is-hovered-background-color: var(--semantics-buttons-neutral-tinted-is-hovered-background-color);
+		--_is-hovered-content-color: var(--semantics-buttons-neutral-tinted-is-hovered-content-color);
+		--_is-active-background-color: var(--semantics-buttons-neutral-tinted-is-active-background-color);
+		--_is-active-content-color: var(--semantics-buttons-neutral-tinted-is-active-content-color);
+
 		display: inline-flex;
 		position: relative;
+		border-radius: var(--semantics-controls-md-corner-radius);
+		background-color: var(--_background-color);
 		align-items: center;
+		color: var(--_content-color);
+		transition:
+			background-color var(--primitives-transition-duration-fast) var(--primitives-transition-easing-default),
+			color var(--primitives-transition-duration-fast) var(--primitives-transition-easing-default)
+		;
+	}
+
+	@media (hover: hover) {
+		.pagination__select-wrapper:hover {
+			background-color: var(--_is-hovered-background-color);
+			color: var(--_is-hovered-content-color);
+		}
+	}
+
+	.pagination__select-wrapper:active {
+		background-color: var(--_is-active-background-color);
+		color: var(--_is-active-content-color);
+	}
+
+	:host([select-expanded]) .pagination__select-wrapper {
+		--_background-color: var(--semantics-buttons-neutral-tinted-is-expanded-background-color);
+		--_content-color: var(--semantics-buttons-neutral-tinted-is-expanded-content-color);
+		--_is-hovered-background-color: var(--semantics-buttons-neutral-tinted-is-expanded-is-hovered-background-color);
+		--_is-hovered-content-color: var(--semantics-buttons-neutral-tinted-is-expanded-is-hovered-content-color);
+		--_is-active-background-color: var(--semantics-buttons-neutral-tinted-is-expanded-is-active-background-color);
+		--_is-active-content-color: var(--semantics-buttons-neutral-tinted-is-expanded-is-active-content-color);
+	}
+
+	@media (prefers-reduced-motion: reduce) {
+		.pagination__select-wrapper {
+			transition: none;
+		}
 	}
 
 	.pagination__select {
@@ -158,7 +212,7 @@ export const paginationStyles = css`
 		height: var(--semantics-controls-md-min-size);
 		padding-block: var(--primitives-space-8);
 		padding-inline-start: var(--primitives-space-12);
-		padding-inline-end: calc(var(--primitives-space-24) + var(--primitives-space-4));
+		padding-inline-end: calc(var(--primitives-space-24) + var(--primitives-space-12));
 		color: inherit;
 		font: var(--semantics-buttons-md-font);
 		appearance: none;

--- a/src/components/navigation/pagination/pagination.template.ts
+++ b/src/components/navigation/pagination/pagination.template.ts
@@ -76,6 +76,7 @@ export function paginationTemplate(component: NLDDPagination): TemplateResult {
 						@focus=${component._handleSelectFocus}
 						@blur=${component._handleSelectBlur}
 						@keydown=${component._handleSelectKeydown}
+						@toggle=${component._handleSelectToggle}
 					>
 						${Array.from({ length: component.total }, (_, i) => i + 1).map((page) => html`
 							<option value=${page} ?selected=${page === component.current}>${page} / ${component.total}</option>

--- a/src/components/navigation/pagination/pagination.test.ts
+++ b/src/components/navigation/pagination/pagination.test.ts
@@ -265,3 +265,41 @@ describe('nldd-pagination – translations', () => {
 	});
 });
 
+describe('nldd-pagination – select expanded state', () => {
+	let el: NLDDPagination;
+
+	afterEach(() => {
+		if (el) cleanup(el);
+	});
+
+	it('sets the select-expanded attribute when the picker opens', async () => {
+		el = await fixture<NLDDPagination>('<nldd-pagination current="1" total="5"></nldd-pagination>');
+		await waitForUpdate(el);
+
+		el._handleSelectToggle(Object.assign(new Event('toggle'), { newState: 'open' }));
+		expect(el.hasAttribute('select-expanded')).toBe(true);
+	});
+
+	it('removes the select-expanded attribute when the picker closes', async () => {
+		el = await fixture<NLDDPagination>('<nldd-pagination current="1" total="5"></nldd-pagination>');
+		await waitForUpdate(el);
+
+		el._handleSelectToggle(Object.assign(new Event('toggle'), { newState: 'open' }));
+		expect(el.hasAttribute('select-expanded')).toBe(true);
+
+		el._handleSelectToggle(Object.assign(new Event('toggle'), { newState: 'closed' }));
+		expect(el.hasAttribute('select-expanded')).toBe(false);
+	});
+
+	it('clears the select-expanded attribute on blur', async () => {
+		el = await fixture<NLDDPagination>('<nldd-pagination current="1" total="5"></nldd-pagination>');
+		await waitForUpdate(el);
+
+		el._handleSelectToggle(Object.assign(new Event('toggle'), { newState: 'open' }));
+		expect(el.hasAttribute('select-expanded')).toBe(true);
+
+		el._handleSelectBlur();
+		expect(el.hasAttribute('select-expanded')).toBe(false);
+	});
+});
+

--- a/src/components/navigation/pagination/pagination.ts
+++ b/src/components/navigation/pagination/pagination.ts
@@ -131,11 +131,23 @@ export class NLDDPagination extends LitElement {
 
 	_handleSelectBlur = (): void => {
 		this.toggleAttribute('is-pointer-focus', false);
+		this.toggleAttribute('select-expanded', false);
 	};
 
 	/** Any key press while focused promotes to keyboard mode — drop the marker. */
 	_handleSelectKeydown = (): void => {
 		this.toggleAttribute('is-pointer-focus', false);
+	};
+
+	/**
+	 * Native <select> dispatches a `toggle` event with `newState` of 'open' or
+	 * 'closed' (Chrome 131+, Firefox 134+, Safari 18+). Older browsers silently
+	 * skip this — the visual expanded state is then a no-op. Drives the
+	 * `select-expanded` host attribute that switches the wrapper to its
+	 * is-expanded surface tokens.
+	 */
+	_handleSelectToggle = (e: Event): void => {
+		this.toggleAttribute('select-expanded', (e as ToggleEvent).newState === 'open');
 	};
 
 	override render() {


### PR DESCRIPTION
## Summary

- `nldd-button` en `nldd-icon-button` zijn form-associated → `type="submit"`/`"reset"` werken nu binnen een `<form>` (voorheen deed een klik niets over de shadow-grens)
- `button` krijgt een `text`-slot voor rijke labelinhoud (inline markup)
- Consistente `:active` (pressed) state over pagination-paginaknoppen, de pagination-select, segmented-control items, toggle-button en de menu-token; de pagination-select krijgt daarnaast hover/active/expanded surfaces zoals de dropdown, en de token-expanded volgt nu de volledige `is-expanded`-tokenfamilie
- Fixes: form-field label-to-control gap, forms tight-gap, container `height: auto`

## Changelog (Unreleased)

### Highlights

- Buttons doen nu echt mee in formulieren: `nldd-button` en `nldd-icon-button` zijn form-associated, dus `type="submit"` en `type="reset"` werken nu ook binnen een `<form>`.
- Consistente "pressed" (active) feedback op alle neutral-tinted controls.

### Added

- **actions:** add a text slot to button for rich label content
- **actions:** make button form-associated so type=submit/reset works
- **actions:** make icon-button form-associated so type=submit/reset works
- **inputs:** add active states and align expanded states across controls

### Fixed

- **forms:** widen form-field label-to-control gap so focus ring clears the label
- **forms:** widen the tight gap between stacked form elements
- **layout:** container height auto instead of 100%