### PR TITLE
ci(review): always post the review as a sticky PR comment

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           use_sticky_comment: true
-          claude_args: "--allowedTools mcp__github_inline_comment__create_inline_comment,Bash,Read,Glob,Grep"
+          claude_args: "--allowedTools mcp__github_comment__update_claude_comment,mcp__github_inline_comment__create_inline_comment,Bash,Read,Glob,Grep"
           prompt: |
             Review PR #${{ github.event.pull_request.number }} in ${{ github.repository }}.
 
@@ -98,13 +98,21 @@ jobs:
 
             ## Output format
 
-            Structure your review as a single comment with sections for each dimension that has
+            You MUST publish your review as a PR comment by calling the
+            mcp__github_comment__update_claude_comment tool. Your final answer text is
+            discarded — a review that is not posted with that tool does not exist.
+            ALWAYS post the comment, on every run, including when you find no issues:
+            in that case post a brief comment stating what you reviewed and that you
+            found no issues.
+
+            Structure the comment with sections for each dimension that has
             findings. Use this severity scale:
 
             - 🔴 **Critical** — broken component, accessibility failure, security issue
             - 🟠 **Significant** — likely bug, missing token, broken pattern
             - 🟡 **Minor** — code quality, style, non-blocking improvement
 
-            Also leave inline comments on specific lines where possible.
+            Also leave inline comments on specific lines where possible, using
+            mcp__github_inline_comment__create_inline_comment.
 
-            If there are no issues, say so briefly. Do not pad the review with praise or filler.
+            Do not pad the review with praise or filler.


### PR DESCRIPTION
## Problem

The `claude-code-review.yml` workflow only produces a PR comment in roughly **1 in 5 runs**, and has done so since it was introduced in March (595 runs analyzed: Mar 24%, Apr 17%, May 28%, Jun 23%, Jul 18%). Sometimes a review needs to be triggered 5 times before anything appears — matching that base rate exactly.

Two things interact:

1. **The prompt never told the agent to publish the review.** It said *"structure your review as a single comment"*, but the agent's final answer goes to the action's hidden SDK output and is discarded. A comment only appeared when the model decided on its own initiative to run `gh pr comment` via the unrestricted `Bash` tool — a coin flip.
2. **`use_sticky_comment: true` never worked.** The `--allowedTools` override in `claude_args` replaces the default toolset and dropped `mcp__github_comment__update_claude_comment`, the tool the sticky comment relies on. Evidence: every claude[bot] comment in the repo's history is a freshly created comment (varying titles, `created_at == updated_at`), and every run ends with `No buffered inline comments`.

#140 and #141 fixed the diff computation and inline comments, but not the missing publish step: the post-fix run on #139 ([29478715707](https://github.com/MinBZK/storybook/actions/runs/29478715707)) completed successfully (130s, 19 turns) and still posted nothing.

## Fix

- Add `mcp__github_comment__update_claude_comment` to `--allowedTools` so the sticky-comment mechanism can actually be used (one comment per PR, updated on every push).
- Instruct the review to **always** post via that tool — including a brief comment when there are no findings — and state explicitly that an unposted review does not exist.

## Follow-up suggestion (not in this PR)

The action is unpinned (`@v1` moving tag, ~50 releases since May; the default model silently switched sonnet-4-6 → sonnet-5 around July 1). Consider pinning to a release tag so behavior stops shifting under the same workflow file.