### PR TITLE
build(deps): pin the conventionalcommits preset to the writer we have

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -481,6 +481,19 @@
         "node": ">=22.12.0"
       }
     },
+    "node_modules/@commitlint/config-conventional/node_modules/conventional-changelog-conventionalcommits": {
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-10.2.1.tgz",
+      "integrity": "sha512-n4Kr1HFMTf3iMbES0TMxKIcYtUUv4rKqyQQp2JwfOEfFCOfGT3Tq4mCyJ8S9/YPyWhydjfKrrvnyl+gCjA+mJQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@conventional-changelog/template": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
     "node_modules/@commitlint/config-validator": {
       "version": "21.2.0",
       "resolved": "https://registry.npmjs.org/@commitlint/config-validator/-/config-validator-21.2.0.tgz",
@@ -5550,19 +5563,6 @@
       "version": "9.4.0",
       "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-9.4.0.tgz",
       "integrity": "sha512-HdxRxuS8bBXVIuo4V82gvSwAXT0vYQUizrjs/izmPg5JdDstr8v8I5hduGL3iQbG+o310dUDxC4+LetuS5hu9w==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "@conventional-changelog/template": "^1.4.0"
-      },
-      "engines": {
-        "node": ">=22"
-      }
-    },
-    "node_modules/conventional-changelog-conventionalcommits": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-10.4.0.tgz",
-      "integrity": "sha512-Rriac6ZrAlVm6cy9Bz4NSp+WMHpwNXoPIYex+HjCgduAVUSbnew29DQjQw0C4g9u3HtSYzGiGY+pdBXAZo+4aA==",
       "dev": true,
       "license": "ISC",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,6 +45,7 @@
         "@vitest/browser-playwright": "4.1.11",
         "@vitest/coverage-v8": "4.1.11",
         "conventional-changelog": "^8.1.0",
+        "conventional-changelog-conventionalcommits": "10.2.1",
         "eslint": "^10.8.0",
         "eslint-plugin-lit-a11y": "^5.1.1",
         "eslint-plugin-storybook": "^10.5.7",
@@ -479,19 +480,6 @@
       },
       "engines": {
         "node": ">=22.12.0"
-      }
-    },
-    "node_modules/@commitlint/config-conventional/node_modules/conventional-changelog-conventionalcommits": {
-      "version": "10.2.1",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-10.2.1.tgz",
-      "integrity": "sha512-n4Kr1HFMTf3iMbES0TMxKIcYtUUv4rKqyQQp2JwfOEfFCOfGT3Tq4mCyJ8S9/YPyWhydjfKrrvnyl+gCjA+mJQ==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "@conventional-changelog/template": "^1.2.1"
-      },
-      "engines": {
-        "node": ">=22"
       }
     },
     "node_modules/@commitlint/config-validator": {
@@ -5567,6 +5555,19 @@
       "license": "ISC",
       "dependencies": {
         "@conventional-changelog/template": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/conventional-changelog-conventionalcommits": {
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-10.2.1.tgz",
+      "integrity": "sha512-n4Kr1HFMTf3iMbES0TMxKIcYtUUv4rKqyQQp2JwfOEfFCOfGT3Tq4mCyJ8S9/YPyWhydjfKrrvnyl+gCjA+mJQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@conventional-changelog/template": "^1.2.1"
       },
       "engines": {
         "node": ">=22"

--- a/package.json
+++ b/package.json
@@ -583,5 +583,8 @@
     "@lezer/highlight": "^1.2.3",
     "lit": "^3.3.1"
   },
-  "customElements": "custom-elements.json"
+  "customElements": "custom-elements.json",
+  "overrides": {
+    "conventional-changelog-conventionalcommits": "10.2.1"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -538,6 +538,7 @@
     "@vitest/browser-playwright": "4.1.11",
     "@vitest/coverage-v8": "4.1.11",
     "conventional-changelog": "^8.1.0",
+    "conventional-changelog-conventionalcommits": "10.2.1",
     "eslint": "^10.8.0",
     "eslint-plugin-lit-a11y": "^5.1.1",
     "eslint-plugin-storybook": "^10.5.7",


### PR DESCRIPTION
The 0.8.84 release died in `generateNotes`:

```
Missing helper: "conventional-changelog-conventionalcommits requires
conventional-changelog-writer@9 or newer"
```

Self-inflicted, by the npm-minor-patch bump in #219. `conventional-changelog` went 8.1.1 to 8.1.3 and pulled `conventional-changelog-writer@9.2.1` to the root, which pushed `@semantic-release/release-notes-generator`'s own requirement (`^8.0.0`) down into a nested 8.4.0 copy. De zelfde install verschoof het preset van 10.2.1 naar 10.4.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)