### PR TITLE
fix(list): fill the width under justify-self: start parents (rich-text)

### DIFF
--- a/src/components/lists-and-tables/list/list.styles.ts
+++ b/src/components/lists-and-tables/list/list.styles.ts
@@ -15,6 +15,7 @@ export const listStyles = css`
 
 		display: block;
 		position: relative;
+		width: 100%;
 		isolation: isolate;
 	}
 


### PR DESCRIPTION
nldd-list is display:block, which fills in normal flow but shrinkwraps under a justify-self: start grid/flex parent — notably nldd-rich-text, which gives non-text children justify-self: start and expects width:100% children to fill the span. Embedded lists (e.g. doc feature cards) collapsed to their content width. Add width:100% to the host so the list fills its column there too.