### PR TITLE
ci: geef CI en Validate een read-only token en persist het niet op schijf

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,16 @@ on:
   push:
     branches:
       - main
+
+# Zonder dit blok erft deze workflow de repo-default, en die staat op dit
+# moment op read-write. Lint, tests, de componentbuild en `playwright install`
+# voeren code van dependencies uit (vite, rollup, esbuild, de playwright-CLI,
+# eslint- en vitest-plugins); --ignore-scripts sluit het install-moment af,
+# niet dit. Zo'n job hoort geen token te hebben waarmee naar main gepusht kan
+# worden.
+permissions:
+  contents: read
+
 jobs:
   build-and-check:
     name: Build & Validate
@@ -11,6 +21,14 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          # Zonder dit laat actions/checkout het token achter als een credential
+          # dat de git-config van deze checkout oplost, de hele job. Alles wat
+          # daarna draait kan erbij, inclusief de dependency-code hieronder.
+          # Geen enkele stap heeft dit credential nodig: de
+          # `git diff --exit-code`-checks zijn lokaal, en de npm-cache van
+          # setup-node en `playwright install` gebruiken het niet.
+          persist-credentials: false
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:

--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -21,6 +21,14 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          # Hygiëne: deze workflow declareerde `contents: read` al vóór deze PR,
+          # dus hier stond geen read-write token op het spel zoals in ci.yml en
+          # validate.yml. Het token draagt wel `pages: write`, en het blijft de
+          # hele job bereikbaar via de git-config van deze checkout terwijl
+          # `build-storybook` dependency-code draait. Geen enkele stap heeft het
+          # nodig: configure-pages en upload-pages-artifact gaan niet via git.
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -6,6 +6,12 @@ on:
     branches:
       - main
 
+# Zie de toelichting in ci.yml: zonder dit blok draait deze workflow met de
+# read-write repo-default, terwijl `cem analyze` en de vue-types-keten
+# (tsc/vue-tsc) dependency-code uitvoeren.
+permissions:
+  contents: read
+
 jobs:
   validate:
     name: Validate CSS Variables
@@ -14,6 +20,12 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          # Zie ci.yml: anders blijft het token de hele job bereikbaar via de
+          # git-config van deze checkout, terwijl de stappen hieronder
+          # dependency-code uitvoeren. De `git diff --exit-code`-checks zijn
+          # lokaal en hebben het credential niet nodig.
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@v6


### PR DESCRIPTION
Twee helften van dezelfde afscherming voor de drie workflows die dependency-code draaien op elke PR: het token dat ze krijgen wordt read-only, én het blijft niet op schijf achter.

## Helft 1: `permissions: contents: read`

`ci.yml` en `validate.yml` hadden **geen `permissions:`-blok**, dus ze erven de repo-default. Die staat op `write` (nagetrokken via de API: `default_workflow_permissions: "write"`).

In die jobs draaien `npm run lint`, `npm run typecheck`, `npm run test:run`, `npm run build:components`, `npx playwright install` en de vue-types-keten. Dat is allemaal code van dependencies: vite, rollup, esbuild, eslint-plugins, vitest, `cem analyze`, vue-tsc. `--ignore-scripts` (#167) sloot het **install**-moment af — dit is het **build**-moment, en daar doet die vlag niets tegen.

Eén gekaapte transitieve dependency in die verzameling leest het `GITHUB_TOKEN` van de runner en pusht naar `main`. Fork-PRs zijn veilig (die krijgen sowieso een read-only token); pushes en branches binnen de repo niet.

## Helft 2: `persist-credentials: false`

Een read-only token is nog steeds een token dat je niet hoeft achter te laten. `actions/checkout` laat het standaard achter als een credential dat de git-config van die checkout oplost — de hele job lang, dus ook terwijl bovengenoemde dependency-code draait. #168 heeft dit al voor `version-bump.yml` gedaan (waar het om `VERSION_BUMP_TOKEN` ging); dit zijn de checkouts die daarna nog overbleven.

Nagelopen per workflow dat niets het credential nodig heeft:

| Workflow | Waarom het credential overbodig is |
|---|---|
| `ci.yml` | De twee `git diff --exit-code`-checks zijn puur lokaal; de npm-cache van `setup-node` loopt via de Actions-cacheservice en `playwright install` haalt browsers van een CDN. |
| `validate.yml` | Idem: alleen lokale `git diff --exit-code`-checks. |
| `deploy-storybook.yml` | `configure-pages`, `upload-pages-artifact` en `deploy-pages` gaan via API-token/OIDC, niet via git. De `deploy`-job doet zelf geen checkout. |

Geen van de drie pusht, tagt, fetcht of praat anderszins met de git-remote.

**`deploy-storybook.yml` is hier hygiëne, geen fix.** Die workflow declareerde `contents: read` al, dus daar stond geen read-write token op het spel zoals in de andere twee. Het token draagt er wel `pages: write`, dus het is de moeite waard om ook daar niet te laten slingeren.

## Waarom dit veilig is

Geen enkele stap in deze workflows schrijft iets terug: ze checken uit, installeren, valideren en bouwen. Alle andere workflows in deze repo declareerden hun permissions al expliciet — `ci.yml` en `validate.yml` waren de laatste twee.

## Wat hier niet in kan

1. **De repo-default zelf hoort op read-only.** Dat is een instelling, geen commit. Nagekeken dat het veilig kan: `claude.yml`, `claude-code-review.yml`, `deploy-storybook.yml`, `publish-npm.yml` en `version-bump.yml` declareren allemaal hun eigen permissions, dus die veranderen er niet door.
2. **`main` heeft geen enkele required status check** (`required_status_checks: null`) en `enforce_admins: false`. Er zit dus niets tussen een gepushte commit en `main`. Die twee jobs als required check instellen is een aparte actie.
3. **`publish-npm.yml` persist zijn credential nog wel.** Die job houdt `NPM_TOKEN` vast en draait de volledige `npm run build`, en niets erin praat met de git-remote (`npm version --no-git-tag-version`, `npm publish --provenance`). Dezelfde twee regels horen daar ook thuis — bewust buiten deze PR gehouden om de scope niet verder op te rekken.

Komt uit een security review van de CI-supply-chain van regelrecht, poc-machine-law en storybook, na de kaping van het keyv/cacheable-maintaineraccount op 2026-08-04.
