### PR TITLE
ci: publiceer vanuit een aparte job zonder dependency-code

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -3,6 +3,13 @@ name: Publish to npmjs
 # Requires repository secret NPM_TOKEN: a granular npmjs token with
 # read+write access to the @nldd scope and 2FA bypass enabled.
 # Without it, the publish step fails with E401/EAUTH at runtime.
+#
+# The work is split over two jobs on purpose. `npm ci` and `npm run build`
+# execute third-party code by design - vite, tsc, the custom-elements analyzer
+# and every plugin they load. NPM_TOKEN must therefore not be reachable from
+# the job that does that. `build` holds no secrets and hands over a plain
+# artifact; `publish` holds the token and runs no dependency code at all.
+# --ignore-scripts closes the install moment; this closes the build moment.
 
 on:
   push:
@@ -20,7 +27,7 @@ on:
         type: string
 
 jobs:
-  publish:
+  build:
     runs-on: ubuntu-latest
     # Only publish when triggered by version-bump commit, release, or manual dispatch
     if: >-
@@ -29,7 +36,6 @@ jobs:
       startsWith(github.event.head_commit.message, 'chore(release):')
     permissions:
       contents: read
-      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -39,24 +45,67 @@ jobs:
         with:
           node-version: '20'
           cache: 'npm'
-          registry-url: 'https://registry.npmjs.org'
-          scope: '@nldd'
 
       # --ignore-scripts: a hijacked dependency release must not get to run its
-      # preinstall/postinstall hook in the one job that holds NPM_TOKEN. Nothing
-      # in this tree needs lifecycle scripts at install time - the build below
-      # runs the generators explicitly.
+      # preinstall/postinstall hook. Nothing in this tree needs lifecycle
+      # scripts at install time; the build runs its generators explicitly.
       - name: Install dependencies
         run: npm ci --ignore-scripts
 
       - name: Build package
         run: npm run build
 
+      # De input gaat via de env in plaats van via ${{ }} in de run-regel:
+      # workflow_dispatch-input is vrije tekst en zou daar als shell worden
+      # geïnterpreteerd.
       - name: Update version (if specified)
         if: ${{ inputs.version != '' }}
-        run: npm version ${{ inputs.version }} --no-git-tag-version
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+        run: npm version "$INPUT_VERSION" --no-git-tag-version
 
+      # Precies wat `files` in package.json publiceert, plus de twee bestanden
+      # die npm er altijd bij pakt (package.json en README). package.json en
+      # custom-elements.json staan erbij omdat de build ze herschrijft.
+      - name: Upload publish payload
+        uses: actions/upload-artifact@v4
+        with:
+          name: npm-package
+          retention-days: 1
+          if-no-files-found: error
+          path: |
+            package.json
+            README.md
+            LICENSE
+            NOTICES.md
+            custom-elements.json
+            dist/
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # Nodig voor `npm publish --provenance`: npm ruilt dit OIDC-token in bij
+      # Sigstore. Staat bewust alleen op deze job.
+      id-token: write
+    steps:
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+          scope: '@nldd'
+
+      - name: Download publish payload
+        uses: actions/download-artifact@v4
+        with:
+          name: npm-package
+
+      # --ignore-scripts ook hier: npm draait bij publish standaard `prepare`
+      # en `prepack`. Er valt niets te prepareren - dist/ komt kant en klaar uit
+      # de build-job - dus die hoeven niet te draaien.
       - name: Publish to npmjs
-        run: npm publish --provenance
+        run: npm publish --provenance --ignore-scripts
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -4,12 +4,15 @@ name: Publish to npmjs
 # read+write access to the @nldd scope and 2FA bypass enabled.
 # Without it, the publish step fails with E401/EAUTH at runtime.
 #
