### PR TITLE
ci: voeg Dependabot toe met een cooldown van vijf dagen

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,73 @@
+version: 2
+
+# Cooldown: a release has to be five days old before Dependabot opens a version
+# update for it. Dependabot's own default has been three days since 2026-07-14;
+# raising it here also records the choice, so a later change to that default
+# cannot silently shrink the window.
+#
+# Five days is measured against how fast the registry compromises of the past
+# year surfaced - chalk/debug, shai-hulud, and the keyv/cacheable maintainer
+# hijack of 2026-08-04 were all detected within hours to days. Cooldown filters
+# a too-young release out of a run entirely rather than holding a pending PR,
+# so with `interval: weekly` the real delay is "at least five days, and at most
+# until the first weekly run that lands five or more days after the release" -
+# up to about twelve days for a release that misses a run by a hair.
+#
+# This applies to version updates only. Dependabot *security* updates are
+# exempt from cooldown and keep opening immediately, so advisory fixes are not
+# delayed by this.
+#
+# Note what cooldown does not cover: it keys off the age of a *new release*. An
+# attacker who repoints an existing tag or version at malicious content - the
+# tj-actions/changed-files pattern (CVE-2025-30066) - never triggers a version
+# update at all. SHA-pinning the workflow actions is what closes that; this
+# repo does not pin them yet (all 17 `uses:` refs are floating tags), so that
+# is still open and worth a separate PR.
+#
+# No `labels:` here on purpose. Dependabot only applies labels that already
+# exist in the repository, and setting the key opts out of the defaults it
+# would otherwise create itself. This repo has neither `dependencies` nor an
+# ecosystem label, so an explicit list would land these PRs unlabelled. Letting
+# Dependabot use its defaults gets them created and applied.
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    cooldown:
+      default-days: 5
+    # Without a prefix Dependabot writes "Bump x from 1 to 2", which
+    # .releaserc.json treats as an unrecognised type and releases as a patch.
+    # This repo squash-merges, so that title lands on main verbatim. The split
+    # follows CLAUDE.md's criterion - does the bump change what consumers get?
+    # `dependencies` reach consumers either way (bundled into dist/, or
+    # installed alongside it - lit and @floating-ui/dom are marked external in
+    # vite.config.ts), so `build` (patch); devDependencies are build tooling
+    # only, so `chore` (no release).
+    commit-message:
+      prefix: build
+      prefix-development: chore
+      include: scope
+    groups:
+      npm-minor-patch:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    cooldown:
+      default-days: 5
+    # `ci` releases nothing: a workflow bump never reaches consumers.
+    commit-message:
+      prefix: ci
+      include: scope
+    groups:
+      actions-minor-patch:
+        update-types:
+          - minor
+          - patch


### PR DESCRIPTION
Voegt `.github/dependabot.yml` toe met `npm` en `github-actions`, beide met `cooldown: default-days: 5`.

## Waarom

Deze repo had **helemaal geen `dependabot.yml`**. Uitgerekend de repo die naar npm publiceert kreeg dus geen dependency-updates, geen Dependabot-security-updates en geen updates van de actions in `.github/workflows`. In de cooldown-ronde van vandaag (poc-machine-law, regelrecht-mvp-private, zad-cli, zad-actions) is deze repo over het hoofd gezien, juist omdat er geen bestand was om aan te passen.

## De cooldown

Dependabots eigen default is sinds 2026-07-14 drie dagen. Dit verhoogt dat naar vijf en legt de keuze vast, zodat een latere wijziging van die default het venster niet stilletjes verkleint. Vijf dagen is afgemeten aan hoe snel de registry-compromitteringen van het afgelopen jaar boven water kwamen — chalk/debug, shai-hulud en de keyv/cacheable-maintainerkaping van 2026-08-04 werden allemaal binnen uren tot dagen ontdekt.

Cooldown geldt alleen voor **version** updates. Security-updates vallen er buiten en komen onmiddellijk binnen.

Nagetrokken dat `cooldown` en `default-days` voor **beide** ecosystems worden ondersteund, `github-actions` inbegrepen — het blok wordt daar niet stilzwijgend genegeerd.

## Commit-message-prefixes

Zonder `commit-message:` schrijft Dependabot `Bump x from 1 to 2`. De `headerPattern` in `.releaserc.json` herkent daar geen type in, en `{"type": null, "release": "patch"}` maakt daar een patch-release van. Deze repo squash-merget met `COMMIT_OR_PR_TITLE`, dus die titel landt letterlijk op `main`, waar `version-bump.yml` semantic-release draait. Elke gemergde Dependabot-PR zou dus een release van `@nldd/design-system` uitrollen — ook een `actions/checkout@v6→v7`-bump, die niets verandert aan wat consumers krijgen.

De prefixes volgen daarom het criterium uit CLAUDE.md:

| Wat | Prefix | Gevolg |
|---|---|---|
| npm runtime `dependencies` | `build(deps)` | patch — die bereiken consumers (gebundeld in `dist/`, of external en ernaast geïnstalleerd) |
| npm `devDependencies` | `chore(deps-dev)` | geen release — puur buildgereedschap |
| github-actions | `ci(deps)` | geen release — workflows bereiken consumers nooit |

Alle drie de types staan in de `type-enum` van `commitlint.config.js`. Gegroepeerde PR's behouden de prefix.

## Geen labels

Bewust geen `labels:`-blok. Dependabot past alleen labels toe die **al bestaan** in de repo, en het zetten van de key schakelt de defaults uit die Dependabot anders zelf aanmaakt. `gh label list -R MinBZK/storybook` geeft alleen de negen GitHub-standaardlabels: `dependencies`, `javascript` en `github_actions` bestaan geen van drieën. Een expliciete lijst zou deze PR's dus ongelabeld laten landen. Zonder de key maakt Dependabot `dependencies` + het ecosystem-label zelf aan en past ze toe.

## Wat het niet dekt

Staat ook in het bestand: cooldown kijkt naar de leeftijd van een *nieuwe release*. Wie een bestaande tag of versie op kwaadaardige inhoud richt — het tj-actions/changed-files-patroon (CVE-2025-30066) — triggert helemaal geen version update. De 17 actions in deze repo staan allemaal op een zwevende tag; die op SHA pinnen is wat dát dichtzet, en dat is een aparte PR waard.

Met `interval: weekly` is de praktische vertraging minstens vijf dagen en hooguit tot de eerste wekelijkse run die vijf dagen of meer na de release valt — tot zo'n twaalf dagen voor een release die een run net misloopt.

Deze repo heeft `keyv@4.5.4` en `file-entry-cache@8.0.0` transitief via eslint. Beide ver onder de vergiftigde releases, dus hier is niets besmet.
