### PR TITLE
feat(button): exporteer NLDDButtonVariant-type + waarschuw bij onbekende variant

### DIFF
--- a/src/components/actions/button/button.test.ts
+++ b/src/components/actions/button/button.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, afterEach, vi } from 'vitest';
 import { fixture, cleanup, waitForUpdate, deepActiveElement } from '../../../test-utils.js';
-import type { NLDDButton } from './button.js';
+import { NLDD_BUTTON_VARIANTS, type NLDDButton, type NLDDButtonVariant } from './button.js';
 import './button.js';
 
 describe('nldd-button', () => {
@@ -53,6 +53,41 @@ describe('nldd-button', () => {
 		await waitForUpdate(el);
 		const inner = el.shadowRoot!.querySelector('button');
 		expect(inner!.hasAttribute('aria-label')).toBe(false);
+	});
+});
+
+describe('nldd-button – variant type & unknown-variant warning', () => {
+	let el: NLDDButton;
+
+	afterEach(() => {
+		if (el) cleanup(el);
+	});
+
+	it('exports NLDD_BUTTON_VARIANTS as the single source of truth', () => {
+		expect(NLDD_BUTTON_VARIANTS).toContain('destructive');
+		expect(NLDD_BUTTON_VARIANTS).toContain('critical-tinted');
+		expect(NLDD_BUTTON_VARIANTS).toContain('neutral-tinted');
+		// `critical` is a <nldd-tag> color, NOT a button variant (issue #83).
+		expect(NLDD_BUTTON_VARIANTS).not.toContain('critical');
+		// Type is derived from the array — this only compiles if it lines up.
+		const v: NLDDButtonVariant = 'destructive';
+		expect(v).toBe('destructive');
+	});
+
+	it('warns when an unknown variant is set', async () => {
+		const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+		el = await fixture<NLDDButton>('<nldd-button text="Verwijderen" variant="critical"></nldd-button>');
+		await waitForUpdate(el);
+		expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('unknown variant "critical"'));
+		warnSpy.mockRestore();
+	});
+
+	it('does not warn for a valid variant', async () => {
+		const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+		el = await fixture<NLDDButton>('<nldd-button text="Verwijderen" variant="destructive"></nldd-button>');
+		await waitForUpdate(el);
+		expect(warnSpy).not.toHaveBeenCalled();
+		warnSpy.mockRestore();
 	});
 });
 

--- a/src/components/actions/button/button.ts
+++ b/src/components/actions/button/button.ts
@@ -2,7 +2,7 @@
  * Nederlandse Digitale Dienst Button Component (Lit + TypeScript)
  *
  * @element nldd-button
- * @attr {string} variant - Button variant: 'primary' | 'secondary' | 'destructive' | 'accent-filled' | 'accent-transparent' | 'neutral-tinted' | 'neutral-transparent' | 'critical-tinted' | 'critical-transparent'
+ * @attr {string} variant - Button variant: 'primary' | 'secondary' | 'destructive' | 'accent-filled' | 'accent-transparent' | 'neutral-tinted' | 'neutral-transparent' | 'critical-tinted' | 'critical-transparent'. Importable as the `NLDDButtonVariant` type / `NLDD_BUTTON_VARIANTS` runtime list.
  * @attr {string} size - Button size: 'xs' | 'sm' | 'md' (default: 'md')
  * @attr {boolean} disabled - Disabled state
  * @attr {string} type - Button type for form submission: 'button' | 'submit' | 'reset' (ignored when href is set)
@@ -32,16 +32,25 @@ import { buttonStyles } from './button.styles.js';
 import { template } from './button.template.js';
 import './../../content/icon/icon.js';
 
-type Variant =
-	| 'primary'
-	| 'secondary'
-	| 'destructive'
-	| 'accent-filled'
-	| 'accent-transparent'
-	| 'neutral-tinted'
-	| 'neutral-transparent'
-	| 'critical-tinted'
-	| 'critical-transparent';
+/**
+ * All valid `variant` values for `<nldd-button>`. Single source of truth:
+ * `NLDDButtonVariant` is derived from this array, and `updated()` uses it to
+ * emit a dev-only warning when an unknown variant is set (which otherwise
+ * renders an unstyled, near-invisible button — see issue #83).
+ */
+export const NLDD_BUTTON_VARIANTS = [
+	'primary',
+	'secondary',
+	'destructive',
+	'accent-filled',
+	'accent-transparent',
+	'neutral-tinted',
+	'neutral-transparent',
+	'critical-tinted',
+	'critical-transparent',
+] as const;
+
+export type NLDDButtonVariant = (typeof NLDD_BUTTON_VARIANTS)[number];
 type Size = 'xs' | 'sm' | 'md';
 type ButtonType = 'button' | 'submit' | 'reset';
 type PopupType = 'menu' | 'listbox' | 'dialog' | 'tree' | 'grid';
