### PR TITLE
feat(plugin): marktplaats voor de nldd-plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
+  "name": "nldd-plugins",
+  "metadata": {
+    "description": "Plugin voor het NLDD Design System (Nederlandse Digitale Dienst, Rijksoverheid)"
+  },
+  "owner": {
+    "name": "MinBZK"
+  },
+  "plugins": [
+    {
+      "name": "nldd",
+      "description": "Bouw applicaties met het NLDD Design System (@nldd/design-system): de visie erachter en hoe je de web components goed gebruikt. Voor consumenten van het pakket, niet voor wie het systeem zelf onderhoudt.",
+      "version": "0.1.0",
+      "author": {
+        "name": "MinBZK"
+      },
+      "source": "./",
+      "category": "productivity",
+      "tags": [
+        "overheid",
+        "design-system",
+        "web-components",
+        "frontend",
+        "toegankelijkheid",
+        "rijksoverheid"
+      ]
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -32,6 +32,21 @@ import { NLDDButton, NLDDCheckbox, NLDDSwitch } from '@nldd/design-system';
 
 Bekijk de live component documentatie: **https://minbzk.github.io/storybook/**
 
+## Claude Code plugin
+
+Deze repository is ook een Claude Code marketplace. De `nldd`-plugin geeft
+Claude de kennis om applicaties te bouwen bovenop `@nldd/design-system`: de
+juiste tags, attributen, CSS-tokens en patronen.
+
+Toevoegen en installeren:
+
+```
+/plugin marketplace add MinBZK/storybook
+/plugin install nldd@nldd-plugins
+```
+
+Bijwerken naar een nieuwere versie doe je met `/plugin marketplace update nldd-plugins`.
+
 ## Development setup
 
 ```bash


### PR DESCRIPTION
## Wat

Voegt een Claude Code **marketplace** toe aan deze repo, zodat de bestaande `nldd`-plugin installeerbaar wordt via `/plugin`.

- `.claude-plugin/marketplace.json` — marketplace `nldd-plugins` met één plugin-entry (`nldd`). De plugin ligt al in de repo-root (`.claude-plugin/plugin.json` + `skills/nldd/`), dus `"source": "./"`.
- README — sectie met installatie-instructies.

Format volgt het voorbeeld van [`developer-overheid-nl/skills-marketplace`](https://github.com/developer-overheid-nl/skills-marketplace) (owner, metadata, author, category, tags).

## Installeren

```
/plugin marketplace add MinBZK/storybook
/plugin install nldd@nldd-plugins
```

## Buiten scope

- Geen aggregator-marketplace; de overheid-brede catalogus hoort thuis in `skills-marketplace`. `nldd` daar opnemen kan later met een losse PR op die repo.
- Geen cross-platform generator (Cursor/Windsurf) zoals het voorbeeld; overkill voor één plugin uit één repo.