### PR TITLE
ci(review): let the review post inline comments and see the full diff

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
-          fetch-depth: 1
+          fetch-depth: 0
 
       - name: Run Claude Code Review
         id: claude-review
@@ -26,7 +26,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           use_sticky_comment: true
-          claude_args: "--allowedTools Bash,Read,Glob,Grep"
+          claude_args: "--allowedTools mcp__github_inline_comment__create_inline_comment,Bash,Read,Glob,Grep"
           prompt: |
             Review PR #${{ github.event.pull_request.number }} in ${{ github.repository }}.
 


### PR DESCRIPTION
Two fixes so the Claude code review stops silently returning "no findings":

- Add `mcp__github_inline_comment__create_inline_comment` to `--allowedTools` - the tool the agent needs to post inline comments. Without it, the action's buffering step logs "No buffered inline comments" and drops findings.
- `fetch-depth: 0` so inline comments map to the right diff lines.

Validation requires this workflow to match the default branch, so it only takes effect after merge to main.