### PR TITLE
feat(actions): part="button" toevoegen aan button en icon-button

### DIFF
--- a/src/components/actions/button/button.template.ts
+++ b/src/components/actions/button/button.template.ts
@@ -46,6 +46,7 @@ export function template(this: NLDDButton, helpers: TemplateHelpers) {
 		const resolvedRel = this._resolvedRel();
 		return html`
 			<a class="button"
+				part="button"
 				href=${this.href}
 				target=${this.target || nothing}
 				rel=${resolvedRel || nothing}
@@ -67,6 +68,7 @@ export function template(this: NLDDButton, helpers: TemplateHelpers) {
 	// drives is non-functional regardless. No per-binding capability check.
 	return html`
 		<button class="button"
+			part="button"
 			type=${this.type}
 			?disabled=${this.disabled}
 			aria-disabled=${this.disabled ? 'true' : nothing}

--- a/src/components/actions/button/button.test.ts
+++ b/src/components/actions/button/button.test.ts
@@ -133,6 +133,28 @@ describe('nldd-button – icon attributes', () => {
 	});
 });
 
+describe('nldd-button – part="button"', () => {
+	let el: NLDDButton;
+
+	afterEach(() => {
+		if (el) cleanup(el);
+	});
+
+	it('exposes part="button" on the inner <button>', async () => {
+		el = await fixture<NLDDButton>('<nldd-button text="Opslaan"></nldd-button>');
+		await waitForUpdate(el);
+		const btn = el.shadowRoot!.querySelector('button')!;
+		expect(btn.getAttribute('part')).toBe('button');
+	});
+
+	it('exposes part="button" on the inner <a> when href is set', async () => {
+		el = await fixture<NLDDButton>('<nldd-button href="/overzicht" text="Terug"></nldd-button>');
+		await waitForUpdate(el);
+		const a = el.shadowRoot!.querySelector('a')!;
+		expect(a.getAttribute('part')).toBe('button');
+	});
+});
+
 describe('nldd-button – href / link rendering', () => {
 	let el: NLDDButton;
 

--- a/src/components/actions/button/button.ts
+++ b/src/components/actions/button/button.ts
@@ -23,6 +23,11 @@
  * @slot start-icon - Slot for a custom start icon (e.g. custom SVG). Only used when start-icon attribute is not set.
  * @slot end-icon - Slot for a custom end icon (e.g. custom SVG). Only used when end-icon attribute is not set.
  *
+ * @csspart button - The inner interactive element: the `<button>`, or the `<a>`
+ *                    when `href` is set. Use `nldd-button::part(button)` to apply
+ *                    consumer-specific styling across the shadow boundary without
+ *                    recreating the component.
+ *
  * @fires click - When button is clicked (not fired when disabled)
  */
 

--- a/src/components/actions/icon-button/icon-button.template.ts
+++ b/src/components/actions/icon-button/icon-button.template.ts
@@ -43,6 +43,7 @@ export function template(this: NLDDIconButton) {
 			const resolvedRel = this._resolvedRel();
 			return html`
 				<a class="icon-button"
+					part="button"
 					href=${this.href}
 					target=${this.target || nothing}
 					rel=${resolvedRel || nothing}
@@ -64,6 +65,7 @@ export function template(this: NLDDIconButton) {
 		// this button drives is non-functional regardless. No capability check.
 		return html`
 			<button class="icon-button"
+				part="button"
 				type=${this.type}
 				?disabled=${this.disabled}
 				aria-disabled=${this.disabled ? 'true' : nothing}

--- a/src/components/actions/icon-button/icon-button.test.ts
+++ b/src/components/actions/icon-button/icon-button.test.ts
@@ -295,6 +295,32 @@ describe('nldd-icon-button – href / link rendering', () => {
 	});
 });
 
+/* ============================================================
+   CSS part (external styling hook)
+   ============================================================ */
+
+describe('nldd-icon-button – part="button"', () => {
+	let el: NLDDIconButton;
+
+	afterEach(() => {
+		if (el) cleanup(el);
+	});
+
+	it('exposes part="button" on the inner <button>', async () => {
+		el = await fixture<NLDDIconButton>('<nldd-icon-button icon="dismiss" text="Sluiten" tooltip-timing="never"></nldd-icon-button>');
+		await waitForUpdate(el);
+		const btn = el.shadowRoot!.querySelector('button')!;
+		expect(btn.getAttribute('part')).toBe('button');
+	});
+
+	it('exposes part="button" on the inner <a> when href is set', async () => {
+		el = await fixture<NLDDIconButton>('<nldd-icon-button href="/overzicht" icon="arrow-left" text="Terug" tooltip-timing="never"></nldd-icon-button>');
+		await waitForUpdate(el);
+		const a = el.shadowRoot!.querySelector('a')!;
+		expect(a.getAttribute('part')).toBe('button');
+	});
+});
+
 describe('nldd-icon-button – aria-expanded / aria-haspopup', () => {
 	let el: NLDDIconButton;
 

--- a/src/components/actions/icon-button/icon-button.ts
+++ b/src/components/actions/icon-button/icon-button.ts
@@ -29,6 +29,11 @@
  *
  * @slot icon - Slot for a custom icon (e.g. custom SVG). Only used when icon attribute is not set.
  *
+ * @csspart button - The inner interactive element: the `<button>`, or the `<a>`
+ *                    when `href` is set. Use `nldd-icon-button::part(button)` to
+ *                    apply consumer-specific styling (e.g. padding, custom hover)
+ *                    across the shadow boundary without recreating the component.
+ *
  * @example
  * ```html
  * <nldd-icon-button text="Download" icon="download"></nldd-icon-button>


### PR DESCRIPTION
Het interactieve element (`<button>`, of `<a>` wanneer `href` gezet is) zit in de shadow DOM zonder styling-haak. Consumers kunnen styling op control-niveau (padding, eigen hover, enzovoort) daardoor niet van buitenaf aanpassen, en bouwen het component vaak na met een native button.

In de hele component-bibliotheek exposeert nog geen enkele interactieve control een `part` (alleen `nldd-button-bar` heeft er een). Deze PR introduceert het patroon consistent voor **beide** enkelvoudige knoppen: `<nldd-button>` en `<nldd-icon-button>`.

Met `part="button"` op zowel de `<button>` als de `<a>` kunnen consumers het element aanspreken via `nldd-button::part(button)` / `nldd-icon-button::part(button)`. Puur additief: de rendering verandert niet. Gedocumenteerd als `@csspart` in de component-JSDoc en gedekt met tests voor zowel de button- als linkmodus.

## Voorbeeld

Bijvoorbeeld een sluitknop (modal-header-X, toast-dismiss, search-clear) die in zijn context wat krappere padding en een eigen hover-achtergrond nodig heeft.

**Zonder styling-haak** valt de consumer terug op een eigen native button — en bouwt daarmee `aria-label`, tooltip en focus-afhandeling zelf opnieuw:

```html
<button class="close"><nldd-icon name="dismiss"></nldd-icon></button>
```
```css
.close { display: inline-flex; padding: 4px; }
.close:hover { background-color: var(--…-hover-bg); }
```

**Met `part="button"`** blijft `<nldd-icon-button>` in gebruik en past de consumer alleen het control-element aan:

```css
nldd-icon-button.close::part(button) { padding: 4px; }
nldd-icon-button.close::part(button):hover { background-color: var(--…-hover-bg); }
```

`::part()` is daarbij een witte lijst: alleen elementen met een `part`-attribuut zijn extern styleable; de rest van de shadow DOM blijft afgeschermd. Het design system houdt de regie.

## Wijzigingen

- `button.template.ts` / `icon-button.template.ts` — `part="button"` op het interne `<button>` en `<a>`
- `button.ts` / `icon-button.ts` — `@csspart`-documentatie in de component-JSDoc
- `button.test.ts` / `icon-button.test.ts` — tests voor het part in button- en linkmodus

## Verificatie

- Tests: 93/93 groen (button 47, icon-button 46)
- ESLint + TypeScript: clean
