### PR TITLE
ci(review): enable track_progress so the review comment can actually be posted

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -26,6 +26,14 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           use_sticky_comment: true
+          # Force tag mode: the action creates the tracking comment that
+          # mcp__github_comment__update_claude_comment updates. Without this the
+          # workflow runs in agent mode, no comment id exists, and every
+          # update_claude_comment call fails — the review is never posted.
+          track_progress: true
+          # Show the full execution transcript in the Actions log so a silent
+          # run can be diagnosed instead of guessed at.
+          show_full_output: true
           claude_args: "--allowedTools mcp__github_comment__update_claude_comment,mcp__github_inline_comment__create_inline_comment,Bash,Read,Glob,Grep"
           prompt: |
             Review PR #${{ github.event.pull_request.number }} in ${{ github.repository }}.


### PR DESCRIPTION
## Problem — why #143 was not enough

After #143, the run on #139 (run 29490754227) executed with the new prompt and allowed tools, ran 3 minutes at 20 turns, ended "success" — and still posted nothing.

Root cause, confirmed in the action source: `mcp__github_comment__update_claude_comment` updates an **existing** tracking comment identified by the `CLAUDE_COMMENT_ID` env var (`src/mcp/github-comment-server.ts` throws `CLAUDE_COMMENT_ID environment variable is required` without it). That comment is only created in **tag mode**. With an explicit `prompt` and no `track_progress`, the action runs in **agent mode**, which hardcodes `claudeCommentId: undefined` (`src/modes/agent/index.ts`) — so the tool is mounted but every call fails, and the agent's fallback attempts go nowhere.

## Fix

- **`track_progress: true`** — forces tag mode (`src/modes/detector.ts`): the action creates the tracking comment up front, `CLAUDE_COMMENT_ID` exists, and `update_claude_comment` works. The custom review prompt is preserved (GitHub context gets injected). This matches the action's own `examples/pr-review-comprehensive.yml`, which uses exactly this combination for custom-prompt PR reviews.
- **`show_full_output: true`** — the execution transcript is currently hidden ("full output hidden for security"), which is why every silent run has required forensic guesswork. With this on, the Actions log shows what the agent actually did, so the next anomaly can be diagnosed directly.

An additional benefit of tag mode: the tracking comment is created at run start, so even a run that finds nothing leaves a visible trace on the PR.

## Validation

Like #143, the review job will skip on this PR itself (the action refuses to run a workflow file that differs from the default branch). Validate after merge on the next push to any open PR, e.g. #139.