### PR TITLE
fix(menu): set aria-haspopup on the anchor from first render

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ the type of conventional-commit determines the release. Conventional types
 `chore`, `docs`, `ci`, `style`, `test`, `build` are intentionally omitted
 here; consult the commit history if you need that level of detail.
 
+### Fixed
+
+- **`nldd-menu`** — a button that opens a menu now carries `aria-haspopup` from the first render instead of from its first open. `aria-haspopup` describes the trigger ("this button opens a menu"), not a state, and deferring it left a screen reader tabbing a row of identical "more" buttons hearing plain "button" — precisely when the type matters, since nothing has been opened yet. Because `popup-type` also decides whether `aria-expanded` is rendered at all, a button without `expandable` had neither attribute until first use. `nldd-popover` already worked this way; the two now agree. Setting `popup-type` yourself still wins, so no markup has to change.
+
 ## <small>0.8.75 (2026-08-01)</small>
 
 * feat: font-free stylesheet entry, month picker, markdown code blocks and open-source docs (#164) ([263ffd6](https://github.com/MinBZK/storybook/commit/263ffd6)), closes [#164](https://github.com/MinBZK/storybook/issues/164)

--- a/skills/nldd/changelog.md
+++ b/skills/nldd/changelog.md
@@ -15,6 +15,10 @@ the type of conventional-commit determines the release. Conventional types
 `chore`, `docs`, `ci`, `style`, `test`, `build` are intentionally omitted
 here; consult the commit history if you need that level of detail.
 
+### Fixed
+
+- **`nldd-menu`** — a button that opens a menu now carries `aria-haspopup` from the first render instead of from its first open. `aria-haspopup` describes the trigger ("this button opens a menu"), not a state, and deferring it left a screen reader tabbing a row of identical "more" buttons hearing plain "button" — precisely when the type matters, since nothing has been opened yet. Because `popup-type` also decides whether `aria-expanded` is rendered at all, a button without `expandable` had neither attribute until first use. `nldd-popover` already worked this way; the two now agree. Setting `popup-type` yourself still wins, so no markup has to change.
+
 ## <small>0.8.75 (2026-08-01)</small>
 
 * feat: font-free stylesheet entry, month picker, markdown code blocks and open-source docs (#164) ([263ffd6](https://github.com/MinBZK/storybook/commit/263ffd6)), closes [#164](https://github.com/MinBZK/storybook/issues/164)

--- a/src/components/actions/menu/menu.test.ts
+++ b/src/components/actions/menu/menu.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { fixture, cleanup, waitForUpdate, installUniversalReset } from '../../../test-utils.js';
 import './menu.js';
+import '../button/button.js';
 
 function getButton(el: Element): HTMLElement {
 	return el.shadowRoot?.querySelector('button') as HTMLElement;
@@ -2398,5 +2399,112 @@ describe('nldd-menu-group en nldd-menu-divider onder een universele reset', () =
 		const line = divider.shadowRoot!.querySelector('.menu__divider')!;
 		const offset = line.getBoundingClientRect().top - divider.getBoundingClientRect().top;
 		expect(offset).toBe(4);
+	});
+});
+
+describe('nldd-menu anchor popup semantics', () => {
+	let el: HTMLElement;
+
+	afterEach(() => {
+		if (el) cleanup(el);
+	});
+
+	/** Settle the menu's deferred seed and the anchor's re-render after it. */
+	async function settle(button: HTMLElement & { updateComplete?: Promise<boolean> }) {
+		await waitForUpdate(button);
+		await Promise.resolve();
+		await button.updateComplete;
+	}
+
+	it('seeds aria-haspopup on a slotted-in anchor before any interaction', async () => {
+		el = await fixture(`
+			<nldd-button text="Acties">
+				<nldd-menu slot="popup">
+					<nldd-menu-item text="Bewerken"></nldd-menu-item>
+				</nldd-menu>
+			</nldd-button>
+		`);
+		const button = el as HTMLElement & { popupType?: string };
+		await settle(button);
+		expect(button.popupType).toBe('menu');
+		expect(getButton(button).getAttribute('aria-haspopup')).toBe('menu');
+		// popupType also drives whether aria-expanded is rendered at all, so a
+		// button without `expandable` used to have neither before its first open.
+		expect(getButton(button).getAttribute('aria-expanded')).toBe('false');
+	});
+
+	it('seeds listbox rather than menu for a listbox variant', async () => {
+		el = await fixture(`
+			<nldd-button text="Kies">
+				<nldd-menu slot="popup" variant="listbox">
+					<nldd-menu-item text="Een"></nldd-menu-item>
+				</nldd-menu>
+			</nldd-button>
+		`);
+		const button = el as HTMLElement & { popupType?: string };
+		await settle(button);
+		expect(button.popupType).toBe('listbox');
+	});
+
+	it('leaves a popup type the consumer chose alone', async () => {
+		el = await fixture(`
+			<nldd-button text="Acties" popup-type="dialog">
+				<nldd-menu slot="popup">
+					<nldd-menu-item text="Bewerken"></nldd-menu-item>
+				</nldd-menu>
+			</nldd-button>
+		`);
+		const button = el as HTMLElement & { popupType?: string };
+		await settle(button);
+		expect(button.popupType).toBe('dialog');
+	});
+
+	it('seeds a button reached through the anchor attribute too', async () => {
+		// The reason this lives in nldd-menu and not in the button: with
+		// `anchor="id"` the button knows nothing about the menu, so only the
+		// menu can tell it what kind of popup it opens.
+		el = await fixture(`
+			<div>
+				<nldd-button id="acties-knop" text="Acties"></nldd-button>
+				<nldd-menu anchor="acties-knop">
+					<nldd-menu-item text="Bewerken"></nldd-menu-item>
+				</nldd-menu>
+			</div>
+		`);
+		const button = el.querySelector('nldd-button') as HTMLElement & {
+			popupType?: string;
+			updateComplete: Promise<boolean>;
+		};
+		await waitForUpdate(el.querySelector('nldd-menu') as HTMLElement);
+		await Promise.resolve();
+		await button.updateComplete;
+		expect(button.popupType).toBe('menu');
+		expect(getButton(button).getAttribute('aria-haspopup')).toBe('menu');
+	});
+
+	it('seeds an anchor assigned after the menu first rendered', async () => {
+		el = await fixture(`
+			<div>
+				<nldd-button id="later" text="Acties"></nldd-button>
+				<nldd-menu>
+					<nldd-menu-item text="Bewerken"></nldd-menu-item>
+				</nldd-menu>
+			</div>
+		`);
+		const menu = el.querySelector('nldd-menu') as HTMLElement & {
+			anchorElement: Element | null;
+			updateComplete: Promise<boolean>;
+		};
+		const button = el.querySelector('nldd-button') as HTMLElement & {
+			popupType?: string;
+			updateComplete: Promise<boolean>;
+		};
+		await waitForUpdate(menu);
+		await Promise.resolve();
+		expect(button.popupType).toBeFalsy();
+		menu.anchorElement = button;
+		await menu.updateComplete;
+		await button.updateComplete;
+		expect(button.popupType).toBe('menu');
 	});
 });

