### PR TITLE
feat(icon): aliassen voor messaging- en composer-iconen toevoegen

### DIFF
--- a/src/components/content/icon/icon-aliases.js
+++ b/src/components/content/icon/icon-aliases.js
@@ -135,9 +135,11 @@ export const aliases = {
 	// face-smiling
 	'happy': 'face-smiling',
 	'smiling': 'face-smiling',
+	'emoji': 'face-smiling',
 
 	// face-smiling-badge-plus
 	'add-emoji': 'face-smiling-badge-plus',
+	'smile-plus': 'face-smiling-badge-plus',
 
 	// file-text
 	'document': 'file-text',
@@ -220,6 +222,8 @@ export const aliases = {
 
 	// paper-plane
 	'send': 'paper-plane',
+	'send-horizontal': 'paper-plane',
+	'paper-airplane': 'paper-plane',
 
 	// paperclip
 	'attachment': 'paperclip',

--- a/src/components/content/icon/icon.test.ts
+++ b/src/components/content/icon/icon.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect, afterEach } from 'vitest';
 import { fixture, cleanup, waitForUpdate } from '../../../test-utils.js';
+import { aliases } from './icon-aliases.js';
+import { iconRegistry } from './icon-registry.js';
 import './icon.js';
 import type { NLDDIcon } from './icon.js';
 
@@ -54,5 +56,19 @@ describe('nldd-icon', () => {
 		expect(painted).not.toBeNull();
 		expect(getComputedStyle(painted as Element).fill).toBe('rgb(255, 0, 0)');
 		cleanup(wrapper);
+	});
+});
+
+describe('icon aliases – messaging/composer', () => {
+	// Each alias must resolve (aliases[name] -> target) to an icon that
+	// actually exists in the registry, mirroring icon.ts#_loadIcon.
+	it.each([
+		['emoji', 'face-smiling'],
+		['smile-plus', 'face-smiling-badge-plus'],
+		['send-horizontal', 'paper-plane'],
+		['paper-airplane', 'paper-plane'],
+	])('alias "%s" resolves to existing icon "%s"', (alias, target) => {
+		expect(aliases[alias]).toBe(target);
+		expect(iconRegistry.has(target)).toBe(true);
 	});
 });


### PR DESCRIPTION
Consumers die van een andere iconenset komen, gebruiken gangbare glyph-namen die in NLDD niet resolven. Daardoor houden ze een externe iconenset aan voor een handvol iconen die NLDD zelf al heeft.

Deze PR voegt aliassen toe zodat die gangbare namen naar de bestaande iconen wijzen:

| Alias | Bestaand NLDD-icoon |
|---|---|
| `emoji` | `face-smiling` (gewone smiley) |
| `smile-plus` | `face-smiling-badge-plus` (smiley met plus-badge) |
| `send-horizontal`, `paper-airplane` | `paper-plane` |

`emoji` wijst bewust naar de gewone smiley; `smile-plus` naar de variant met plus-badge (naast het bestaande `add-emoji`). Alleen aliassen — geen nieuwe SVG's. Aliassen resolven via `aliases[name] ?? name` in `icon.ts`, net als de bestaande `send` en `add-emoji`.

## Wijzigingen

- `icon-aliases.js` — vier aliassen toegevoegd, bij hun bestaande doel-icoon
- `icon.test.ts` — test per alias die verifieert dat hij resolvet naar een icoon dat in de registry bestaat

## Verificatie

- Tests: 10/10 groen
- ESLint: clean

## Buiten scope

Glyphs waarvoor NLDD nog geen (volledig) passend equivalent heeft, vallen bewust buiten deze PR en vragen om nieuwe canonieke SVG's: een losse `book`/`book-open` (alleen `books-vertical` bestaat), een **dashed** speech-bubble voor concept-/draft-status (de solide `message-rectangle-text` bestaat al) en een `loader`/`spinner`.
