### PR TITLE
fix: give the publish job its Node version back

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -95,10 +95,15 @@ jobs:
       # signing-certificaat. Staat bewust alleen op deze job.
       id-token: write
     steps:
+      # The one place the version is written by hand, and it cannot be otherwise
+      # here: this job deliberately does not check out the repository (it only
+      # publishes the tarball `build` packed), so there is no .nvmrc to read.
+      # Keep it equal to .nvmrc. Adding a checkout to read a single file would
+      # pull more into this job than it needs, which is what the setup avoids.
       - name: Setup Node.js
         uses: actions/setup-node@v7
         with:
-          node-version-file: '.nvmrc'
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org'
           scope: '@nldd'
 


### PR DESCRIPTION
The publish job deliberately does not check out the repository: it takes the tarball `build` packed and publishes it. When every workflow was pointed at `.nvmrc`, this job was handed a file that is not there, and the 0.8.81 release fell over on `The specified node version file at: .nvmrc does not exist`.

The version is written by hand again there, with the reason beside it. Adding a checkout to read a single file would pull more into that job than it needs, which is what the setup avoids.

The other five do have a checkout before their setup-node and keep following `.nvmrc`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)