### PR TITLE
feat!: container order API, breadcrumbs centering fix, CHANGELOG workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,51 @@ the type of conventional-commit determines the release. Conventional types
 `chore`, `docs`, `ci`, `style`, `test`, `build` are intentionally omitted
 here; consult the commit history if you need that level of detail.
 
+### Highlights
+
+- `nldd-container`: per-child ordering replaces the boolean reverse family. Each slotted child can declare `order` / `sm-order` / `md-order` / `lg-order` (any integer, including negative) and the container observes slot + attribute mutations to bridge those to `--_slot-{attr}` inline custom properties on the child; the container's shadow CSS reads them via `::slotted(*)` inside `@container` queries with a `sm/md/lg-order → order → 0` fallback cascade. No `ResizeObserver`, no enumerated value rules — and `layout="grid"` now keeps its 2D grid track when items reorder (the previous grid→flex fallback for `reverse` is gone).
+- `nldd-breadcrumbs`: `.breadcrumbs` switched from `display: block` to `display: flex` so the `inline-flex` `__level-up` link no longer sits on a baseline line-box, fixing the vertical alignment of the chevron + label at sm.
+- `nldd-container` stories: control + story ordering aligned with the canonical skill groups (visueel dominant → space → alignment); optional selects use the `'(geen)'` + `mapping` pattern; booleans default to `false` so the toggle is interactive immediately (no intermediate "Set boolean" step); the defaults column is populated across all controls.
+- CHANGELOG workflow: section conventions moved to `CONTRIBUTING.md`; the `## Unreleased` header is dropped — hand-written `### Highlights` / `### Breaking Changes` now sit directly above the current top version and nest naturally under the new version block that semantic-release prepends on release.
+
+### Breaking Changes
+
+- `nldd-container`: `reverse`, `sm-reverse`, `md-reverse`, `lg-reverse` boolean attributes are **removed**. Use per-child `order` / `sm-order` / `md-order` / `lg-order` on the slotted items instead.
+
+  Migration — full reverse of two children:
+
+  ```html
+  <!-- before -->
+  <nldd-container layout="row" reverse>
+    <a>First</a>
+    <b>Second</b>
+  </nldd-container>
+
+  <!-- after — either flip the DOM order, or set explicit per-child order -->
+  <nldd-container layout="row">
+    <a order="2">First</a>
+    <b order="1">Second</b>
+  </nldd-container>
+  ```
+
+  Migration — responsive flip (was `md-reverse lg-reverse` on a two-child container):
+
+  ```html
+  <!-- before -->
+  <nldd-container md-reverse lg-reverse>
+    <figure>…</figure>
+    <p>…</p>
+  </nldd-container>
+
+  <!-- after — the second child moves before the first at md+ -->
+  <nldd-container>
+    <figure>…</figure>
+    <p md-order="-1" lg-order="-1">…</p>
+  </nldd-container>
+  ```
+
+  `layout="grid"` + reorder no longer falls back to flex — the grid track stays aligned on every breakpoint. `layout="columns"` reorder is still a no-op (CSS multicol has no per-item ordering hook).
+
 ## <small>0.8.48 (2026-05-25)</small>
 
 * fix: padding new page-footer ([fbbdf2c](https://github.com/MinBZK/storybook/commit/fbbdf2c))
@@ -16,26 +61,6 @@ here; consult the commit history if you need that level of detail.
 ## <small>0.8.47 (2026-05-25)</small>
 
 * feat!: page-footer, breadcrumbs, container layout API, window scheme ([f96ebf1](https://github.com/MinBZK/storybook/commit/f96ebf1)), closes [#154273](https://github.com/MinBZK/storybook/issues/154273)
-
-## Section conventions
-
-- **Highlights** — short narrative summary, only when there is something
-  worth calling out.
-- **Breaking Changes** — incompatible API changes that need consumer action.
-  Each entry describes what changed and the migration step.
-- **Added** — new components, attributes, variants.
-- **Changed** — modifications to existing functionality (non-breaking).
-- **Fixed** — bug fixes.
-- **Deprecated** — APIs marked for removal in a future release.
-- **Removed** — APIs that have been removed.
-
-## Unreleased
-
-<!--
-  Alleen Highlights worden hier handmatig bijgehouden — de Added/Changed/Fixed
-  entries genereert semantic-release bij de merge automatisch uit de commits.
-  Verplaats deze Highlights na de release onder de nieuwe versie-sectie.
--->
 
 ### Highlights
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,24 @@
+# Contributing to NLDD Design System
+
+## CHANGELOG conventions
+
+`CHANGELOG.md` is bumped automatically by semantic-release on merge to main.
+The Added / Changed / Fixed bullet lists under each version block are
+generated from conventional-commit messages.
+
+For hand-curated content (Highlights, Breaking Changes migrations, etc.):
+write the `###` subsections directly above the current most-recent version
+block. When semantic-release runs, it prepends a fresh `## <small>x.y.z (…)
+</small>` block above your hand-written content, so the subsections nest
+naturally under the new version in the rendered output. No `## Unreleased`
+header is needed.
+
+Use these section labels:
+
+- **Highlights** — short narrative summary, only when there is something worth calling out.
+- **Breaking Changes** — incompatible API changes that need consumer action. Each entry describes what changed and the migration step.
+- **Added** — new components, attributes, variants.
+- **Changed** — modifications to existing functionality (non-breaking).
+- **Fixed** — bug fixes.
+- **Deprecated** — APIs marked for removal in a future release.
+- **Removed** — APIs that have been removed.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nldd/design-system",
-  "version": "0.8.44",
+  "version": "0.8.48",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nldd/design-system",
-      "version": "0.8.44",
+      "version": "0.8.48",
       "license": "EUPL-1.2",
       "dependencies": {
         "@floating-ui/dom": "^1.7.6",

--- a/src/components/layout/container/container.stories.ts
+++ b/src/components/layout/container/container.stories.ts
@@ -8,8 +8,10 @@ const SIZES = ['0', '2', '4', '6', '8', '10', '12', '16', '20', '24', '28', '32'
 
 const sizeControl = (description: string) => ({
 	control: 'select',
-	options: SIZES,
+	options: ['(geen)', ...SIZES],
+	mapping: { '(geen)': undefined },
 	description,
+	table: { defaultValue: { summary: '(geen)' } },
 });
 
 /**
@@ -51,22 +53,92 @@ export default {
 			type: 'stable',
 		},
 	},
+	args: {
+		layout: undefined,
+		columnCount: undefined,
+		smColumnCount: undefined,
+		mdColumnCount: undefined,
+		lgColumnCount: undefined,
+		gap: undefined,
+		smGap: undefined,
+		mdGap: undefined,
+		lgGap: undefined,
+		padding: undefined,
+		paddingInline: undefined,
+		paddingBlock: undefined,
+		paddingTop: undefined,
+		paddingRight: undefined,
+		paddingBottom: undefined,
+		paddingLeft: undefined,
+		smPadding: undefined,
+		smPaddingInline: undefined,
+		smPaddingBlock: undefined,
+		smPaddingTop: undefined,
+		smPaddingRight: undefined,
+		smPaddingBottom: undefined,
+		smPaddingLeft: undefined,
+		mdPadding: undefined,
+		mdPaddingInline: undefined,
+		mdPaddingBlock: undefined,
+		mdPaddingTop: undefined,
+		mdPaddingRight: undefined,
+		mdPaddingBottom: undefined,
+		mdPaddingLeft: undefined,
+		lgPadding: undefined,
+		lgPaddingInline: undefined,
+		lgPaddingBlock: undefined,
+		lgPaddingTop: undefined,
+		lgPaddingRight: undefined,
+		lgPaddingBottom: undefined,
+		lgPaddingLeft: undefined,
+		horizontalAlignment: undefined,
+		verticalAlignment: undefined,
+	},
 	argTypes: {
-		layout: { control: 'select', options: [undefined, 'stack', 'row', 'wrap', 'grid', 'columns'], description: 'Layout-modus' },
-		reverse: { control: 'boolean', description: 'Keer de volgorde van items om' },
-		smReverse: { name: 'sm-reverse', control: 'boolean', description: 'Reverse alleen op sm-viewport' },
-		mdReverse: { name: 'md-reverse', control: 'boolean', description: 'Reverse alleen op md-viewport' },
-		lgReverse: { name: 'lg-reverse', control: 'boolean', description: 'Reverse alleen op lg-viewport' },
-		columnCount: { name: 'column-count', control: 'select', options: [undefined, 1, 2, 3, 4, 5, 6, 7, 8], description: 'Aantal kolommen (grid/columns)' },
-		smColumnCount: { name: 'sm-column-count', control: 'select', options: [undefined, 1, 2, 3, 4, 5, 6, 7, 8], description: 'Kolom-aantal bij sm container-breedte' },
-		mdColumnCount: { name: 'md-column-count', control: 'select', options: [undefined, 1, 2, 3, 4, 5, 6, 7, 8], description: 'Kolom-aantal bij md container-breedte' },
-		lgColumnCount: { name: 'lg-column-count', control: 'select', options: [undefined, 1, 2, 3, 4, 5, 6, 7, 8], description: 'Kolom-aantal bij lg container-breedte' },
+		layout: {
+			control: 'select',
+			options: ['(geen)', 'stack', 'row', 'wrap', 'grid', 'columns'],
+			mapping: { '(geen)': undefined },
+			description: 'Layout-modus',
+			table: { defaultValue: { summary: 'stack' } },
+		},
+		columnCount: {
+			name: 'column-count',
+			control: 'select',
+			options: ['(geen)', 1, 2, 3, 4, 5, 6, 7, 8],
+			mapping: { '(geen)': undefined },
+			description: 'Aantal kolommen (grid/columns)',
+			table: { defaultValue: { summary: '(geen)' } },
+		},
+		smColumnCount: {
+			name: 'sm-column-count',
+			control: 'select',
+			options: ['(geen)', 1, 2, 3, 4, 5, 6, 7, 8],
+			mapping: { '(geen)': undefined },
+			description: 'Kolom-aantal bij sm container-breedte',
+			table: { defaultValue: { summary: '(geen)' } },
+		},
+		mdColumnCount: {
+			name: 'md-column-count',
+			control: 'select',
+			options: ['(geen)', 1, 2, 3, 4, 5, 6, 7, 8],
+			mapping: { '(geen)': undefined },
+			description: 'Kolom-aantal bij md container-breedte',
+			table: { defaultValue: { summary: '(geen)' } },
+		},
+		lgColumnCount: {
+			name: 'lg-column-count',
+			control: 'select',
+			options: ['(geen)', 1, 2, 3, 4, 5, 6, 7, 8],
+			mapping: { '(geen)': undefined },
+			description: 'Kolom-aantal bij lg container-breedte',
+			table: { defaultValue: { summary: '(geen)' } },
+		},
+
 		gap: sizeControl('Gap tussen kinderen'),
 		smGap: { name: 'sm-gap', ...sizeControl('Gap bij sm') },
 		mdGap: { name: 'md-gap', ...sizeControl('Gap bij md') },
 		lgGap: { name: 'lg-gap', ...sizeControl('Gap bij lg') },
-		horizontalAlignment: { name: 'horizontal-alignment', control: 'select', options: [undefined, 'left', 'center', 'right'], description: 'Horizontale uitlijning' },
-		verticalAlignment: { name: 'vertical-alignment', control: 'select', options: [undefined, 'top', 'center', 'bottom'], description: 'Verticale uitlijning' },
 
 		padding: sizeControl('Padding voor alle zijden'),
 		paddingInline: { name: 'padding-inline', ...sizeControl('Padding links en rechts') },
@@ -99,6 +171,23 @@ export default {
 		lgPaddingRight: { name: 'lg-padding-right', ...sizeControl('Padding right bij lg') },
 		lgPaddingBottom: { name: 'lg-padding-bottom', ...sizeControl('Padding bottom bij lg') },
 		lgPaddingLeft: { name: 'lg-padding-left', ...sizeControl('Padding left bij lg') },
+
+		horizontalAlignment: {
+			name: 'horizontal-alignment',
+			control: 'select',
+			options: ['(geen)', 'left', 'center', 'right'],
+			mapping: { '(geen)': undefined },
+			description: 'Horizontale uitlijning',
+			table: { defaultValue: { summary: '(geen)' } },
+		},
+		verticalAlignment: {
+			name: 'vertical-alignment',
+			control: 'select',
+			options: ['(geen)', 'top', 'center', 'bottom'],
+			mapping: { '(geen)': undefined },
+			description: 'Verticale uitlijning',
+			table: { defaultValue: { summary: '(geen)' } },
+		},
 	},
 };
 
@@ -109,10 +198,6 @@ export const Standaard = {
 	render: (args: Record<string, any>) => html`
 		<nldd-container
 			layout=${ifDefined(args.layout)}
-			?reverse=${args.reverse}
-			?sm-reverse=${args.smReverse}
-			?md-reverse=${args.mdReverse}
-			?lg-reverse=${args.lgReverse}
 			column-count=${ifDefined(args.columnCount)}
 			sm-column-count=${ifDefined(args.smColumnCount)}
 			md-column-count=${ifDefined(args.mdColumnCount)}
@@ -121,8 +206,6 @@ export const Standaard = {
 			sm-gap=${ifDefined(args.smGap)}
 			md-gap=${ifDefined(args.mdGap)}
 			lg-gap=${ifDefined(args.lgGap)}
-			horizontal-alignment=${ifDefined(args.horizontalAlignment)}
-			vertical-alignment=${ifDefined(args.verticalAlignment)}
 			padding=${ifDefined(args.padding)}
 			padding-inline=${ifDefined(args.paddingInline)}
 			padding-block=${ifDefined(args.paddingBlock)}
@@ -151,6 +234,8 @@ export const Standaard = {
 			lg-padding-right=${ifDefined(args.lgPaddingRight)}
 			lg-padding-bottom=${ifDefined(args.lgPaddingBottom)}
 			lg-padding-left=${ifDefined(args.lgPaddingLeft)}
+			horizontal-alignment=${ifDefined(args.horizontalAlignment)}
+			vertical-alignment=${ifDefined(args.verticalAlignment)}
 			style="outline: 1px dashed var(--primitives-color-neutral-150);"
 		>
 			<nldd-container padding="12" style="outline: 1px dashed var(--primitives-color-neutral-150);">
@@ -161,54 +246,6 @@ export const Standaard = {
 			</nldd-container>
 		</nldd-container>
 	`,
-};
-
-export const PaddingAlleZijden = {
-	render: () => html`
-		<nldd-container padding="24" style="outline: 1px dashed var(--primitives-color-neutral-150);">
-			<nldd-rich-text><p>Padding aan alle zijden.</p></nldd-rich-text>
-		</nldd-container>
-	`,
-	storyName: 'Padding — alle zijden',
-};
-
-export const PaddingInline = {
-	render: () => html`
-		<nldd-container padding-inline="32" style="outline: 1px dashed var(--primitives-color-neutral-150);">
-			<nldd-rich-text><p>Padding links en rechts.</p></nldd-rich-text>
-		</nldd-container>
-	`,
-	storyName: 'Padding — inline (links/rechts)',
-};
-
-export const PaddingIndividueel = {
-	render: () => html`
-		<nldd-container
-			padding-top="8"
-			padding-right="32"
-			padding-bottom="16"
-			padding-left="64"
-			style="outline: 1px dashed var(--primitives-color-neutral-150);"
-		>
-			<nldd-rich-text><p>Individuele padding: top=8 right=32 bottom=16 left=64.</p></nldd-rich-text>
-		</nldd-container>
-	`,
-	storyName: 'Padding — individuele zijden',
-};
-
-export const PaddingResponsief = {
-	render: () => html`
-		<nldd-container
-			padding="8"
-			sm-padding="16"
-			md-padding="24"
-			lg-padding="32"
-			style="outline: 1px dashed var(--primitives-color-neutral-150);"
-		>
-			<nldd-rich-text><p>Padding: 8 (default) → 16 (sm) → 24 (md) → 32 (lg).</p></nldd-rich-text>
-		</nldd-container>
-	`,
-	storyName: 'Padding — responsief',
 };
 
 export const LayoutStack = {
@@ -276,46 +313,53 @@ export const LayoutColumns = {
 	storyName: 'Layout — columns (multicol, min 280px)',
 };
 
-export const ReverseRow = {
+export const OrderRow = {
 	render: () => html`
-		<nldd-container layout="row" reverse gap="12" padding="16" style="outline: 1px dashed var(--primitives-color-neutral-150);">
-			<nldd-rich-text><p>1</p></nldd-rich-text>
-			<nldd-rich-text><p>2</p></nldd-rich-text>
-			<nldd-rich-text><p>3</p></nldd-rich-text>
-			<nldd-rich-text><p>4</p></nldd-rich-text>
+		<nldd-container layout="row" gap="12" padding="16" style="outline: 1px dashed var(--primitives-color-neutral-150);">
+			<nldd-rich-text order="4"><p>1 (order=4)</p></nldd-rich-text>
+			<nldd-rich-text order="3"><p>2 (order=3)</p></nldd-rich-text>
+			<nldd-rich-text order="2"><p>3 (order=2)</p></nldd-rich-text>
+			<nldd-rich-text order="1"><p>4 (order=1)</p></nldd-rich-text>
 		</nldd-container>
 	`,
-	storyName: 'Reverse — row (items 4→1)',
+	storyName: 'Order — row (omgekeerd via per-child order)',
 };
 
-export const ReverseWrap = {
+export const OrderGrid = {
 	render: () => html`
-		<nldd-container layout="wrap" reverse gap="12" padding="16" style="outline: 1px dashed var(--primitives-color-neutral-150); max-width: 320px;">
-			<nldd-tag>Tag 1</nldd-tag>
-			<nldd-tag>Tag 2</nldd-tag>
-			<nldd-tag>Tag 3</nldd-tag>
-			<nldd-tag>Tag 4</nldd-tag>
-			<nldd-tag>Tag 5</nldd-tag>
-			<nldd-tag>Tag 6</nldd-tag>
+		<nldd-container layout="grid" gap="12" padding="16" style="outline: 1px dashed var(--primitives-color-neutral-150);">
+			<nldd-rich-text order="3"><p>1 (order=3)</p></nldd-rich-text>
+			<nldd-rich-text order="1"><p>2 (order=1)</p></nldd-rich-text>
+			<nldd-rich-text order="2"><p>3 (order=2)</p></nldd-rich-text>
+			<nldd-rich-text order="4"><p>4 (order=4)</p></nldd-rich-text>
+			<nldd-rich-text order="6"><p>5 (order=6)</p></nldd-rich-text>
+			<nldd-rich-text order="5"><p>6 (order=5)</p></nldd-rich-text>
 		</nldd-container>
 	`,
-	storyName: 'Reverse — wrap (laatste tag eerst, wraps van rechtsboven)',
+	storyName: 'Order — grid (per-cell, grid-track blijft intact)',
 };
 
-export const ReverseGrid = {
+export const OrderResponsief = {
 	render: () => html`
-		<nldd-container layout="grid" reverse gap="12" padding="16" style="outline: 1px dashed var(--primitives-color-neutral-150);">
-			<nldd-rich-text><p>1</p></nldd-rich-text>
-			<nldd-rich-text><p>2</p></nldd-rich-text>
-			<nldd-rich-text><p>3</p></nldd-rich-text>
-			<nldd-rich-text><p>4</p></nldd-rich-text>
-			<nldd-rich-text><p>5</p></nldd-rich-text>
-			<nldd-rich-text><p>6</p></nldd-rich-text>
-			<nldd-rich-text><p>7</p></nldd-rich-text>
-			<nldd-rich-text><p>8</p></nldd-rich-text>
+		<nldd-container layout="row" gap="12" padding="16" style="outline: 1px dashed var(--primitives-color-neutral-150);">
+			<nldd-rich-text order="1" sm-order="3"><p>A (lg=1, sm=3)</p></nldd-rich-text>
+			<nldd-rich-text order="2" sm-order="1"><p>B (lg=2, sm=1)</p></nldd-rich-text>
+			<nldd-rich-text order="3" sm-order="2"><p>C (lg=3, sm=2)</p></nldd-rich-text>
 		</nldd-container>
 	`,
-	storyName: 'Reverse — grid (valt terug op flex, 2D omkering)',
+	storyName: 'Order — responsief (sm-order valt terug op order)',
+};
+
+export const OrderNegatief = {
+	render: () => html`
+		<nldd-container layout="row" gap="12" padding="16" style="outline: 1px dashed var(--primitives-color-neutral-150);">
+			<nldd-rich-text><p>Item</p></nldd-rich-text>
+			<nldd-rich-text><p>Item</p></nldd-rich-text>
+			<nldd-rich-text order="-1"><p>Eerste (order=-1)</p></nldd-rich-text>
+			<nldd-rich-text><p>Item</p></nldd-rich-text>
+		</nldd-container>
+	`,
+	storyName: 'Order — negatieve waarde duwt item naar voren',
 };
 
 export const ColumnCountFooter = {
@@ -348,16 +392,61 @@ export const ColumnCountColumns = {
 	storyName: 'Column-count — multicol 3 kolommen',
 };
 
-export const ReverseScopedSm = {
+export const PaddingAlleZijden = {
 	render: () => html`
-		<nldd-container layout="row" sm-reverse gap="12" padding="16" style="outline: 1px dashed var(--primitives-color-neutral-150);">
-			<nldd-rich-text><p>1</p></nldd-rich-text>
-			<nldd-rich-text><p>2</p></nldd-rich-text>
-			<nldd-rich-text><p>3</p></nldd-rich-text>
-			<nldd-rich-text><p>4</p></nldd-rich-text>
+		<nldd-container padding="24" style="outline: 1px dashed var(--primitives-color-neutral-150);">
+			<nldd-rich-text><p>Padding aan alle zijden.</p></nldd-rich-text>
 		</nldd-container>
 	`,
-	storyName: 'Reverse — alleen sm (versmal viewport om effect te zien)',
+	storyName: 'Padding — alle zijden',
+};
+
+export const PaddingInline = {
+	render: () => html`
+		<nldd-container padding-inline="32" style="outline: 1px dashed var(--primitives-color-neutral-150);">
+			<nldd-rich-text><p>Padding links en rechts.</p></nldd-rich-text>
+		</nldd-container>
+	`,
+	storyName: 'Padding — inline (links/rechts)',
+};
+
+export const PaddingIndividueel = {
+	render: () => html`
+		<nldd-container
+			padding-top="8"
+			padding-right="32"
+			padding-bottom="16"
+			padding-left="64"
+			style="outline: 1px dashed var(--primitives-color-neutral-150);"
+		>
+			<nldd-rich-text><p>Individuele padding: top=8 right=32 bottom=16 left=64.</p></nldd-rich-text>
+		</nldd-container>
+	`,
+	storyName: 'Padding — individuele zijden',
+};
+
+export const PaddingResponsief = {
+	render: () => html`
+		<nldd-container
+			padding="8"
+			sm-padding="16"
+			md-padding="24"
+			lg-padding="32"
+			style="outline: 1px dashed var(--primitives-color-neutral-150);"
+		>
+			<nldd-rich-text><p>Padding: 8 (default) → 16 (sm) → 24 (md) → 32 (lg).</p></nldd-rich-text>
+		</nldd-container>
+	`,
+	storyName: 'Padding — responsief',
+};
+
+export const GeenPadding = {
+	render: () => html`
+		<nldd-container padding="0" style="outline: 1px dashed var(--primitives-color-neutral-150);">
+			<nldd-rich-text><p>Geen padding.</p></nldd-rich-text>
+		</nldd-container>
+	`,
+	storyName: 'Geen padding',
 };
 
 export const Alignment = {
@@ -375,13 +464,4 @@ export const Alignment = {
 		</nldd-container>
 	`,
 	storyName: 'Alignment — center op beide assen',
-};
-
-export const GeenPadding = {
-	render: () => html`
-		<nldd-container padding="0" style="outline: 1px dashed var(--primitives-color-neutral-150);">
-			<nldd-rich-text><p>Geen padding.</p></nldd-rich-text>
-		</nldd-container>
-	`,
-	storyName: 'Geen padding',
 };

--- a/src/components/layout/container/container.styles.ts
+++ b/src/components/layout/container/container.styles.ts
@@ -36,6 +36,10 @@ export const containerStyles = css`
 		--_lg-padding-right: var(--_padding-right);
 		--_lg-padding-bottom: var(--_padding-bottom);
 		--_lg-padding-left: var(--_padding-left);
+		--_slot-order: 0;
+		--_slot-sm-order: var(--_slot-order);
+		--_slot-md-order: var(--_slot-order);
+		--_slot-lg-order: var(--_slot-order);
 
 		container-type: inline-size;
 		display: block;
@@ -207,150 +211,25 @@ export const containerStyles = css`
 	}
 
 
-	/* # Reverse — base (applies at all breakpoints) */
+	/* # Slot order — per-child via order / sm-order / md-order / lg-order
+	   attributes on slotted children. Container JS bridges those to
+	   --_slot-{attr} inline custom props on the child; the queries below
+	   pick the right value per breakpoint with var() cascading
+	   sm/md/lg-order → order → 0. No-op for layout="columns" (multicol). */
 
-	:host([reverse]:not([layout])) .container,
-	:host([reverse][layout="stack"]) .container {
-		flex-direction: column-reverse;
+	::slotted(*) {
+		order: var(--_slot-order, 0);
 	}
 
-	:host([reverse][layout="row"]) .container {
-		flex-direction: row-reverse;
+	@container (max-width: ${smMax}) {
+		::slotted(*) { order: var(--_slot-sm-order, var(--_slot-order, 0)); }
 	}
 
-	:host([reverse][layout="wrap"]) .container {
-		flex-direction: row-reverse;
-		flex-wrap: wrap-reverse;
+	@container (min-width: ${mdMin}) and (max-width: ${mdMax}) {
+		::slotted(*) { order: var(--_slot-md-order, var(--_slot-order, 0)); }
 	}
 
-	/* Grid + reverse: fall back to flex so the 2D order truly reverses.
-	   Trade-off: last row no longer aligns to grid track. */
-	:host([reverse][layout="grid"]) .container {
-		display: flex;
-		flex-direction: row-reverse;
-		flex-wrap: wrap-reverse;
-	}
-	:host([reverse][layout="grid"]) ::slotted(*) {
-		flex-grow: 1;
-		flex-shrink: 1;
-		flex-basis: var(--_min-column-width);
-		min-width: 0;
-	}
-	:host([reverse][layout="grid"][column-count]) ::slotted(*) {
-		flex-basis: calc((100% - (var(--_column-count) - 1) * var(--_gap)) / var(--_column-count));
-	}
-
-	/* layout="columns" + reverse: intentional no-op (multicol has no
-	   item-order hook). */
-
-
-	/* # Reverse — sm scope */
-
-	@media (max-width: ${smMax}) {
-		:host([sm-reverse]:not([layout])) .container,
-		:host([sm-reverse][layout="stack"]) .container { flex-direction: column-reverse; }
-		:host([sm-reverse][layout="row"]) .container { flex-direction: row-reverse; }
-		:host([sm-reverse][layout="wrap"]) .container { flex-direction: row-reverse; flex-wrap: wrap-reverse; }
-		:host([sm-reverse][layout="grid"]) .container { display: flex; flex-direction: row-reverse; flex-wrap: wrap-reverse; }
-		:host([sm-reverse][layout="grid"]) ::slotted(*) {
-			flex-grow: 1;
-			flex-shrink: 1;
-			flex-basis: var(--_min-column-width);
-			min-width: 0;
-		}
-		:host([sm-reverse][layout="grid"][column-count]) ::slotted(*) {
-			flex-basis: calc((100% - (var(--_column-count) - 1) * var(--_gap)) / var(--_column-count));
-		}
-	}
-
-	@container layout-container (max-width: ${smMax}) {
-		:host([sm-reverse]:not([layout])) .container,
-		:host([sm-reverse][layout="stack"]) .container { flex-direction: column-reverse; }
-		:host([sm-reverse][layout="row"]) .container { flex-direction: row-reverse; }
-		:host([sm-reverse][layout="wrap"]) .container { flex-direction: row-reverse; flex-wrap: wrap-reverse; }
-		:host([sm-reverse][layout="grid"]) .container { display: flex; flex-direction: row-reverse; flex-wrap: wrap-reverse; }
-		:host([sm-reverse][layout="grid"]) ::slotted(*) {
-			flex-grow: 1;
-			flex-shrink: 1;
-			flex-basis: var(--_min-column-width);
-			min-width: 0;
-		}
-		:host([sm-reverse][layout="grid"][column-count]) ::slotted(*) {
-			flex-basis: calc((100% - (var(--_column-count) - 1) * var(--_gap)) / var(--_column-count));
-		}
-	}
-
-
-	/* # Reverse — md scope */
-
-	@media (min-width: ${mdMin}) and (max-width: ${mdMax}) {
-		:host([md-reverse]:not([layout])) .container,
-		:host([md-reverse][layout="stack"]) .container { flex-direction: column-reverse; }
-		:host([md-reverse][layout="row"]) .container { flex-direction: row-reverse; }
-		:host([md-reverse][layout="wrap"]) .container { flex-direction: row-reverse; flex-wrap: wrap-reverse; }
-		:host([md-reverse][layout="grid"]) .container { display: flex; flex-direction: row-reverse; flex-wrap: wrap-reverse; }
-		:host([md-reverse][layout="grid"]) ::slotted(*) {
-			flex-grow: 1;
-			flex-shrink: 1;
-			flex-basis: var(--_min-column-width);
-			min-width: 0;
-		}
-		:host([md-reverse][layout="grid"][column-count]) ::slotted(*) {
-			flex-basis: calc((100% - (var(--_column-count) - 1) * var(--_gap)) / var(--_column-count));
-		}
-	}
-
-	@container layout-container (min-width: ${mdMin}) and (max-width: ${mdMax}) {
-		:host([md-reverse]:not([layout])) .container,
-		:host([md-reverse][layout="stack"]) .container { flex-direction: column-reverse; }
-		:host([md-reverse][layout="row"]) .container { flex-direction: row-reverse; }
-		:host([md-reverse][layout="wrap"]) .container { flex-direction: row-reverse; flex-wrap: wrap-reverse; }
-		:host([md-reverse][layout="grid"]) .container { display: flex; flex-direction: row-reverse; flex-wrap: wrap-reverse; }
-		:host([md-reverse][layout="grid"]) ::slotted(*) {
-			flex-grow: 1;
-			flex-shrink: 1;
-			flex-basis: var(--_min-column-width);
-			min-width: 0;
-		}
-		:host([md-reverse][layout="grid"][column-count]) ::slotted(*) {
-			flex-basis: calc((100% - (var(--_column-count) - 1) * var(--_gap)) / var(--_column-count));
-		}
-	}
-
-
-	/* # Reverse — lg scope */
-
-	@media (min-width: ${lgMin}) {
-		:host([lg-reverse]:not([layout])) .container,
-		:host([lg-reverse][layout="stack"]) .container { flex-direction: column-reverse; }
-		:host([lg-reverse][layout="row"]) .container { flex-direction: row-reverse; }
-		:host([lg-reverse][layout="wrap"]) .container { flex-direction: row-reverse; flex-wrap: wrap-reverse; }
-		:host([lg-reverse][layout="grid"]) .container { display: flex; flex-direction: row-reverse; flex-wrap: wrap-reverse; }
-		:host([lg-reverse][layout="grid"]) ::slotted(*) {
-			flex-grow: 1;
-			flex-shrink: 1;
-			flex-basis: var(--_min-column-width);
-			min-width: 0;
-		}
-		:host([lg-reverse][layout="grid"][column-count]) ::slotted(*) {
-			flex-basis: calc((100% - (var(--_column-count) - 1) * var(--_gap)) / var(--_column-count));
-		}
-	}
-
-	@container layout-container (min-width: ${lgMin}) {
-		:host([lg-reverse]:not([layout])) .container,
-		:host([lg-reverse][layout="stack"]) .container { flex-direction: column-reverse; }
-		:host([lg-reverse][layout="row"]) .container { flex-direction: row-reverse; }
-		:host([lg-reverse][layout="wrap"]) .container { flex-direction: row-reverse; flex-wrap: wrap-reverse; }
-		:host([lg-reverse][layout="grid"]) .container { display: flex; flex-direction: row-reverse; flex-wrap: wrap-reverse; }
-		:host([lg-reverse][layout="grid"]) ::slotted(*) {
-			flex-grow: 1;
-			flex-shrink: 1;
-			flex-basis: var(--_min-column-width);
-			min-width: 0;
-		}
-		:host([lg-reverse][layout="grid"][column-count]) ::slotted(*) {
-			flex-basis: calc((100% - (var(--_column-count) - 1) * var(--_gap)) / var(--_column-count));
-		}
+	@container (min-width: ${lgMin}) {
+		::slotted(*) { order: var(--_slot-lg-order, var(--_slot-order, 0)); }
 	}
 `;

--- a/src/components/layout/container/container.template.ts
+++ b/src/components/layout/container/container.template.ts
@@ -1,10 +1,10 @@
 import { html, TemplateResult } from 'lit';
 import type { NLDDContainer } from './container.js';
 
-export function containerTemplate(_component: NLDDContainer): TemplateResult {
+export function containerTemplate(component: NLDDContainer): TemplateResult {
 	// Inner .container holds the layout (display, grid, flex, columns). The
 	// :host stays the padding wrapper + the query container (container-type:
 	// inline-size). CSS spec forbids an element from matching its own
 	// container queries, so the layout rules live on a descendant of :host.
-	return html`<div class="container"><slot></slot></div>`;
+	return html`<div class="container"><slot @slotchange=${component._onSlotChange}></slot></div>`;
 }

--- a/src/components/layout/container/container.test.ts
+++ b/src/components/layout/container/container.test.ts
@@ -142,9 +142,6 @@ describe('nldd-container', () => {
 		el = await fixture('<nldd-container layout="grid" vertical-alignment="center"></nldd-container>');
 		await waitForUpdate(el);
 		expect(el.style.getPropertyValue('--_align-items')).toBe('center');
-		// For grid we set justify-content too (so grid+reverse → flex still works),
-		// but vertical-alignment must NOT leak into --_justify-content like it does
-		// for stack layouts.
 		expect(el.style.getPropertyValue('--_justify-content')).toBe('');
 	});
 
@@ -155,51 +152,37 @@ describe('nldd-container', () => {
 		expect(el.style.getPropertyValue('--_justify-content')).toBe('center');
 	});
 
-	it('reverse on the default (stack) layout sets flex-direction: column-reverse on the inner', async () => {
-		el = await fixture('<nldd-container reverse></nldd-container>');
+	it('bridges order attr on a slotted child to --_slot-order inline custom prop', async () => {
+		el = await fixture('<nldd-container layout="row"><div order="3"></div></nldd-container>');
 		await waitForUpdate(el);
-		const inner = el.shadowRoot!.querySelector('.container') as HTMLElement;
-		expect(getComputedStyle(inner).flexDirection).toBe('column-reverse');
+		const child = el.querySelector('div') as HTMLElement;
+		expect(child.style.getPropertyValue('--_slot-order')).toBe('3');
 	});
 
-	it('reverse on layout=row sets flex-direction: row-reverse on the inner', async () => {
-		el = await fixture('<nldd-container layout="row" reverse></nldd-container>');
+	it('bridges sm-order / md-order / lg-order independently', async () => {
+		el = await fixture('<nldd-container layout="row"><div order="1" sm-order="5" md-order="2" lg-order="9"></div></nldd-container>');
 		await waitForUpdate(el);
-		const inner = el.shadowRoot!.querySelector('.container') as HTMLElement;
-		expect(getComputedStyle(inner).flexDirection).toBe('row-reverse');
+		const child = el.querySelector('div') as HTMLElement;
+		expect(child.style.getPropertyValue('--_slot-order')).toBe('1');
+		expect(child.style.getPropertyValue('--_slot-sm-order')).toBe('5');
+		expect(child.style.getPropertyValue('--_slot-md-order')).toBe('2');
+		expect(child.style.getPropertyValue('--_slot-lg-order')).toBe('9');
 	});
 
-	it('reverse on layout=wrap sets row-reverse + wrap-reverse on the inner', async () => {
-		el = await fixture('<nldd-container layout="wrap" reverse></nldd-container>');
+	it('accepts negative order values', async () => {
+		el = await fixture('<nldd-container layout="row"><div order="-1"></div></nldd-container>');
 		await waitForUpdate(el);
-		const inner = el.shadowRoot!.querySelector('.container') as HTMLElement;
-		expect(getComputedStyle(inner).flexDirection).toBe('row-reverse');
-		expect(getComputedStyle(inner).flexWrap).toBe('wrap-reverse');
+		const child = el.querySelector('div') as HTMLElement;
+		expect(child.style.getPropertyValue('--_slot-order')).toBe('-1');
 	});
 
-	it('reverse on layout=grid switches the inner to flex', async () => {
-		el = await fixture('<nldd-container layout="grid" reverse></nldd-container>');
+	it('removes the inline custom prop when the order attribute is cleared', async () => {
+		el = await fixture('<nldd-container layout="row"><div order="3"></div></nldd-container>');
 		await waitForUpdate(el);
-		const inner = el.shadowRoot!.querySelector('.container') as HTMLElement;
-		// Grid + reverse falls back to flex to get true 2D reversal.
-		expect(getComputedStyle(inner).display).toBe('flex');
-		expect(getComputedStyle(inner).flexDirection).toBe('row-reverse');
-		expect(getComputedStyle(inner).flexWrap).toBe('wrap-reverse');
-	});
-
-	it('reverse on layout=columns is a no-op (inner stays block)', async () => {
-		el = await fixture('<nldd-container layout="columns" reverse></nldd-container>');
-		await waitForUpdate(el);
-		const inner = el.shadowRoot!.querySelector('.container') as HTMLElement;
-		expect(getComputedStyle(inner).display).toBe('block');
-	});
-
-	it('reflects sm-reverse / md-reverse / lg-reverse as boolean attributes', async () => {
-		el = await fixture('<nldd-container sm-reverse md-reverse lg-reverse></nldd-container>');
-		await waitForUpdate(el);
-		expect(el.hasAttribute('sm-reverse')).toBe(true);
-		expect(el.hasAttribute('md-reverse')).toBe(true);
-		expect(el.hasAttribute('lg-reverse')).toBe(true);
+		const child = el.querySelector('div') as HTMLElement;
+		child.removeAttribute('order');
+		await new Promise(r => requestAnimationFrame(() => r(null)));
+		expect(child.style.getPropertyValue('--_slot-order')).toBe('');
 	});
 
 	it('accepts 0 as padding value', async () => {

--- a/src/components/layout/container/container.ts
+++ b/src/components/layout/container/container.ts
@@ -26,20 +26,17 @@
  *  - `grid`: horizontal = justify-items, vertical = align-items (per cell)
  *  - `columns`: alignment props have no effect (CSS multicol doesn't expose alignment)
  *
- * The `reverse` boolean inverts item order within the chosen layout:
- *  - `stack` → `flex-direction: column-reverse`
- *  - `row` → `flex-direction: row-reverse`
- *  - `wrap` → `flex-direction: row-reverse` + `flex-wrap: wrap-reverse`
- *  - `grid` → falls back to flex (row-reverse + wrap-reverse + per-item
- *    `flex-grow: 1; flex-shrink: 1; flex-basis: var(--_min-column-width)`
- *    with `min-width: 0`) so items still grow to share space equally and
- *    the 2D order truly reverses. The cost is that the last row no longer
- *    aligns to the grid track — it stretches to fill the remaining width.
- *  - `columns` → no-op (multicol has no item-order hook)
- *
- * `sm-reverse` / `md-reverse` / `lg-reverse` enable reverse only at that
- * breakpoint. Combine with the base `reverse` (always on) or use the
- * scoped ones independently.
+ * Item order is set per-child via attributes on the slotted children
+ * themselves: `<child order="3">` for a fixed position, or `<child sm-order="N">`
+ * / `<child md-order="N">` / `<child lg-order="N">` to override per breakpoint
+ * (resolved against THIS container's width via @container queries, same scope
+ * as the responsive padding/gap). The container observes slot changes and
+ * child attribute mutations and bridges these to `--_slot-order` /
+ * `--_slot-sm-order` / etc. custom properties on each child's inline style,
+ * which the container's CSS then reads via `::slotted(*)` inside @container
+ * queries. Cascade: `sm-order` falls back to `order` falls back to `0` at sm
+ * (and analogously for md/lg). No-op for `layout="columns"` (CSS multicol has
+ * no per-item ordering hook).
  *
  * The `column-count` attribute (1-8) forces an exact column count for
  * `layout="grid"` (overrides auto-fit) and `layout="columns"` (overrides
@@ -52,10 +49,6 @@
  * @element nldd-container
  *
  * @attr {string}  layout                 - 'stack' | 'row' | 'wrap' | 'grid' | 'columns' (default: 'stack')
- * @attr {boolean} reverse                - Reverse the visual order of items
- * @attr {boolean} sm-reverse             - Reverse only at the sm breakpoint
- * @attr {boolean} md-reverse             - Reverse only at the md breakpoint
- * @attr {boolean} lg-reverse             - Reverse only at the lg breakpoint
  * @attr {number}  column-count           - Force N columns (1-8) for layout=grid/columns
  * @attr {number}  sm-column-count        - Column count when this container is sm-wide
  * @attr {number}  md-column-count        - Column count when this container is md-wide
@@ -107,6 +100,8 @@ const VERTICAL_TO_FLEX: Record<VerticalAlignment, string> = {
 	bottom: 'flex-end',
 };
 
+const ORDER_ATTRS = ['order', 'sm-order', 'md-order', 'lg-order'] as const;
+
 function sizeToValue(size: PaddingSize | undefined): string | null {
 	if (size === undefined) return null;
 	if (size === '0') return '0';
@@ -124,25 +119,6 @@ export class NLDDContainer extends LitElement {
 	// specifically).
 	@property({ type: String, reflect: true })
 	layout?: Layout;
-
-	// Reverse the visual order of items within the chosen layout. For
-	// stack/row/wrap this is native flex-direction reverse (+ wrap-reverse
-	// for the 2D wrap case). For grid the host falls back to flex with
-	// wrap-reverse so 2D reversal works; the trade-off is that the last
-	// row no longer aligns to the grid track. For columns reverse is a
-	// no-op — multicol items flow top→bottom inside each column with no
-	// CSS hook to invert that.
-	@property({ type: Boolean, reflect: true })
-	reverse = false;
-
-	@property({ type: Boolean, reflect: true, attribute: 'sm-reverse' })
-	smReverse = false;
-
-	@property({ type: Boolean, reflect: true, attribute: 'md-reverse' })
-	mdReverse = false;
-
-	@property({ type: Boolean, reflect: true, attribute: 'lg-reverse' })
-	lgReverse = false;
 
 	// Explicit column count for layout="grid" (overrides auto-fit) and for
 	// layout="columns" (overrides the natural width-driven count). 1-8.
@@ -275,12 +251,9 @@ export class NLDDContainer extends LitElement {
 
 		// Alignment maps to a different CSS property depending on the
 		// layout's axes:
-		//  - Row/wrap (and grid+reverse, which falls back to flex):
-		//    horizontal = justify-content (main), vertical = align-items (cross)
-		//  - Stack (flex column):
-		//    horizontal = align-items (cross), vertical = justify-content (main)
-		//  - Grid (non-reverse): per-cell —
-		//    horizontal = justify-items, vertical = align-items
+		//  - Row/wrap: horizontal = justify-content (main), vertical = align-items (cross)
+		//  - Stack (flex column): horizontal = align-items (cross), vertical = justify-content (main)
+		//  - Grid: per-cell — horizontal = justify-items, vertical = align-items
 		// We set --_justify-content/--_justify-items/--_align-items
 		// independently; the .container picks up whichever applies to its
 		// current display. Columns layout has no alignment hooks.
@@ -330,6 +303,44 @@ export class NLDDContainer extends LitElement {
 		const bottom = get('PaddingBottom') ?? block ?? all;
 		const left = get('PaddingLeft') ?? inline ?? all;
 		return [top, right, bottom, left];
+	}
+
+	// Bridge: read order/sm-order/md-order/lg-order attributes on each slotted
+	// child and write them as --_slot-{attr} inline custom props on that child.
+	// The container's @container queries pick the right one per breakpoint via
+	// var() fallback. Inline style cannot itself host @container queries, so
+	// this bridge exists to expose declarative attrs while letting CSS do the
+	// breakpoint switching natively (no ResizeObserver).
+	private _childObserver?: MutationObserver;
+
+	override disconnectedCallback(): void {
+		super.disconnectedCallback();
+		this._childObserver?.disconnect();
+		this._childObserver = undefined;
+	}
+
+	_onSlotChange = (e: Event): void => {
+		const slot = e.target as HTMLSlotElement;
+		this._childObserver?.disconnect();
+		this._childObserver = new MutationObserver(muts => {
+			for (const m of muts) {
+				if (m.target instanceof HTMLElement) this._applyOrderProps(m.target);
+			}
+		});
+		for (const el of slot.assignedElements()) {
+			if (!(el instanceof HTMLElement)) continue;
+			this._applyOrderProps(el);
+			this._childObserver.observe(el, { attributes: true, attributeFilter: [...ORDER_ATTRS] });
+		}
+	};
+
+	private _applyOrderProps(el: HTMLElement): void {
+		for (const attr of ORDER_ATTRS) {
+			const v = el.getAttribute(attr);
+			const prop = `--_slot-${attr}`;
+			if (v !== null) el.style.setProperty(prop, v);
+			else el.style.removeProperty(prop);
+		}
 	}
 
 	override render() {

--- a/src/components/navigation/breadcrumbs/breadcrumbs.styles.ts
+++ b/src/components/navigation/breadcrumbs/breadcrumbs.styles.ts
@@ -14,7 +14,7 @@ export const breadcrumbsStyles = css`
 	}
 
 	.breadcrumbs {
-		display: block;
+		display: flex;
 	}
 
 	.breadcrumbs__items {


### PR DESCRIPTION
## Summary
- **`nldd-container`** — per-child `order` / `sm-order` / `md-order` / `lg-order` attributes replace the boolean `reverse` family. JS bridges slotted child attrs to `--_slot-{attr}` inline custom props; container's shadow CSS reads them via `::slotted(*)` inside `@container` queries with a `sm/md/lg-order → order → 0` fallback cascade. No `ResizeObserver`, no enumerated value rules. `layout="grid"` now keeps its 2D grid track when items reorder (no more grid→flex fallback).
- **`nldd-breadcrumbs`** — `.breadcrumbs` switched from `display: block` to `display: flex` so the `inline-flex` `__level-up` no longer sits on a baseline line-box: the chevron + label optically center at sm.
- **`nldd-container` stories polish** — control + story ordering aligned with the canonical skill groups (visueel dominant → space → alignment); optional selects use the `'(geen)'` + `mapping` pattern; booleans default to `false` so the toggle is interactive immediately; the defaults column is populated across all controls.
- **CHANGELOG workflow** — section conventions moved to a new `CONTRIBUTING.md`; the `## Unreleased` header is dropped. Hand-written `### Highlights` / `### Breaking Changes` now sit directly above the current top version and nest naturally under the new version block that semantic-release prepends on release.

Full Highlights + migration snippets at the top of `CHANGELOG.md`.

## Breaking changes
Container `reverse`, `sm-reverse`, `md-reverse`, `lg-reverse` boolean attributes removed — use per-child `order` / `sm-order` / `md-order` / `lg-order` on slotted items. Migration snippets in `CHANGELOG.md`.

## Test plan
- [ ] Storybook → Components/Layout/Container → Order stories (row, grid, responsief, negatief) render with the expected ordering at the matching breakpoint
- [ ] Storybook → Components/Layout/Container → Standaard controls panel: layout shows `stack` as default, gap/padding show `(geen)`, no booleans (none remain) — defaults column populated
- [ ] Storybook → Components/Navigation/Breadcrumbs at sm viewport: chevron-left icon optically centers with the parent label text
- [ ] Local: tarball install in regelrecht docs → landing example section, case 2 stacks on sm + md, flips to text-left / figure-right on lg