--- a/src/components/actions/menu/menu.ts
+++ b/src/components/actions/menu/menu.ts
@@ -585,6 +585,13 @@ export class NLDDMenu extends LitElement {
 				(item as NLDDMenuItem).menuVariant = this.variant;
 			});
 		}
+		// A new anchor arrives closed and unlabelled — seed it right away rather
+		// than at its first open. Covers the popup slot (where the invoking
+		// control assigns `anchorElement` on slotchange, which may land after
+		// our firstUpdated) and a runtime `anchor` swap.
+		if (changedProperties.has('anchor') || changedProperties.has('anchorElement')) {
+			this._syncAnchorPopupState(this._isOpen);
+		}
 	}
 
 	// — Anchor ————————————————————————————————————————————————————————————————
@@ -651,7 +658,14 @@ export class NLDDMenu extends LitElement {
 		// an empty string is not a valid aria-haspopup token, so it must
 		// still be seeded rather than left invalid. An intentional opt-out
 		// is `popup-type="false"`, which is truthy and preserved here.
-		if (isOpen && 'popupType' in anchor && !anchor.popupType) {
+		//
+		// Deliberately not gated on `isOpen`: aria-haspopup is a static
+		// property of the trigger ("this button opens a menu"), not state.
+		// Seeding it on first open would leave a screen reader tabbing a row
+		// of identical "more" buttons hearing plain "button" — exactly the
+		// moment the type matters most, since nothing has been opened yet.
+		// nldd-popover already works this way.
+		if ('popupType' in anchor && !anchor.popupType) {
 			anchor.popupType = this.variant === 'listbox' ? 'listbox' : 'menu';
 		}
 		if ('popoverTargetAction' in anchor) {
@@ -1644,6 +1658,10 @@ export class NLDDMenu extends LitElement {
 		// root only).
 		this._onHeaderSlotChange();
 		this._onFooterSlotChange();
+		// Give the anchor its aria-haspopup before any interaction. Deferred a
+		// microtask because an `anchor="id"` target may render after us; a later
+		// anchor still gets seeded from `updated()`. Mirrors nldd-popover.
+		Promise.resolve().then(() => this._syncAnchorPopupState(this._isOpen));
 	}
 
 	override disconnectedCallback(): void {


### PR DESCRIPTION
### Fixed

- **`nldd-menu`** — a button that opens a menu now carries `aria-haspopup` from the first render instead of from its first open. `aria-haspopup` describes the trigger ("this button opens a menu"), not a state, and deferring it left a screen reader tabbing a row of identical "more" buttons hearing plain "button" — precisely when the type matters, since nothing has been opened yet. Because `popup-type` also decides whether `aria-expanded` is rendered at all, a button without `expandable` had neither attribute until first use. `nldd-popover` already worked this way; the two now agree. Setting `popup-type` yourself still wins, so no markup has to change.