### PR TITLE
ci(review): fetch full history so code review can compute the PR diff

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
-          fetch-depth: 1
+          fetch-depth: 0
 
       - name: Run Claude Code Review
         id: claude-review


### PR DESCRIPTION
fetch-depth: 1 left the base branch out of the local clone, so the review agent's git diff against main produced nothing and every review came back with no findings. Fetching full history (fetch-depth: 0) makes the diff available.

Note: claude-code-action validates that the workflow matches the default branch, so this only takes effect once merged to main. After merge, open PRs review with the fix (including chore/component-tweaks, which already carries the same change).