### PR TITLE
ci(release): stop releasing on ci/chore/test, keep releasing what ships

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -10,15 +10,15 @@
         { "type": "feat", "release": "patch" },
         { "type": "fix", "release": "patch" },
         { "type": "perf", "release": "patch" },
+        { "type": "refactor", "release": "patch" },
+        { "type": "style", "release": "patch" },
+        { "type": "docs", "release": "patch" },
+        { "type": "build", "release": "patch" },
         { "breaking": true, "release": "patch" },
         { "type": "chore", "release": false },
-        { "type": "docs", "release": false },
         { "type": "ci", "release": false },
-        { "type": "style", "release": false },
         { "type": "test", "release": false },
-        { "type": "build", "release": false },
-        { "type": "refactor", "release": false },
-        { "message": "*", "release": "patch" }
+        { "type": null, "release": "patch" }
       ]
     }],
     ["@semantic-release/release-notes-generator", {

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -14,6 +14,7 @@
         { "type": "style", "release": "patch" },
         { "type": "docs", "release": "patch" },
         { "type": "build", "release": "patch" },
+        { "type": "revert", "release": "patch" },
         { "breaking": true, "release": "patch" },
         { "type": "chore", "release": false },
         { "type": "ci", "release": false },

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -23,22 +23,7 @@
       ]
     }],
     ["@semantic-release/release-notes-generator", {
-      "preset": "conventionalcommits",
-      "presetConfig": {
-        "types": [
-          { "type": "feat", "section": "Added" },
-          { "type": "fix", "section": "Fixed" },
-          { "type": "perf", "section": "Changed" },
-          { "type": "revert", "section": "Reverted" },
-          { "type": "refactor", "hidden": true },
-          { "type": "chore", "hidden": true },
-          { "type": "docs", "hidden": true },
-          { "type": "ci", "hidden": true },
-          { "type": "style", "hidden": true },
-          { "type": "test", "hidden": true },
-          { "type": "build", "hidden": true }
-        ]
-      }
+      "preset": "conventionalcommits"
     }],
     ["@semantic-release/changelog", {
       "changelogFile": "CHANGELOG.md",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,6 +97,7 @@ release halen consumers de gewijzigde skill-docs nooit op (zie Plugin-versie).
 | `feat:` | Patch (0.5.0 → 0.5.1) |
 | `fix:`, `perf:` | Patch (0.5.0 → 0.5.1) |
 | `refactor:`, `style:`, `docs:`, `build:` | Patch (raken `dist/` of de skill-docs) |
+| `revert:` | Patch (een revert moet consumers ook bereiken) |
 | `feat!:` of `BREAKING CHANGE:` | Patch (0.5.0 → 0.5.1) |
 | `chore:`, `ci:`, `test:` | Geen |
 | Niet-herkend (geen conventionele prefix) | Patch (behandeld als feat) |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,12 +87,18 @@ Elk component MOET minimaal een **smoke test** hebben. Run tests met `npm test`.
 
 Versies worden **automatisch** verhoogd door semantic-release bij merge naar main.
 
+Leidend criterium: verandert de commit wat consumers krijgen (`dist/` of de
+meegeleverde `skills/nldd/*`)? Zo ja, dan hoort er een release uit te komen.
+`docs:` telt daarin mee, want de plugin-versie volgt de pakketversie: zonder
+release halen consumers de gewijzigde skill-docs nooit op (zie Plugin-versie).
+
 | Commit type | Versieverhoging |
 |-------------|-----------------|
 | `feat:` | Patch (0.5.0 → 0.5.1) |
 | `fix:`, `perf:` | Patch (0.5.0 → 0.5.1) |
+| `refactor:`, `style:`, `docs:`, `build:` | Patch (raken `dist/` of de skill-docs) |
 | `feat!:` of `BREAKING CHANGE:` | Patch (0.5.0 → 0.5.1) |
-| `docs:`, `chore:`, `ci:`, etc. | Geen |
+| `chore:`, `ci:`, `test:` | Geen |
 | Niet-herkend (geen conventionele prefix) | Patch (behandeld als feat) |
 
 **Handmatig versie verhogen is niet nodig.** Gebruik conventionele commits en CI doet de rest.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,6 +108,10 @@ release halen consumers de gewijzigde skill-docs nooit op (zie Plugin-versie).
 
 `CHANGELOG.md` wordt door semantic-release beheerd: bij elke merge naar main zet het een nieuw versieblok (`## <small>x.y.z (datum)</small>`) bovenaan, afgeleid van de conventionele commits.
 
+**De leesbare inhoud schrijf je met de hand.** Dat is bewust: `nldd-avatar - nieuw component voor een persoon of organisatie` zegt een consument veel meer dan `refactor(avatar): rename css var`. Commit-titels schrijf je voor reviewers, changelog-entries voor consumers. Het gegenereerde deel is daarom expres niet meer dan een kale bullet per release (de PR-titel); de `### Highlights` / `### Added`-secties eronder zijn handwerk.
+
+Laat daarom de regel `"preset": "conventionalcommits"` in `.releaserc.json` staan. Haal je die weg, dan valt de release-notes-generator terug op zijn eigen default en gaat hij de notes alsnog in `### Features` / `### Bug Fixes` opdelen, wat je juist niet wilt.
+
 Wil je toch handmatig iets toevoegen (bijv. iets dat semantic-release niet uit de commits haalt):
 
 - Zet de entry **direct bovenaan**, boven het nieuwste versieblok. **Geen `## Unreleased`-kopje** — dat past niet in het door semantic-release gegenereerde format.


### PR DESCRIPTION
The catch-all `{ message: "*", release: "patch" }` matched every commit, and commit-analyzer returns the HIGHEST release type of all matching rules - so it always beat the `release: false` rules. Those seven rules were dead code: every commit produced a patch, including pure CI config (0.8.67, 0.8.68).

Replaced with `{ type: null }`, which only matches commits without a recognised type (the documented "unrecognised = patch" intent).

Release on what reaches consumers: feat, fix, perf, refactor, style, docs, build. No release for chore, ci, test.

Verified against the real commit-analyzer: all 13 cases behave as intended.