### PR TITLE
fix(timeline-track-cell): laat het spoor over de rijgrens doorlopen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ the type of conventional-commit determines the release. Conventional types
 `chore`, `docs`, `ci`, `style`, `test`, `build` are intentionally omitted
 here; consult the commit history if you need that level of detail.
 
+### Fixed
+
+- **The timeline track broke at every row.** An `nldd-list-item` reserves a divider's worth of space below itself, and the lines of `nldd-timeline-track-cell` stopped at the cell's edge — leaving a hairline gap between one row's track and the next. The lines that run on downward now bridge that band.
+
 ## <small>0.8.71 (2026-07-29)</small>
 
 * feat: step indicator, tree lists and a reworked list-item (#161) ([2c87577](https://github.com/MinBZK/storybook/commit/2c87577)), closes [#161](https://github.com/MinBZK/storybook/issues/161)

--- a/skills/nldd/changelog.md
+++ b/skills/nldd/changelog.md
@@ -15,6 +15,10 @@ the type of conventional-commit determines the release. Conventional types
 `chore`, `docs`, `ci`, `style`, `test`, `build` are intentionally omitted
 here; consult the commit history if you need that level of detail.
 
+### Fixed
+
+- **The timeline track broke at every row.** An `nldd-list-item` reserves a divider's worth of space below itself, and the lines of `nldd-timeline-track-cell` stopped at the cell's edge — leaving a hairline gap between one row's track and the next. The lines that run on downward now bridge that band.
+
 ## <small>0.8.71 (2026-07-29)</small>
 
 * feat: step indicator, tree lists and a reworked list-item (#161) ([2c87577](https://github.com/MinBZK/storybook/commit/2c87577)), closes [#161](https://github.com/MinBZK/storybook/issues/161)

--- a/src/components/lists-and-tables/cells/timeline-track-cell/timeline-track-cell.styles.ts
+++ b/src/components/lists-and-tables/cells/timeline-track-cell/timeline-track-cell.styles.ts
@@ -65,9 +65,13 @@ export const timelineTrackCellStyles = css`
 		width: var(--_line-width);
 	}
 
+	/* The lines that run on downward also bridge the row boundary: an
+	   nldd-list-item reserves a divider's worth of space below itself, and
+	   without this the track breaks at every row. The top line needs nothing —
+	   the row above already covers the band. */
 	.timeline-track-cell__full-line {
 		top: 0;
-		bottom: 0;
+		bottom: calc(-1 * var(--semantics-dividers-thickness));
 	}
 
 	.timeline-track-cell__top-line {
@@ -77,7 +81,7 @@ export const timelineTrackCellStyles = css`
 
 	.timeline-track-cell__bottom-line {
 		top: 50%;
-		height: 50%;
+		bottom: calc(-1 * var(--semantics-dividers-thickness));
 	}
 
 	:host([status="future"]) .timeline-track-cell__top-line,

--- a/src/components/lists-and-tables/cells/timeline-track-cell/timeline-track-cell.test.ts
+++ b/src/components/lists-and-tables/cells/timeline-track-cell/timeline-track-cell.test.ts
@@ -102,6 +102,27 @@ describe('nldd-timeline-track-cell', () => {
 		expect(el.shadowRoot!.querySelector('slot')).toBeNull();
 	});
 
+	// The row reserves a divider's worth of space below itself, so a line that
+	// stops at the cell's edge breaks the track at every row boundary. Measured
+	// on the declaration, not on two stacked rows: the row's padding bleed only
+	// settles after a layout pass, which makes a pixel comparison flaky here.
+	it('laat de neergaande lijnen over de rijgrens doorlopen', async () => {
+		// The token itself comes from settings.css, which the test page doesn't
+		// load, so set it here: what's being checked is that the line reaches past
+		// the cell by exactly that thickness.
+		el = await fixture<NLDDTimelineTrackCell>('<nldd-timeline-track-cell position="first"></nldd-timeline-track-cell>');
+		el.style.setProperty('--semantics-dividers-thickness', '1px');
+		await waitForUpdate(el);
+		const onder = el.shadowRoot!.querySelector('.timeline-track-cell__bottom-line')!;
+		expect(getComputedStyle(onder).bottom).toBe('-1px');
+
+		el = await fixture<NLDDTimelineTrackCell>('<nldd-timeline-track-cell status="none"></nldd-timeline-track-cell>');
+		el.style.setProperty('--semantics-dividers-thickness', '1px');
+		await waitForUpdate(el);
+		const vol = el.shadowRoot!.querySelector('.timeline-track-cell__full-line')!;
+		expect(getComputedStyle(vol).bottom).toBe('-1px');
+	});
+
 	it('renders a full line for status=none', async () => {
 		el = await fixture<NLDDTimelineTrackCell>('<nldd-timeline-track-cell status="none"></nldd-timeline-track-cell>');
 		await waitForUpdate(el);

--- a/src/components/status-and-feedback/activity-indicator/activity-indicator.stories.ts
+++ b/src/components/status-and-feedback/activity-indicator/activity-indicator.stories.ts
@@ -3,6 +3,9 @@ import './activity-indicator.js';
 import '../progress-circle/progress-circle.js';
 import '../progress-bar/progress-bar.js';
 import '../../actions/button/button.js';
+import '../../layout/card/card.js';
+import '../../layout/container/container.js';
+import '../../content/rich-text/rich-text.js';
 
 /**
  * Een layout placeholder die de beschikbare ruimte vult en een indeterminate
@@ -80,23 +83,33 @@ export default {
 	},
 };
 
+// De kaart staat om de indicator heen, niet andersom: de backdrop is een
+// rechthoek met inset 0 zonder eigen hoekradius, dus met de kaart erbinnen zou
+// hij over de ronde hoeken heen steken. Zo klipt de kaart hem netjes af, en
+// leest het als "de inhoud van deze kaart laadt".
 const Template = ({ size, text, showText, timing, noBackdrop, complete }: Record<string, unknown>) => html`
-	<nldd-activity-indicator size=${size as string}
-		text=${text as string}
-		?show-text=${showText as boolean}
-		timing=${timing as string}
-		?no-backdrop=${noBackdrop as boolean}
-		?complete=${complete as boolean}
-		style="width: 360px; border-radius: 12px; overflow: hidden; background: var(--semantics-surfaces-base-background-color); box-shadow: 0 1px 4px rgba(0, 0, 0, 0.12);"
-	>
-		<div style="padding: 20px; display: flex; flex-direction: column; gap: 12px; align-items: flex-start;">
-			<p style="margin: 0; font: var(--primitives-font-body-md-medium-tight); color: var(--semantics-content-color);">Voorbeeldcontent</p>
-			<p style="margin: 0; font: var(--primitives-font-body-sm-regular-tight); color: var(--semantics-content-secondary-color);">
-				De content zit nu IN de activity indicator, geen wrapper-div meer. Tijdens het laden is deze inert: de knop kan niet gefocust of geklikt worden.
-			</p>
-			<nldd-button text="Knop in de content"></nldd-button>
-		</div>
-	</nldd-activity-indicator>
+	<div style="width: 360px;">
+		<nldd-card accessible-label="Voorbeeldkaart">
+			<nldd-activity-indicator size=${size as string}
+				text=${text as string}
+				?show-text=${showText as boolean}
+				timing=${timing as string}
+				?no-backdrop=${noBackdrop as boolean}
+				?complete=${complete as boolean}
+			>
+				<nldd-container padding="20" gap="12">
+					<nldd-rich-text>
+						<p><strong>Voorbeeldcontent</strong></p>
+						<p>
+							De content zit IN de activity indicator. Tijdens het laden is die inert:
+							de knop kan niet gefocust of geklikt worden.
+						</p>
+					</nldd-rich-text>
+					<nldd-button text="Knop in de content"></nldd-button>
+				</nldd-container>
+			</nldd-activity-indicator>
+		</nldd-card>
+	</div>
 `;
 
 export const Default = {
@@ -189,16 +202,21 @@ export const CustomCircleViaSlot = {
 export const Backdrop = {
 	name: 'Backdrop over content',
 	render: ({ noBackdrop }: Record<string, unknown>) => html`
-		<nldd-activity-indicator ?no-backdrop=${noBackdrop as boolean} show-text text="Bezig met verwerken…" timing="instant"
-			style="width: 320px; border-radius: 12px; overflow: hidden; background: var(--semantics-surfaces-base-background-color); box-shadow: 0 1px 4px rgba(0, 0, 0, 0.12);"
-		>
-			<div style="padding: 20px; display: flex; flex-direction: column; gap: 8px;">
-				<p style="margin: 0; font: var(--primitives-font-body-md-medium-tight); color: var(--semantics-content-color);">Aanvraag indienen</p>
-				<p style="margin: 0; font: var(--primitives-font-body-sm-regular-tight); color: var(--semantics-content-secondary-color);">
-					Deze gegevens worden verwerkt. De content blijft zichtbaar maar dimt en blurt achter de indicator, zodat duidelijk is dat het proces nog loopt.
-				</p>
-			</div>
-		</nldd-activity-indicator>
+		<div style="width: 320px;">
+			<nldd-card accessible-label="Aanvraag indienen">
+				<nldd-activity-indicator ?no-backdrop=${noBackdrop as boolean} show-text text="Bezig met verwerken…" timing="instant">
+					<nldd-container padding="20" gap="8">
+						<nldd-rich-text>
+							<p><strong>Aanvraag indienen</strong></p>
+							<p>
+								Deze gegevens worden verwerkt. De content blijft zichtbaar maar dimt en
+								blurt achter de indicator, zodat duidelijk is dat het proces nog loopt.
+							</p>
+						</nldd-rich-text>
+					</nldd-container>
+				</nldd-activity-indicator>
+			</nldd-card>
+		</div>
 	`,
 	args: { noBackdrop: false },
 	parameters: {


### PR DESCRIPTION
### Fixed

- **The timeline track broke at every row.** An `nldd-list-item` reserves a divider's worth of space below itself, and the lines of `nldd-timeline-track-cell` stopped at the cell's edge — leaving a hairline gap between one row's track and the next. The lines that run on downward now bridge that band.