### PR TITLE
fix(popover): clear a stale centering transform when the override goes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ the type of conventional-commit determines the release. Conventional types
 `chore`, `docs`, `ci`, `style`, `test`, `build` are intentionally omitted
 here; consult the commit history if you need that level of detail.
 
+### Fixed
+
+- **`nldd-popover`** — a popover that loses its `centered` (or edge) override at runtime no longer keeps the centering transform. The override branch cleared `transform` only while it was still being taken, so a responsive popover switching from centered to anchored on a breakpoint change kept `translate(-50%, …)` on top of Floating UI's coordinates and landed half its width off its anchor, partly off screen. Floating UI positions purely through `left`/`top`, so the transform is now cleared whenever no override applies.
+
 ## <small>0.8.76 (2026-08-02)</small>
 
 * fix(menu): set aria-haspopup on the anchor from first render (#165) ([2486d28](https://github.com/MinBZK/storybook/commit/2486d28)), closes [#165](https://github.com/MinBZK/storybook/issues/165)

--- a/skills/nldd/changelog.md
+++ b/skills/nldd/changelog.md
@@ -15,6 +15,10 @@ the type of conventional-commit determines the release. Conventional types
 `chore`, `docs`, `ci`, `style`, `test`, `build` are intentionally omitted
 here; consult the commit history if you need that level of detail.
 
+### Fixed
+
+- **`nldd-popover`** — a popover that loses its `centered` (or edge) override at runtime no longer keeps the centering transform. The override branch cleared `transform` only while it was still being taken, so a responsive popover switching from centered to anchored on a breakpoint change kept `translate(-50%, …)` on top of Floating UI's coordinates and landed half its width off its anchor, partly off screen. Floating UI positions purely through `left`/`top`, so the transform is now cleared whenever no override applies.
+
 ## <small>0.8.76 (2026-08-02)</small>
 
 * fix(menu): set aria-haspopup on the anchor from first render (#165) ([2486d28](https://github.com/MinBZK/storybook/commit/2486d28)), closes [#165](https://github.com/MinBZK/storybook/issues/165)

--- a/src/components/layout/popover/popover.test.ts
+++ b/src/components/layout/popover/popover.test.ts
@@ -511,6 +511,33 @@ describe('nldd-popover', () => {
 			expect(popover.style.transform).toContain(', -50%');
 		});
 
+		it('laat geen centreer-transform achter wanneer centered wegvalt', async () => {
+			// Een responsieve popover die op een breakpoint van gecentreerd naar
+			// geankerd wisselt: zonder opruimen houdt hij translate(-50%, …) en
+			// landt hij een halve breedte naast zijn anker, deels buiten beeld.
+			const wrapper = await fixture(`
+				<div>
+					<button id="trigger-uncenter">Trigger</button>
+					<nldd-popover anchor="trigger-uncenter" accessible-label="Test" centered top="0"></nldd-popover>
+				</div>
+			`);
+			el = wrapper;
+			const popover = wrapper.querySelector('nldd-popover') as NLDDPopover;
+			asMd(popover);
+			await waitForUpdate(popover);
+
+			popover.show();
+			await waitForUpdate(popover);
+			expect(popover.style.transform).toContain('-50%');
+
+			popover.centered = false;
+			popover.top = '';
+			await waitForUpdate(popover);
+			await new Promise(r => setTimeout(r, 0));
+
+			expect(popover.style.transform).toBe('');
+		});
+
 		it('centered + top="0" → horizontaal gecentreerd, top-aligned', async () => {
 			const wrapper = await fixture(`
 				<div>

--- a/src/components/layout/popover/popover.ts
+++ b/src/components/layout/popover/popover.ts
@@ -331,6 +331,15 @@ export class NLDDPopover extends LitElement {
 			return;
 		}
 
+		// Drop a centering transform left over from an override that has since
+		// been removed. The branch above only clears it while it is still being
+		// taken, so a popover that loses `centered` at runtime — a responsive one
+		// switching from centered to anchored on a breakpoint change — would keep
+		// its `translate(-50%, …)` and land half its width off the anchor, partly
+		// off screen. Floating UI positions purely via left/top, so there is never
+		// a transform to preserve here.
+		this.style.removeProperty('transform');
+
 		const anchorEl = this._getAnchorEl();
 		if (!anchorEl) return;
 


### PR DESCRIPTION
### Fixed

- **`nldd-popover`** — a popover that loses its `centered` (or edge) override at runtime no longer keeps the centering transform. The override branch cleared `transform` only while it was still being taken, so a responsive popover switching from centered to anchored on a breakpoint change kept `translate(-50%, …)` on top of Floating UI's coordinates and landed half its width off its anchor, partly off screen. Floating UI positions purely through `left`/`top`, so the transform is now cleared whenever no override applies.