-# The work is split over two jobs on purpose. `npm ci` and `npm run build`
-# execute third-party code by design - vite, tsc, the custom-elements analyzer
-# and every plugin they load. NPM_TOKEN must therefore not be reachable from
-# the job that does that. `build` holds no secrets and hands over a plain
-# artifact; `publish` holds the token and runs no dependency code at all.
-# --ignore-scripts closes the install moment; this closes the build moment.
+# The work is split over two jobs on purpose. `npm run build` executes
+# third-party code by design - vite, tsc, the custom-elements analyzer and
+# every plugin they load. NPM_TOKEN must therefore not be reachable from
+# the job that does that. `build` holds no publish credentials and hands over
+# a finished tarball; `publish` holds the token and runs no dependency code.
+# --ignore-scripts closes the install moment; this closes the token exposure of
+# the build moment. It does not make the build output trustworthy - a hijacked
+# build dependency can still poison dist/, and that dist/ goes into the tarball
+# the provenance vouches for.
 
 on:
   push:
@@ -56,38 +59,40 @@ jobs:
         run: npm run build
 
       # De input gaat via de env in plaats van via ${{ }} in de run-regel:
-      # workflow_dispatch-input is vrije tekst en zou daar als shell worden
-      # geïnterpreteerd.
+      # workflow_dispatch-input is vrije tekst en zou daar als shellcode worden
+      # geïnterpreteerd. De `--` scheidt hem daarnaast van de vlaggen: zonder
+      # die scheiding leest npm een waarde die met `-` begint als optie.
       - name: Update version (if specified)
         if: ${{ inputs.version != '' }}
         env:
           INPUT_VERSION: ${{ inputs.version }}
-        run: npm version "$INPUT_VERSION" --no-git-tag-version
+        run: npm version --no-git-tag-version -- "$INPUT_VERSION"
 
-      # Precies wat `files` in package.json publiceert, plus de twee bestanden
-      # die npm er altijd bij pakt (package.json en README). package.json en
-      # custom-elements.json staan erbij omdat de build ze herschrijft.
+      # npm bepaalt zelf wat er in het pakket hoort: `files` in package.json,
+      # plus de bestanden die npm sowieso insluit. Een handgeschreven padlijst
+      # hier zou daar stilzwijgend naast gaan lopen zodra `files` verandert, en
+      # dat levert een incompleet pakket op mét geldige provenance.
+      - name: Pack publish payload
+        run: npm pack --ignore-scripts
+
       - name: Upload publish payload
         uses: actions/upload-artifact@v4
         with:
           name: npm-package
-          retention-days: 1
+          # Ruim genoeg om een mislukte publish-job later opnieuw te draaien
+          # zonder de build over te moeten doen.
+          retention-days: 7
           if-no-files-found: error
-          path: |
-            package.json
-            README.md
-            LICENSE
-            NOTICES.md
-            custom-elements.json
-            dist/
+          path: '*.tgz'
 
   publish:
     needs: build
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      # Nodig voor `npm publish --provenance`: npm ruilt dit OIDC-token in bij
-      # Sigstore. Staat bewust alleen op deze job.
+      # Nodig voor `npm publish --provenance`: alleen met deze permissie kan npm
+      # een OIDC-token opvragen en dat bij Sigstore inruilen voor een
+      # signing-certificaat. Staat bewust alleen op deze job.
       id-token: write
     steps:
       - name: Setup Node.js
@@ -102,10 +107,13 @@ jobs:
         with:
           name: npm-package
 
-      # --ignore-scripts ook hier: npm draait bij publish standaard `prepare`
-      # en `prepack`. Er valt niets te prepareren - dist/ komt kant en klaar uit
-      # de build-job - dus die hoeven niet te draaien.
+      # Publiceren vanuit de tarball: npm leest het manifest uit het archief en
+      # draait geen enkel lifecycle-script, want die draaien alleen bij een
+      # directory-publish. --ignore-scripts blijft staan als tweede slot, al
+      # houdt die vlag in npm 10 wél de pack- en publish-scripts tegen, maar
+      # `prepare` niet. Een tarball-publish zet geen `gitHead` in de metadata;
+      # de provenance legt de commit-sha al vast.
       - name: Publish to npmjs
