### PR TITLE
ci(release): generate the plugin version after the npm version bump

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
     {
       "name": "nldd",
       "description": "Bouw applicaties met het NLDD Design System (@nldd/design-system): de visie erachter en hoe je de web components goed gebruikt. Voor consumenten van het pakket, niet voor wie het systeem zelf onderhoudt.",
-      "version": "0.8.60",
+      "version": "0.8.61",
       "author": {
         "name": "MinBZK"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "nldd",
   "description": "Bouw applicaties met het NLDD Design System (@nldd/design-system): de visie erachter en hoe je de web components goed gebruikt. Voor consumenten van het pakket, niet voor wie het systeem zelf onderhoudt.",
-  "version": "0.8.60"
+  "version": "0.8.61"
 }

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -43,11 +43,11 @@
       "changelogFile": "CHANGELOG.md",
       "changelogTitle": "# Changelog\n\nAll notable changes to the NLDD design system are documented here.\n\nThe format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),\nand this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).\nVersions are bumped automatically by semantic-release on merge to main —\nthe type of conventional-commit determines the release. Conventional types\n`chore`, `docs`, `ci`, `style`, `test`, `build` are intentionally omitted\nhere; consult the commit history if you need that level of detail."
     }],
-    ["@semantic-release/exec", {
-      "prepareCmd": "npm run generate:skill-docs"
-    }],
     ["@semantic-release/npm", {
       "npmPublish": false
+    }],
+    ["@semantic-release/exec", {
+      "prepareCmd": "npm run generate:skill-docs"
     }],
     ["@semantic-release/git", {
       "assets": ["package.json", "CHANGELOG.md", "skills/nldd/changelog.md", "skills/nldd/reference.md", "skills/nldd/design-guidelines.md", ".claude-plugin/plugin.json", ".claude-plugin/marketplace.json"],


### PR DESCRIPTION
@semantic-release/exec (which runs generate:skill-docs -> generate:plugin-version) was ordered before @semantic-release/npm, so sync-plugin-version.js read the pre-bump package.json version and the .claude-plugin manifests lagged a release: 0.8.61 shipped with 0.8.60 manifests, failing the "Verify plugin manifests" check. Move @semantic-release/npm ahead of @semantic-release/exec, and sync the manifests to the current 0.8.61.