### PR TITLE
ci: laat actions/checkout het VERSION_BUMP_TOKEN niet op schijf achter

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -20,6 +20,14 @@ jobs:
         with:
           fetch-depth: 0
           token: ${{ secrets.VERSION_BUMP_TOKEN }}
+          # Zonder dit schrijft actions/checkout het token naar de git-config
+          # van deze checkout, waar het blijft staan zolang de job draait. Alles
+          # wat daarna in deze job draait kan het van schijf lezen — inclusief
+          # de dependency-code die `npx semantic-release` hieronder inlaadt.
+          # `npm ci --ignore-scripts` sluit alleen het install-moment af, niet
+          # dit. semantic-release pusht zelf met GITHUB_TOKEN uit de env van de
+          # laatste stap en heeft de gepersisteerde credential niet nodig.
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -20,13 +20,14 @@ jobs:
         with:
           fetch-depth: 0
           token: ${{ secrets.VERSION_BUMP_TOKEN }}
-          # Zonder dit schrijft actions/checkout het token naar de git-config
-          # van deze checkout, waar het blijft staan zolang de job draait. Alles
-          # wat daarna in deze job draait kan het van schijf lezen — inclusief
-          # de dependency-code die `npx semantic-release` hieronder inlaadt.
-          # `npm ci --ignore-scripts` sluit alleen het install-moment af, niet
-          # dit. semantic-release pusht zelf met GITHUB_TOKEN uit de env van de
-          # laatste stap en heeft de gepersisteerde credential niet nodig.
+          # Without this, actions/checkout leaves the token on disk for the rest
+          # of the job — an http.https://github.com/.extraheader credential that
+          # this checkout's git config resolves. Anything that runs afterwards
+          # can read it, including the dependency code `npx semantic-release`
+          # loads below. `npm ci --ignore-scripts` only closes the install hook,
+          # not this. semantic-release builds its own authenticated push URL from
+          # the GITHUB_TOKEN env var on its step, so it does not need the
+          # persisted credential.
           persist-credentials: false
 
       - name: Setup Node.js


### PR DESCRIPTION
Voegt `persist-credentials: false` toe aan de checkout in `version-bump.yml`.

## Het probleem

```yaml
- uses: actions/checkout@v6
  with:
    token: ${{ secrets.VERSION_BUMP_TOKEN }}   # geen persist-credentials: false
- run: npm ci --ignore-scripts
- run: npx semantic-release
```

`actions/checkout` schrijft het meegegeven token naar de git-config van de checkout en laat het daar staan tot de post-job cleanup. Alles wat daartussen in deze job draait kan het gewoon van schijf lezen.

Dat is een **kortere weg dan de install-hook die #167 dichtzette**. `npx semantic-release` laadt zijn plugins en hun complete dependency-boom in; die code draait met leesrechten op de werkmap. Eén gekaapte transitieve dependency van semantic-release is genoeg. En `VERSION_BUMP_TOKEN` mag naar `main` pushen — dat is geen token om te laten slingeren.

## Waarom dit veilig is

semantic-release heeft de gepersisteerde credential niet nodig. Het bouwt zijn eigen push-URL uit `GITHUB_TOKEN`, dat al in de env van de laatste stap staat (`version-bump.yml:41-42`). Dat is ook de manier waarop semantic-release het zelf documenteert.

## Wat je moet controleren na de merge

Ik kan dit niet lokaal bewijzen — het blijkt pas uit een echte push naar `main`. **De eerstvolgende niet-`chore(release):`-commit op main hoort weer een `chore(release):`-commit op te leveren.** Blijft die uit, dan is deze regel de verdachte en is hij in één commit weer weg. De faalmodus is zichtbaar (rode job of geen release), niet stil.

Daarom staat deze bewust apart van #167 en niet in dezelfde merge.