-        run: npm publish --provenance --ignore-scripts
+        run: npm publish ./*.tgz --provenance --ignore-scripts
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Splitst `publish-npm.yml` in een `build`-job zonder publish-credentials en een `publish`-job met het token.

## Waarom

`--ignore-scripts` (#167) sloot het **install**-moment af. Het build-moment bleef open: `npm run build` voert per definitie code van derden uit — vite, tsc, de custom-elements analyzer, en elke plugin die ze inladen — en dat gebeurde in dezelfde job waar `NPM_TOKEN` staat. Eén gekaapte build-dependency kon dat token dus alsnog bereiken, of de `dist/` vergiftigen die daarna mét geldige provenance de registry op gaat. Dat laatste is precies wat de keyv/cacheable-versies van vandaag zo overtuigend maakt.

## Wat er verandert

| | vóór | ná |
|---|---|---|
| `npm ci` + `npm run build` | zelfde job als NPM_TOKEN | job zonder publish-credentials |
| inpakken | impliciet in `npm publish` | `npm pack` in de build-job |
| `npm publish` | na de build, zelfde job | eigen job, alleen tarball + token |
| `id-token: write` | op de hele job | alleen op de publish-job |
| lifecycle-scripts bij publish | `prepare` draaide | tarball-publish draait er geen |

De publish-job doet geen `npm ci`, geen build, geen checkout. Alleen `setup-node`, artifact ophalen, `npm publish ./*.tgz`.

## Waarom een tarball en geen padlijst

De eerste versie van deze PR somde in de upload-stap met de hand op wat er in het pakket hoort. Dat is een tweede kopie van `files` in package.json, en die gaat er stilzwijgend naast lopen zodra `files` verandert: `if-no-files-found: error` slaat alleen aan als er hélemaal niets matcht, en npm-packlist negeert een ontbrekende `files`-regel zonder klacht. Het resultaat zou een incompleet pakket zijn mét geldige provenance — precies de fout die deze workflow wil voorkomen.

Nu pakt de build-job zelf in met `npm pack`, en blijft npm de enige bron voor de inhoud.

## Verificatie

Publiceren vanuit een directory met alléén de tarball geeft dezelfde shasum als publiceren vanuit een volledige checkout:

```
353c1b000503bc820ab2a4582e2344c6b8753ea9   1565 bestanden
LICENSE  NOTICES.md  README.md  custom-elements.json  dist/  package.json
```

Zelfde `latest`-tag, en `public`-access uit de `publishConfig` in de tarball. `npm publish --provenance` heeft geen `.git` en geen `package.json` in de working directory nodig: het bouwt de attestatie uit de `GITHUB_*`-env plus `ACTIONS_ID_TOKEN_REQUEST_URL`.

Twee dingen die onderweg zijn rechtgezet:

- `npm version "$INPUT_VERSION" --no-git-tag-version` las een waarde die met `-` begint als optie in plaats van als versie. Staat nu als `npm version --no-git-tag-version -- "$INPUT_VERSION"`.
- `--ignore-scripts` houdt `prepare` in npm 10 niet tegen, alleen de pack- en publish-scripts. Bij een tarball-publish draait er sowieso geen enkel lifecycle-script, dus dat is nu waterdicht in plaats van bedoeld.

## Meegenomen

`npm version ${{ inputs.version }}` interpoleerde vrije tekst uit een `workflow_dispatch`-input rechtstreeks in een `run`-regel — shell-injectie voor iedereen met write-rechten. Gaat nu via de env.

## Wat dit níét oplost

Dit haalt het token buiten bereik van build-code. Het maakt de build zelf niet betrouwbaar: een gekaapte build-dependency kan nog steeds de `dist/` aanpassen die in de tarball belandt waar de provenance voor instaat. Daar is een ander middel voor nodig (reproduceerbare build, of een diff-gate op het artifact). Bewust buiten deze PR gehouden.

Eén metadata-regressie: zonder checkout zet npm geen `gitHead` meer in de registry-metadata. De provenance legt de commit-sha al vast, dus er gaat geen informatie verloren.

## Resultaat

Inmiddels bewezen op een echte release: `chore(release): 0.8.78` draaide `build: success` / `publish: success`, en 0.8.78 staat op npm met een SLSA-provenance-attestatie. `gitHead` is zoals voorspeld afwezig op 0.8.78 en aanwezig op 0.8.77.