@@ -57,7 +66,7 @@ export class NLDDButton extends LitElement {
 	private _internals = this.attachInternals();
 
 	@property({ type: String, reflect: true })
-	variant: Variant = 'neutral-tinted';
+	variant: NLDDButtonVariant = 'neutral-tinted';
 
 	@property({ type: String, reflect: true })
 	size: Size = 'md';
@@ -146,6 +155,7 @@ export class NLDDButton extends LitElement {
 	rel: string | undefined = undefined;
 
 	private _warnedA11y = false;
+	private _warnedVariant = false;
 
 	override updated(changedProperties: Map<string, unknown>): void {
 		if (changedProperties.has('width')) {
@@ -170,6 +180,19 @@ export class NLDDButton extends LitElement {
 			console.warn('<nldd-button>: button has no text or accessible-label. This produces an inaccessible button (WCAG SC 4.1.2).');
 		} else if (!isEmpty) {
 			this._warnedA11y = false;
+		}
+
+		// An unknown variant matches no `:host([variant=...])` rule and falls
+		// through to no styling at all (the default style only applies via
+		// `:host(:not([variant]))`), producing a near-invisible button. The
+		// type system can't catch it because the attribute is a plain string
+		// from HTML/framework templates — so warn at runtime in dev.
+		const knownVariant = (NLDD_BUTTON_VARIANTS as readonly string[]).includes(this.variant);
+		if (import.meta.env?.DEV && !knownVariant && !this._warnedVariant) {
+			this._warnedVariant = true;
+			console.warn(`<nldd-button>: unknown variant "${this.variant}" — the button renders unstyled. Valid variants: ${NLDD_BUTTON_VARIANTS.join(', ')}.`);
+		} else if (knownVariant) {
+			this._warnedVariant = false;
 		}
 	}
 

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -11,7 +11,8 @@
 
 // # Action components
 
-export { NLDDButton } from './actions/button/button.js';
+export { NLDDButton, NLDD_BUTTON_VARIANTS } from './actions/button/button.js';
+export type { NLDDButtonVariant } from './actions/button/button.js';
 export { NLDDIconButton } from './actions/icon-button/icon-button.js';
 export { NLDDSplitButton } from './actions/split-button/split-button.js';
 export { NLDDButtonGroup } from './actions/button-group/button-group.js';


### PR DESCRIPTION
Een onbekende `variant`-waarde matcht geen enkele `:host([variant=...])`-regel en valt door naar geen enkele styling (de default-stijl geldt alleen via `:host(:not([variant]))`). Resultaat: een ongestylede, nauwelijks zichtbare knop — zonder foutmelding.

TypeScript vangt dit niet af, omdat het `variant`-attribuut een gewone string is uit HTML- of framework-templates. Het gebeurt makkelijk doordat verwante componenten andere waardenamen gebruiken voor hetzelfde concept: `<nldd-tag>` heeft de kleur `critical`, terwijl de rood/gevaar-variant van de knop `destructive` of `critical-tinted` is.

## Wijzigingen

- **`NLDD_BUTTON_VARIANTS`** — een `as const`-array als single source of truth. Het `NLDDButtonVariant`-type wordt eruit afgeleid (`typeof […][number]`), en `updated()` gebruikt dezelfde array voor de runtime-check. Eén lijst, kan niet uit sync raken.
- **Export** — `NLDD_BUTTON_VARIANTS` en `NLDDButtonVariant` worden geëxporteerd via de package-barrel en het `./button`-subpath, zodat consumers hun template-props kunnen typen.
- **Dev-waarschuwing** — `console.warn` in `updated()` wanneer de huidige variant niet in de lijst staat. Alleen in dev (`import.meta.env?.DEV`), eenmalig per component, in lijn met de bestaande a11y-waarschuwing. Geen runtime-impact in productie.

Geen runtime- of styling-wijziging voor geldige varianten.

## Verificatie

- Tests: 48/48 groen (3 nieuw: export-vorm, warn bij onbekende variant, geen warn bij geldige)
- ESLint + TypeScript: clean

## Buiten scope

De naaminconsistentie zelf (`<nldd-tag color="critical">` vs `<nldd-button variant="destructive">`) is een cross-component conventie-keuze en valt bewust buiten deze PR.
