### PR TITLE
ci: install dependencies with --ignore-scripts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,12 @@ jobs:
         with:
           node-version: '20'
           cache: 'npm'
+      # --ignore-scripts: a hijacked dependency release must not get to run its
+      # preinstall/postinstall hook in CI. Nothing in this tree needs lifecycle
+      # scripts at install time; the browsers come from the explicit
+      # `playwright install` in the next step, which has always been required.
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --ignore-scripts
       - name: Install Playwright browsers
         run: npx playwright install --with-deps chromium
       - name: Run ESLint (including lit-a11y rules)

--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -28,8 +28,10 @@ jobs:
           node-version: '20'
           cache: 'npm'
 
+      # --ignore-scripts: a hijacked dependency release must not get to run its
+      # preinstall/postinstall hook in the job that publishes to Pages.
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --ignore-scripts
 
       - name: Build styles
         run: npm run build:styles

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -42,8 +42,12 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
           scope: '@nldd'
 
+      # --ignore-scripts: a hijacked dependency release must not get to run its
+      # preinstall/postinstall hook in the one job that holds NPM_TOKEN. Nothing
+      # in this tree needs lifecycle scripts at install time - the build below
+      # runs the generators explicitly.
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --ignore-scripts
 
       - name: Build package
         run: npm run build

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -21,8 +21,10 @@ jobs:
           node-version: '20'
           cache: 'npm'
 
+      # --ignore-scripts: a hijacked dependency release must not get to run its
+      # preinstall/postinstall hook in CI. Nothing below needs them.
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --ignore-scripts
 
       - name: Validate CSS variables
         run: npm run validate:styles

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -27,8 +27,10 @@ jobs:
           node-version: '22'
           cache: 'npm'
 
+      # --ignore-scripts: a hijacked dependency release must not get to run its
+      # preinstall/postinstall hook in the job that holds VERSION_BUMP_TOKEN.
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --ignore-scripts
 
       - name: Configure Git
         run: |


### PR DESCRIPTION
Adds `--ignore-scripts` to all five `npm ci` calls in the workflows.

## Why

Dependabot resolves with `--ignore-scripts`, so the PR it opens is harmless in itself. The exposure is the **first install on that branch**: `npm ci` runs every dependency's `preinstall`/`postinstall` hook. `publish-npm.yml` does that in the one job that holds `NPM_TOKEN`; `version-bump.yml` in the job that holds `VERSION_BUMP_TOKEN`.

Every registry compromise of the past year — chalk/debug, shai-hulud, and the keyv/cacheable maintainer-account hijack of 2026-08-04 — delivered its payload through exactly that hook. This repo has `keyv@4.5.4` / `file-entry-cache@8.0.0` transitively via eslint; both are far below the poisoned releases, so nothing here is compromised. This closes the door for the next one.

## Why this is safe here

Nothing in this tree needs lifecycle scripts at install time:
- the root `prepare` is `pre-commit install || true`, which is pointless in CI anyway;
- the generators run explicitly from `npm run build`;
- the Playwright browsers `ci.yml` needs already come from their own `npx playwright install --with-deps chromium` step, not from a postinstall.

## Verification

Ran locally against this tree after `npm ci --ignore-scripts`:

| Check | Result |
|---|---|
| `npm run build` (the publish path) | pass |
| `npm run lint` / `npm run typecheck` | pass |
| `npm run test:run` | pass — 119 files, 2820 tests |
| `validate:styles`, `validate:host-styles`, `validate:component-api`, `test:scripts` | pass |
| `build:components:modules` → `generate:vue-types` → `test:vue-types` | pass |
| `npm run build-storybook` | pass |
| `npx playwright install --with-deps chromium` | pass (unaffected by the flag) |